### PR TITLE
feat: redesign footer with ecosystem links

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,119 +1,95 @@
-import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Heart } from 'lucide-react';
+import { Separator } from '@/components/ui/separator';
 
 const Footer = () => {
   const { t } = useTranslation();
-  return (
-    <footer className="bg-neutral-50 border-t border-neutral-100">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-8">
-          {/* Logo and Description */}
-          <div className="md:col-span-2">
-            <Link to="/" className="flex items-center space-x-3 mb-4">
-              <div className="w-10 h-10 bg-gradient-brand rounded-xl flex items-center justify-center">
-                <span className="text-white text-lg font-bold">M</span>
-              </div>
-              <div className="flex flex-col">
-                <span className="font-brand font-semibold text-xl text-neutral-900">
-                  Mon<span className="text-brand-blue">y</span>nha.com
-                </span>
-                <span className="text-sm text-neutral-400 font-medium">
-                  {t('footer.tagline')}
-                </span>
-              </div>
-            </Link>
-            <p className="text-neutral-600 max-w-md">
-              {t('footer.description')}
-            </p>
-          </div>
+  const currentYear = new Date().getFullYear();
 
-          {/* Quick Links */}
-          <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
-              {t('footer.quickLinks')}
+  return (
+    <footer className="border-t bg-background">
+      <div className="container py-10 md:py-12">
+        <div className="grid gap-8 md:grid-cols-2 text-center md:text-left">
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              {t('footer.ecosystem')}
             </h3>
             <ul className="space-y-2">
               <li>
-                <Link
-                  to="/solutions"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                <a
+                  href="https://monynha.tech"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
                 >
-                  {t('navigation.solutions')}
-                </Link>
+                  monynha.tech
+                </a>
               </li>
               <li>
-                <Link
-                  to="/about"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                <a
+                  href="https://monynha.store"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
                 >
-                  {t('navigation.about')}
-                </Link>
+                  monynha.store
+                </a>
               </li>
               <li>
-                <Link
-                  to="/blog"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                <a
+                  href="https://monynha.online"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
                 >
-                  {t('navigation.blog')}
-                </Link>
+                  monynha.online
+                </a>
               </li>
               <li>
-                <Link
-                  to="/contact"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                <a
+                  href="https://monynha.me"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
                 >
-                  {t('navigation.contact')}
-                </Link>
+                  monynha.me
+                </a>
               </li>
             </ul>
           </div>
-
-          {/* Solutions */}
-          <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
-              {t('footer.solutions')}
+          <div className="space-y-4">
+            <h3 className="text-sm font-medium text-muted-foreground">
+              {t('footer.contact')}
             </h3>
             <ul className="space-y-2">
               <li>
-                <span className="text-neutral-600">
-                  {t('footer.solutionList.boteco')}
-                </span>
+                <a
+                  href="mailto:hello@monynha.com"
+                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                >
+                  hello@monynha.com
+                </a>
               </li>
               <li>
-                <span className="text-neutral-600">
-                  {t('footer.solutionList.assistina')}
-                </span>
-              </li>
-              <li>
-                <span className="text-neutral-600">
-                  {t('footer.solutionList.custom')}
-                </span>
-              </li>
-              <li>
-                <span className="text-neutral-600">
-                  {t('footer.solutionList.integration')}
+                <span className="text-sm text-muted-foreground">
+                  São Paulo, Brasil
                 </span>
               </li>
             </ul>
           </div>
         </div>
 
-        <div className="border-t border-neutral-200 mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
-          <p className="text-neutral-500 text-sm">{t('footer.copyright')}</p>
-          <div className="flex space-x-6 mt-4 md:mt-0">
-            <Link
-              to="#"
-              className="text-neutral-500 hover:text-brand-blue transition-colors ease-in-out duration-300 text-sm"
-            >
-              {t('footer.privacy')}
-            </Link>
-            <Link
-              to="#"
-              className="text-neutral-500 hover:text-brand-blue transition-colors ease-in-out duration-300 text-sm"
-            >
-              {t('footer.terms')}
-            </Link>
-          </div>
+        <Separator className="my-8" />
+
+        <div className="flex flex-col md:flex-row items-center justify-between gap-4 text-center">
+          <p className="text-xs text-muted-foreground">
+            {t('footer.copyright', { year: currentYear })}
+          </p>
+          <p className="flex items-center gap-1 text-xs text-muted-foreground">
+            {t('footer.madeWith')}{' '}
+            <Heart className="w-4 h-4 text-red-500" /> {t('footer.and')}{' '}
+            {t('footer.caffeine')}.
+          </p>
         </div>
       </div>
     </footer>
@@ -121,3 +97,4 @@ const Footer = () => {
 };
 
 export default Footer;
+

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -11,22 +11,12 @@
     "backToTop": "Back to top"
   },
   "footer": {
-    "quickLinks": "Quick Links",
-    "solutions": "Solutions",
-    "aboutUs": "About Us",
-    "blog": "Blog",
+    "ecosystem": "Monynha Ecosystem",
     "contact": "Contact",
-    "copyright": "© 2024 Monynha Softwares Agency. All rights reserved.",
-    "privacy": "Privacy Policy",
-    "terms": "Terms of Service",
-    "tagline": "Monynha Softwares: Technology with Pride, Diversity, and Resistance",
-    "description": "Democratizing innovation through inclusive, accessible solutions that empower diverse communities and promote social equity.",
-    "solutionList": {
-      "boteco": "Boteco Pro",
-      "assistina": "AssisTina AI",
-      "custom": "Custom Development",
-      "integration": "AI Integration"
-    }
+    "copyright": "© {{year}} Monynha Softwares. All rights reserved.",
+    "madeWith": "Made with",
+    "and": "and",
+    "caffeine": "caffeine"
   },
   "index": {
     "hero": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -11,22 +11,12 @@
     "backToTop": "Volver arriba"
   },
   "footer": {
-    "quickLinks": "Enlaces Rápidos",
-    "solutions": "Soluciones",
-    "aboutUs": "Sobre Nosotros",
-    "blog": "Blog",
+    "ecosystem": "Ecosistema Monynha",
     "contact": "Contacto",
-    "copyright": "© 2024 Monynha Softwares Agency. Todos los derechos reservados.",
-    "privacy": "Política de Privacidad",
-    "terms": "Términos de Servicio",
-    "tagline": "Monynha Softwares: Tecnología con orgullo, diversidad y resistencia",
-    "description": "Democratizando la innovación con soluciones inclusivas y accesibles que empoderan a comunidades diversas y promueven la equidad social.",
-    "solutionList": {
-      "boteco": "Boteco Pro",
-      "assistina": "AssisTina AI",
-      "custom": "Desarrollo Personalizado",
-      "integration": "Integración de IA"
-    }
+    "copyright": "© {{year}} Monynha Softwares. Todos los derechos reservados.",
+    "madeWith": "Hecho con",
+    "and": "y",
+    "caffeine": "cafeína"
   },
   "index": {
     "hero": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -11,22 +11,12 @@
     "backToTop": "Haut de page"
   },
   "footer": {
-    "quickLinks": "Liens rapides",
-    "solutions": "Solutions",
-    "aboutUs": "À propos de nous",
-    "blog": "Blog",
+    "ecosystem": "Écosystème Monynha",
     "contact": "Contact",
-    "copyright": "© 2024 Monynha Softwares Agency. Tous droits réservés.",
-    "privacy": "Politique de Confidentialité",
-    "terms": "Conditions d'utilisation",
-    "tagline": "Monynha Softwares: Technologie avec fierté, diversité et résistance",
-    "description": "Démocratiser l'innovation grâce à des solutions inclusives et accessibles qui renforcent les communautés diverses et favorisent l'équité sociale.",
-    "solutionList": {
-      "boteco": "Boteco Pro",
-      "assistina": "AssisTina AI",
-      "custom": "Développement personnalisé",
-      "integration": "Intégration IA"
-    }
+    "copyright": "© {{year}} Monynha Softwares. Tous droits réservés.",
+    "madeWith": "Fait avec",
+    "and": "et",
+    "caffeine": "caféine"
   },
   "index": {
     "hero": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -11,22 +11,12 @@
     "backToTop": "Voltar ao topo"
   },
   "footer": {
-    "quickLinks": "Links Rápidos",
-    "solutions": "Soluções",
-    "aboutUs": "Sobre Nós",
-    "blog": "Blog",
+    "ecosystem": "Ecossistema Monynha",
     "contact": "Contato",
-    "copyright": "© 2024 Monynha Softwares Agency. Todos os direitos reservados.",
-    "privacy": "Política de Privacidade",
-    "terms": "Termos de Uso",
-    "tagline": "Monynha Softwares: Tecnologia com orgulho, diversidade e resistência",
-    "description": "Democratizando a inovação com soluções inclusivas e acessíveis que capacitam comunidades diversas e promovem a equidade social.",
-    "solutionList": {
-      "boteco": "Boteco Pro",
-      "assistina": "AssisTina AI",
-      "custom": "Desenvolvimento Personalizado",
-      "integration": "Integração de IA"
-    }
+    "copyright": "© {{year}} Monynha Softwares. Todos os direitos reservados.",
+    "madeWith": "Feito com",
+    "and": "e",
+    "caffeine": "cafeína"
   },
   "index": {
     "hero": {


### PR DESCRIPTION
## Summary
- redesign footer with Monynha ecosystem links and contact info
- add dynamic copyright line and heart message
- update footer translations for en, es, pt and fr

## Testing
- `npm test`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e1b163cf883229c94c415ef9d5aff