### PR TITLE
feat: add Liquid Ether background effect

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,44 @@ VITE_SUPABASE_ANON_KEY=<your-anon-key>
 
 These variables match the placeholders in `.env.example`.
 
+### Liquid Ether background
+
+The animated "Liquid Ether" background is rendered with Three.js and loads on
+the client only. It sits behind every page and automatically falls back to a
+static gradient when WebGL is not available or when visitors prefer reduced
+motion.
+
+The effect can be configured through environment variables (either Vite's
+`VITE_` prefix or the `NEXT_PUBLIC_` prefix for parity with Next.js setups):
+
+```bash
+# Enable/disable the WebGL background entirely (default: true)
+NEXT_PUBLIC_LIQUIDETHER_ENABLED=true
+
+# Downscale factor for the internal render resolution (0.2 – 1, default: 0.5)
+NEXT_PUBLIC_LIQUIDETHER_RESOLUTION=0.5
+
+# Multiplier applied to highlight intensity and shimmer (default: 2.2)
+NEXT_PUBLIC_LIQUIDETHER_INTENSITY=2.2
+```
+
+Runtime overrides are also exposed through the `LiquidEtherClient` component:
+
+```tsx
+<LiquidEtherClient
+  colors={["#5227FF", "#FF9FFC", "#B19EEF"]}
+  mouseForce={24}
+  cursorSize={140}
+  resolution={0.45}
+  autoIntensity={2.8}
+/>
+```
+
+By default the component samples the CSS design tokens
+`--mona-primary`, `--mona-secondary` and `--mona-accent-pink`, defined in
+`src/index.css`. Update those variables to keep the animation in sync with any
+branding changes.
+
 ## Technologies
 
 - React & Vite

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.180.0",
         "vaul": "^0.9.3"
       },
       "devDependencies": {
@@ -10987,6 +10988,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.180.0",
     "vaul": "^0.9.3"
   },
   "devDependencies": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Toaster as Sonner } from '@/components/ui/sonner';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ToastProvider } from '@/hooks/use-toast';
 import { AuthProvider } from '@/hooks/useAuth';
+import LiquidEtherClient from '@/components/effects/LiquidEtherClient';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Suspense, lazy } from 'react';
@@ -25,6 +26,7 @@ const App = () => (
     <AuthProvider>
       <ToastProvider>
         <TooltipProvider>
+          <LiquidEtherClient />
           <Toaster />
           <Sonner />
           <BrowserRouter>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,9 +8,11 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="relative z-10 min-h-screen flex flex-col">
       <Header />
-      <main className="flex-1 pt-20">{children}</main>
+      <main className="relative flex-1 pt-20 bg-background/70 backdrop-blur-sm supports-[backdrop-filter]:backdrop-blur-md">
+        {children}
+      </main>
       <Footer />
       <BackToTop />
     </div>

--- a/src/components/effects/LiquidEtherClient.tsx
+++ b/src/components/effects/LiquidEtherClient.tsx
@@ -1,0 +1,198 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { ComponentType } from 'react';
+import clsx from 'clsx';
+import { useReducedMotion } from '@/lib/a11y';
+
+type LiquidEtherProps = Partial<{
+  colors: string[];
+  mouseForce: number;
+  cursorSize: number;
+  isViscous: boolean;
+  viscous: number;
+  iterationsViscous: number;
+  iterationsPoisson: number;
+  resolution: number;
+  isBounce: boolean;
+  autoDemo: boolean;
+  autoSpeed: number;
+  autoIntensity: number;
+  takeoverDuration: number;
+  autoResumeDelay: number;
+  autoRampDuration: number;
+  className: string;
+}>;
+
+type LiquidEtherComponent = ComponentType<LiquidEtherProps>;
+
+function getEnvValue(name: string) {
+  const metaEnv =
+    typeof import.meta !== 'undefined'
+      ? ((import.meta as ImportMeta & {
+          env?: Record<string, string | boolean | undefined>;
+        }).env ?? undefined)
+      : undefined;
+  const fallbackName = name.startsWith('NEXT_PUBLIC_')
+    ? `VITE_${name.slice('NEXT_PUBLIC_'.length)}`
+    : undefined;
+
+  if (metaEnv) {
+    if (metaEnv[name] !== undefined) return metaEnv[name];
+    if (fallbackName && metaEnv[fallbackName] !== undefined) return metaEnv[fallbackName];
+  }
+
+  if (typeof process !== 'undefined' && process.env) {
+    if (process.env[name] !== undefined) return process.env[name];
+    if (fallbackName && process.env[fallbackName] !== undefined) return process.env[fallbackName];
+  }
+
+  return undefined;
+}
+
+function parseBoolean(value: unknown) {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['true', '1', 'yes', 'on'].includes(normalized)) return true;
+    if (['false', '0', 'no', 'off'].includes(normalized)) return false;
+  }
+  return undefined;
+}
+
+function parseNumber(value: unknown) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number.parseFloat(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+function supportsWebGL() {
+  if (typeof window === 'undefined') return false;
+  try {
+    const canvas = document.createElement('canvas');
+    return !!(
+      window.WebGLRenderingContext &&
+      (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))
+    );
+  } catch (error) {
+    return false;
+  }
+}
+
+function readTokenColor(variableName: string, fallback: string) {
+  if (typeof window === 'undefined') return fallback;
+  const value = getComputedStyle(document.documentElement).getPropertyValue(variableName).trim();
+  return value || fallback;
+}
+
+export default function LiquidEtherClient(props: LiquidEtherProps) {
+  const reduced = useReducedMotion();
+  const [LiquidEther, setLiquidEther] = useState<LiquidEtherComponent | null>(null);
+  const [loadError, setLoadError] = useState(false);
+  const [webglReady, setWebglReady] = useState(false);
+
+  const envEnabled = useMemo(() => {
+    const raw = getEnvValue('NEXT_PUBLIC_LIQUIDETHER_ENABLED');
+    const parsed = parseBoolean(raw);
+    return parsed ?? true;
+  }, []);
+
+  const envResolution = useMemo(() => {
+    const raw =
+      getEnvValue('NEXT_PUBLIC_LIQUIDETHER_RESOLUTION') ??
+      getEnvValue('VITE_LIQUIDETHER_RESOLUTION');
+    return parseNumber(raw);
+  }, []);
+
+  const envIntensity = useMemo(() => {
+    const raw =
+      getEnvValue('NEXT_PUBLIC_LIQUIDETHER_INTENSITY') ??
+      getEnvValue('VITE_LIQUIDETHER_INTENSITY');
+    return parseNumber(raw);
+  }, []);
+
+  const defaultColors = useMemo(
+    () => [
+      readTokenColor('--mona-primary', '#7C3AED'),
+      readTokenColor('--mona-secondary', '#0EA5E9'),
+      readTokenColor('--mona-accent-pink', '#EC4899'),
+    ],
+    []
+  );
+
+  const fallbackBg = useMemo(
+    () => ({
+      background:
+        'radial-gradient(1200px 600px at 70% 30%, rgba(255,255,255,0.15), transparent), linear-gradient(135deg, var(--mona-primary) 0%, var(--mona-secondary) 55%, var(--mona-accent-pink) 100%)',
+    }),
+    []
+  );
+
+  const mergedProps = useMemo(() => {
+    const resolvedColors = props.colors?.length ? props.colors : defaultColors;
+    const resolution = props.resolution ?? envResolution ?? 0.5;
+    const autoIntensity = props.autoIntensity ?? envIntensity ?? 2.2;
+
+    return {
+      ...props,
+      colors: resolvedColors,
+      resolution,
+      autoIntensity,
+    } satisfies LiquidEtherProps;
+  }, [defaultColors, envIntensity, envResolution, props]);
+
+  useEffect(() => {
+    if (reduced || !envEnabled) return;
+
+    setWebglReady(supportsWebGL());
+  }, [envEnabled, reduced]);
+
+  useEffect(() => {
+    if (reduced || !envEnabled) {
+      setLiquidEther(null);
+      return;
+    }
+
+    if (!webglReady) return;
+
+    let cancelled = false;
+
+    import('./vendor/LiquidEther')
+      .then((module) => {
+        if (!cancelled) {
+          setLiquidEther(() => module.default as LiquidEtherComponent);
+          setLoadError(false);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to load Liquid Ether background', error);
+        if (!cancelled) {
+          setLoadError(true);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [envEnabled, reduced, webglReady]);
+
+  if (reduced || loadError || !envEnabled || !webglReady || !LiquidEther) {
+    return (
+      <div
+        aria-hidden
+        className={clsx('pointer-events-none fixed inset-0 -z-10', props.className)}
+        style={fallbackBg}
+      />
+    );
+  }
+
+  return (
+    <div className={clsx('pointer-events-none fixed inset-0 -z-10', props.className)}>
+      <LiquidEther {...mergedProps} />
+    </div>
+  );
+}
+

--- a/src/components/effects/vendor/LiquidEther.tsx
+++ b/src/components/effects/vendor/LiquidEther.tsx
@@ -1,0 +1,454 @@
+import { useEffect, useRef } from 'react';
+import * as THREE from 'three';
+import clsx from 'clsx';
+
+type Props = {
+  colors?: string[];
+  mouseForce?: number;
+  cursorSize?: number;
+  isViscous?: boolean;
+  viscous?: number;
+  iterationsViscous?: number;
+  iterationsPoisson?: number;
+  resolution?: number;
+  isBounce?: boolean;
+  autoDemo?: boolean;
+  autoSpeed?: number;
+  autoIntensity?: number;
+  takeoverDuration?: number;
+  autoResumeDelay?: number;
+  autoRampDuration?: number;
+  className?: string;
+};
+
+const MAX_COLORS = 6;
+
+const vertexShader = /* glsl */ `
+  varying vec2 vUv;
+
+  void main() {
+    vUv = uv;
+    gl_Position = vec4(position.xy, 0.0, 1.0);
+  }
+`;
+
+const fragmentShader = /* glsl */ `
+  precision highp float;
+
+  varying vec2 vUv;
+
+  uniform float uTime;
+  uniform vec2 uResolution;
+  uniform vec2 uPointer;
+  uniform float uPointerStrength;
+  uniform float uCursorSize;
+  uniform float uIntensity;
+  uniform vec3 uColors[${MAX_COLORS}];
+  uniform int uColorCount;
+
+  float hash(vec2 p) {
+    return fract(sin(dot(p, vec2(127.1, 311.7))) * 43758.5453);
+  }
+
+  float noise(vec2 p) {
+    vec2 i = floor(p);
+    vec2 f = fract(p);
+
+    float a = hash(i);
+    float b = hash(i + vec2(1.0, 0.0));
+    float c = hash(i + vec2(0.0, 1.0));
+    float d = hash(i + vec2(1.0, 1.0));
+
+    vec2 u = f * f * (3.0 - 2.0 * f);
+
+    return mix(a, b, u.x) + (c - a) * u.y * (1.0 - u.x) + (d - b) * u.x * u.y;
+  }
+
+  mat2 rotate2d(float angle) {
+    float s = sin(angle);
+    float c = cos(angle);
+    return mat2(c, -s, s, c);
+  }
+
+  float fbm(vec2 p) {
+    float value = 0.0;
+    float amplitude = 0.5;
+    mat2 rot = rotate2d(0.5);
+
+    for (int i = 0; i < 5; i++) {
+      value += amplitude * noise(p);
+      p = rot * p * 2.0;
+      amplitude *= 0.55;
+    }
+
+    return value;
+  }
+
+  vec3 fetchColor(int index) {
+    if (index <= 0) {
+      return uColors[0];
+    } else if (index == 1) {
+      return uColors[1];
+    } else if (index == 2) {
+      return uColors[2];
+    } else if (index == 3) {
+      return uColors[3];
+    } else if (index == 4) {
+      return uColors[4];
+    }
+    return uColors[5];
+  }
+
+  vec3 sampleGradient(float t) {
+    if (uColorCount <= 1) {
+      return fetchColor(0);
+    }
+
+    float scaled = clamp(t, 0.0, 0.9999) * float(uColorCount - 1);
+    int lower = int(floor(scaled));
+    int upper = int(clamp(float(lower + 1), 0.0, float(uColorCount - 1)));
+    float mixAmount = fract(scaled);
+
+    return mix(fetchColor(lower), fetchColor(upper), mixAmount);
+  }
+
+  void main() {
+    vec2 uv = vUv;
+    vec2 centered = uv - 0.5;
+    centered.x *= uResolution.x / uResolution.y;
+
+    float time = uTime * 0.25;
+
+    vec2 drift = vec2(
+      fbm(centered * 1.4 + time * 0.8),
+      fbm(centered * 1.4 - time * 0.6)
+    );
+    vec2 warpedUv = uv + drift * 0.1;
+
+    float base = fbm(warpedUv * 4.0 + time * 1.2);
+    float layer = fbm((warpedUv + drift * 0.5) * 2.0 - time * 0.7);
+    float mixNoise = mix(base, layer, 0.35);
+
+    float pointerRadius = max(uCursorSize, 16.0);
+    vec2 pointerVec = uv - uPointer;
+    pointerVec.x *= uResolution.x / uResolution.y;
+    float pointerDist = length(pointerVec);
+    float pointerMask = exp(-pow(pointerDist * 400.0 / pointerRadius, 2.0)) * uPointerStrength;
+
+    float gradient = clamp(mixNoise * 0.65 + uv.y * 0.55 + time * 0.12 + pointerMask * 0.35, 0.0, 1.0);
+
+    vec3 baseColor = sampleGradient(gradient);
+    vec3 highlight = sampleGradient(clamp(gradient + 0.12 + pointerMask * 0.25, 0.0, 1.0));
+    vec3 color = mix(baseColor, highlight, 0.35 + pointerMask * 0.65);
+
+    float shimmer = fbm(warpedUv * 6.0 - time * 1.5 + pointerMask * 0.8);
+    color += shimmer * 0.05 * uIntensity;
+    color += pointerMask * 0.35 * uIntensity;
+
+    color = clamp(color, 0.0, 1.0);
+    gl_FragColor = vec4(color, 1.0);
+  }
+`;
+
+function clamp01(value: number) {
+  return Math.min(1, Math.max(0, value));
+}
+
+function clampResolution(value: number | undefined) {
+  if (!Number.isFinite(value ?? Number.NaN)) {
+    return 0.5;
+  }
+  return Math.min(1, Math.max(0.2, value!));
+}
+
+function normalizeColorList(colors?: string[]) {
+  if (!colors || colors.length === 0) {
+    return ['#7C3AED', '#0EA5E9', '#EC4899'];
+  }
+
+  return colors.slice(0, MAX_COLORS);
+}
+
+function isWebGLAvailable() {
+  if (typeof window === 'undefined') return false;
+  try {
+    const canvas = document.createElement('canvas');
+    return !!(
+      window.WebGLRenderingContext &&
+      (canvas.getContext('webgl') || canvas.getContext('experimental-webgl'))
+    );
+  } catch (error) {
+    return false;
+  }
+}
+
+const LiquidEther = ({
+  colors,
+  mouseForce = 20,
+  cursorSize = 100,
+  isViscous = false,
+  viscous = 30,
+  iterationsViscous = 32,
+  iterationsPoisson = 32,
+  resolution = 0.5,
+  isBounce = false,
+  autoDemo = true,
+  autoSpeed = 0.5,
+  autoIntensity = 2.2,
+  takeoverDuration = 0.25,
+  autoResumeDelay = 3000,
+  autoRampDuration = 0.6,
+  className,
+}: Props) => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return undefined;
+    if (!isWebGLAvailable()) return undefined;
+
+    const resolvedResolution = clampResolution(resolution);
+    const selectedColors = normalizeColorList(colors);
+
+    const renderer = new THREE.WebGLRenderer({
+      alpha: true,
+      antialias: false,
+      powerPreference: 'high-performance',
+    });
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+    renderer.toneMapping = THREE.ACESFilmicToneMapping;
+
+    const devicePixelRatio = window.devicePixelRatio || 1;
+    const pixelRatio = THREE.MathUtils.clamp(devicePixelRatio * resolvedResolution, 0.5, 2);
+    renderer.setPixelRatio(pixelRatio);
+
+    const size = new THREE.Vector2(window.innerWidth, window.innerHeight);
+    renderer.setSize(size.x, size.y, false);
+    renderer.domElement.style.width = '100%';
+    renderer.domElement.style.height = '100%';
+    renderer.domElement.style.position = 'absolute';
+    renderer.domElement.style.inset = '0';
+    renderer.domElement.style.pointerEvents = 'none';
+
+    container.innerHTML = '';
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+    const geometry = new THREE.PlaneGeometry(2, 2);
+
+    const colorArray = new Float32Array(MAX_COLORS * 3);
+    let colorCount = 0;
+    for (let index = 0; index < MAX_COLORS; index += 1) {
+      const hex = selectedColors[index];
+      if (!hex) break;
+      const color = new THREE.Color(hex);
+      color.convertSRGBToLinear();
+      colorArray[index * 3 + 0] = color.r;
+      colorArray[index * 3 + 1] = color.g;
+      colorArray[index * 3 + 2] = color.b;
+      colorCount += 1;
+    }
+
+    const uniforms = {
+      uTime: { value: 0 },
+      uResolution: { value: size.clone() },
+      uPointer: { value: new THREE.Vector2(0.5, 0.5) },
+      uPointerStrength: { value: 0 },
+      uCursorSize: { value: cursorSize },
+      uIntensity: { value: autoIntensity },
+      uColors: { value: colorArray },
+      uColorCount: { value: Math.max(1, colorCount) },
+    } satisfies Record<string, THREE.IUniform>;
+
+    const material = new THREE.ShaderMaterial({
+      vertexShader,
+      fragmentShader,
+      uniforms,
+      transparent: true,
+    });
+
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    const manualPointer = new THREE.Vector2(0.5, 0.5);
+    const autoPointer = new THREE.Vector2(0.5, 0.5);
+    const blendedPointer = new THREE.Vector2(0.5, 0.5);
+
+    let manualStrengthTarget = 0;
+    let manualStrength = 0;
+    let autoStrength = autoDemo ? 0.4 : 0;
+    let pointerBlend = 0;
+    let autoPhase = Math.random() * Math.PI * 2;
+    let lastInteraction = performance.now();
+    let autoActive = autoDemo;
+    let autoRamp = autoDemo ? 0 : 1;
+    const bounceVelocity = new THREE.Vector2(
+      Math.random() * 0.3 - 0.15,
+      Math.random() * 0.24 - 0.12
+    );
+
+    const viscosityFactor = isViscous ? Math.max(4, viscous) : 18;
+    const viscousIterations = Math.max(1, iterationsViscous);
+    const poissonIterations = Math.max(1, iterationsPoisson);
+    const manualDecay = THREE.MathUtils.clamp(viscosityFactor / viscousIterations / 12, 0.6, 2.4);
+    const autoDecay = THREE.MathUtils.clamp(poissonIterations / 32, 0.4, 1.2);
+    const followSpeed = 1 / Math.max(0.05, takeoverDuration);
+
+    const resize = () => {
+      const width = window.innerWidth;
+      const height = window.innerHeight;
+      size.set(width, height);
+      renderer.setSize(width, height, false);
+      uniforms.uResolution.value.set(width, height);
+    };
+
+    resize();
+
+    const updateManualPointer = (clientX: number, clientY: number) => {
+      const x = clamp01(clientX / size.x);
+      const y = clamp01(1 - clientY / size.y);
+      manualPointer.set(x, y);
+      manualStrengthTarget = Math.max(
+        manualStrengthTarget,
+        THREE.MathUtils.clamp(mouseForce / 30, 0.1, 3)
+      );
+      pointerBlend = 1;
+      lastInteraction = performance.now();
+      autoActive = false;
+      autoRamp = 0;
+    };
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!event.isPrimary) return;
+      updateManualPointer(event.clientX, event.clientY);
+    };
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (!event.isPrimary) return;
+      updateManualPointer(event.clientX, event.clientY);
+    };
+
+    const handleTouchMove = (event: TouchEvent) => {
+      const touch = event.touches[0];
+      if (!touch) return;
+      updateManualPointer(touch.clientX, touch.clientY);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove, { passive: true });
+    window.addEventListener('pointerdown', handlePointerDown, { passive: true });
+    window.addEventListener('touchmove', handleTouchMove, { passive: true });
+    window.addEventListener('resize', resize);
+
+    let animationId = 0;
+    let lastTime = performance.now();
+
+    const animate = () => {
+      const now = performance.now();
+      const delta = (now - lastTime) / 1000;
+      lastTime = now;
+
+      if (autoDemo) {
+        if (!autoActive && now - lastInteraction > autoResumeDelay) {
+          autoActive = true;
+        }
+
+        const rampSpeed = delta / Math.max(0.05, autoRampDuration);
+        autoRamp = THREE.MathUtils.clamp(autoRamp + (autoActive ? rampSpeed : -rampSpeed), 0, 1);
+
+        if (autoActive) {
+          if (isBounce) {
+            const speedScale = autoSpeed * 0.35 + 0.15;
+            autoPointer.x += bounceVelocity.x * speedScale * delta;
+            autoPointer.y += bounceVelocity.y * speedScale * delta;
+
+            if (autoPointer.x < 0.1 || autoPointer.x > 0.9) {
+              autoPointer.x = clamp01(autoPointer.x);
+              bounceVelocity.x *= -1;
+            }
+            if (autoPointer.y < 0.1 || autoPointer.y > 0.9) {
+              autoPointer.y = clamp01(autoPointer.y);
+              bounceVelocity.y *= -1;
+            }
+          } else {
+            autoPhase += delta * (0.6 + autoSpeed * 1.8);
+            const amplitudeX = 0.18 + autoIntensity * 0.05;
+            const amplitudeY = 0.14 + autoIntensity * 0.04;
+            autoPointer.x = clamp01(0.5 + Math.sin(autoPhase) * amplitudeX);
+            autoPointer.y = clamp01(0.5 + Math.cos(autoPhase * 0.82 + 1.2) * amplitudeY);
+          }
+        }
+
+        const targetAutoStrength = autoActive
+          ? THREE.MathUtils.clamp(autoIntensity * 0.35 * (0.6 + autoRamp), 0.1, 2)
+          : 0;
+        const autoLerp = 1 - Math.exp(-delta * (2.4 + autoDecay * 2));
+        autoStrength += (targetAutoStrength - autoStrength) * autoLerp;
+      } else {
+        autoStrength += (0 - autoStrength) * (1 - Math.exp(-delta * 2.2));
+      }
+
+      manualStrengthTarget *= Math.exp(-delta * manualDecay * 2.2);
+      const manualLerp = 1 - Math.exp(-delta * (4 + viscosityFactor * 0.15));
+      manualStrength += (manualStrengthTarget - manualStrength) * manualLerp;
+
+      const manualActive = manualStrengthTarget > 0.01;
+      const blendTarget = manualActive ? 1 : 0;
+      const blendLerp = 1 - Math.exp(-delta * (followSpeed * 2.2));
+      pointerBlend += (blendTarget - pointerBlend) * blendLerp;
+      pointerBlend = clamp01(pointerBlend);
+
+      blendedPointer.copy(autoPointer).lerp(manualPointer, pointerBlend);
+
+      const finalStrength = autoStrength * (1 - pointerBlend) + manualStrength * pointerBlend;
+
+      uniforms.uPointer.value.copy(blendedPointer);
+      uniforms.uPointerStrength.value = THREE.MathUtils.clamp(finalStrength, 0, 4);
+      uniforms.uCursorSize.value = cursorSize;
+      uniforms.uIntensity.value = autoIntensity;
+      uniforms.uTime.value += delta;
+
+      renderer.render(scene, camera);
+      animationId = requestAnimationFrame(animate);
+    };
+
+    animate();
+
+    return () => {
+      cancelAnimationFrame(animationId);
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerdown', handlePointerDown);
+      window.removeEventListener('touchmove', handleTouchMove);
+      window.removeEventListener('resize', resize);
+
+      scene.remove(mesh);
+      geometry.dispose();
+      material.dispose();
+      renderer.dispose();
+      if (renderer.domElement.parentNode === container) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, [
+    autoDemo,
+    autoIntensity,
+    autoRampDuration,
+    autoResumeDelay,
+    autoSpeed,
+    colors,
+    cursorSize,
+    isBounce,
+    isViscous,
+    iterationsPoisson,
+    iterationsViscous,
+    mouseForce,
+    resolution,
+    takeoverDuration,
+    viscous,
+  ]);
+
+  return <div ref={containerRef} className={clsx('h-full w-full', className)} />;
+};
+
+export default LiquidEther;
+

--- a/src/index.css
+++ b/src/index.css
@@ -34,6 +34,10 @@
     --ring: 222.2 84% 4.9%;
 
     --radius: 0.75rem;
+
+    --mona-primary: #7C3AED;
+    --mona-secondary: #0EA5E9;
+    --mona-accent-pink: #EC4899;
   }
 
   * {

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+/**
+ * Detects the user preference for reduced motion in an SSR-safe way.
+ *
+ * The hook mirrors the behaviour of CSS' `prefers-reduced-motion` media query
+ * and will update whenever the preference changes.
+ */
+export function useReducedMotion() {
+  const getPreference = () => {
+    if (typeof window === 'undefined') return false;
+    const query = window.matchMedia?.('(prefers-reduced-motion: reduce)');
+    return query?.matches ?? false;
+  };
+
+  const [reduced, setReduced] = useState(getPreference);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const handleChange = () => {
+      setReduced(mediaQuery.matches);
+    };
+
+    handleChange();
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', handleChange);
+      return () => mediaQuery.removeEventListener('change', handleChange);
+    }
+
+    mediaQuery.addListener(handleChange);
+    return () => mediaQuery.removeListener(handleChange);
+  }, []);
+
+  return reduced;
+}
+

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -4,6 +4,12 @@ interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL: string;
   readonly VITE_SUPABASE_ANON_KEY?: string;
   readonly VITE_SUPABASE_PUBLISHABLE_KEY?: string;
+  readonly NEXT_PUBLIC_LIQUIDETHER_ENABLED?: string;
+  readonly NEXT_PUBLIC_LIQUIDETHER_RESOLUTION?: string;
+  readonly NEXT_PUBLIC_LIQUIDETHER_INTENSITY?: string;
+  readonly VITE_LIQUIDETHER_ENABLED?: string;
+  readonly VITE_LIQUIDETHER_RESOLUTION?: string;
+  readonly VITE_LIQUIDETHER_INTENSITY?: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- add a client-only Liquid Ether background with Three.js plus reduced-motion fallback
- expose configuration via env variables, design tokens, and new helper hook
- document usage and apply subtle layout/backdrop tweaks to keep content legible

## Testing
- npm run lint
- npm run test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95f8456ec83229ea6b79a5be6df8a