### PR TITLE
Centralize Supabase client and add typed query layer

### DIFF
--- a/api/_lib/admin.ts
+++ b/api/_lib/admin.ts
@@ -1,0 +1,42 @@
+import type { SupabaseClient, User } from '@supabase/supabase-js';
+import { createSupabaseServiceRoleClient } from '../../src/integrations/supabase';
+import type { Database } from '../../src/integrations/supabase/types';
+
+export type ServiceSupabaseClient = SupabaseClient<Database>;
+
+interface ApiError extends Error {
+  status?: number;
+}
+
+export const getServiceSupabaseClient = () => createSupabaseServiceRoleClient();
+
+export const requireAdminUser = async (
+  client: ServiceSupabaseClient,
+  accessToken: string
+): Promise<User> => {
+  const { data: userData, error: authError } = await client.auth.getUser(accessToken);
+
+  if (authError || !userData?.user) {
+    const error: ApiError = new Error(authError?.message ?? 'Unauthorized');
+    error.status = 401;
+    throw error;
+  }
+
+  const { data: isAdmin, error: roleError } = await client.rpc('is_admin', {
+    uid: userData.user.id,
+  });
+
+  if (roleError) {
+    const error: ApiError = new Error(roleError.message);
+    error.status = 500;
+    throw error;
+  }
+
+  if (!isAdmin) {
+    const error: ApiError = new Error('Forbidden');
+    error.status = 403;
+    throw error;
+  }
+
+  return userData.user;
+};

--- a/api/admin/leads.ts
+++ b/api/admin/leads.ts
@@ -1,0 +1,50 @@
+import { fetchLeadsForAdmin } from '../../src/lib/leads';
+import { getServiceSupabaseClient, requireAdminUser } from '../_lib/admin';
+
+interface ApiRequest {
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+}
+
+interface ApiResponse {
+  status: (code: number) => ApiResponse;
+  json: (body: unknown) => void;
+}
+
+const extractAccessToken = (authorization?: string | string[]) => {
+  if (!authorization) return undefined;
+  const value = Array.isArray(authorization) ? authorization[0] : authorization;
+  const [scheme, token] = value.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return undefined;
+  }
+  return token.trim();
+};
+
+export default async function handler(req: ApiRequest, res: ApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const headerToken =
+    extractAccessToken(req.headers?.authorization) ||
+    extractAccessToken(req.headers?.Authorization);
+
+  if (!headerToken) {
+    res.status(401).json({ error: 'Missing access token' });
+    return;
+  }
+
+  try {
+    const client = getServiceSupabaseClient();
+    await requireAdminUser(client, headerToken);
+    const data = await fetchLeadsForAdmin(client);
+
+    res.status(200).json({ data });
+  } catch (error) {
+    const status = (error as { status?: number }).status ?? 500;
+    const message = error instanceof Error ? error.message : 'Unexpected server error.';
+    res.status(status).json({ error: message });
+  }
+}

--- a/api/admin/newsletter-subscribers.ts
+++ b/api/admin/newsletter-subscribers.ts
@@ -1,0 +1,50 @@
+import { fetchNewsletterSubscribersForAdmin } from '../../src/lib/newsletterSubscribers';
+import { getServiceSupabaseClient, requireAdminUser } from '../_lib/admin';
+
+interface ApiRequest {
+  method?: string;
+  headers?: Record<string, string | string[] | undefined>;
+}
+
+interface ApiResponse {
+  status: (code: number) => ApiResponse;
+  json: (body: unknown) => void;
+}
+
+const extractAccessToken = (authorization?: string | string[]) => {
+  if (!authorization) return undefined;
+  const value = Array.isArray(authorization) ? authorization[0] : authorization;
+  const [scheme, token] = value.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return undefined;
+  }
+  return token.trim();
+};
+
+export default async function handler(req: ApiRequest, res: ApiResponse) {
+  if (req.method !== 'GET') {
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const headerToken =
+    extractAccessToken(req.headers?.authorization) ||
+    extractAccessToken(req.headers?.Authorization);
+
+  if (!headerToken) {
+    res.status(401).json({ error: 'Missing access token' });
+    return;
+  }
+
+  try {
+    const client = getServiceSupabaseClient();
+    await requireAdminUser(client, headerToken);
+    const data = await fetchNewsletterSubscribersForAdmin(client);
+
+    res.status(200).json({ data });
+  } catch (error) {
+    const status = (error as { status?: number }).status ?? 500;
+    const message = error instanceof Error ? error.message : 'Unexpected server error.';
+    res.status(status).json({ error: message });
+  }
+}

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,17 @@
+const config = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  setupFiles: ['<rootDir>/jest.setup.ts'],
+  globals: {
+    'ts-jest': {
+      useESM: true,
+      tsconfig: 'tsconfig.app.json',
+    },
+  },
+};
+
+export default config;

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,4 @@
+process.env.VITE_SUPABASE_URL =
+  process.env.VITE_SUPABASE_URL ?? 'https://example.supabase.co';
+process.env.VITE_SUPABASE_ANON_KEY =
+  process.env.VITE_SUPABASE_ANON_KEY ?? 'test-anon-key';

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { supabase } from '@/integrations/supabase';
+import { subscribeToNewsletter } from '@/lib/newsletterSubscribers';
 import { useToast } from '@/hooks/use-toast';
 import { Mail, CheckCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -30,28 +30,7 @@ const NewsletterSection = () => {
     }
 
     try {
-      const { error } = await supabase
-        .from('newsletter_subscribers')
-        .insert([{ email: email.trim() }]);
-
-      if (error) {
-        if (error.code === '23505') {
-          // Unique constraint violation
-          toast({
-            title: t('newsletterSection.alreadySubscribedTitle'),
-            description: t('newsletterSection.alreadySubscribedDescription'),
-            variant: 'destructive',
-          });
-        } else {
-          toast({
-            title: t('newsletterSection.errorTitle'),
-            description: t('newsletterSection.errorDescription'),
-            variant: 'destructive',
-          });
-        }
-        setIsSubmitting(false);
-        return;
-      }
+      await subscribeToNewsletter(email.trim());
 
       setIsSubscribed(true);
       toast({
@@ -60,11 +39,21 @@ const NewsletterSection = () => {
       });
     } catch (error) {
       console.error('Newsletter subscription error:', error);
-      toast({
-        title: t('newsletterSection.errorTitle'),
-        description: t('newsletterSection.errorDescription'),
-        variant: 'destructive',
-      });
+      const supabaseError = error as { code?: string };
+
+      if (supabaseError?.code === '23505') {
+        toast({
+          title: t('newsletterSection.alreadySubscribedTitle'),
+          description: t('newsletterSection.alreadySubscribedDescription'),
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: t('newsletterSection.errorTitle'),
+          description: t('newsletterSection.errorDescription'),
+          variant: 'destructive',
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { supabase } from '@/integrations/supabase';
+import { fetchActiveTeamMembers } from '@/lib/teamMembers';
 import { Linkedin, Mail } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
@@ -25,13 +25,7 @@ const TeamSection = () => {
   } = useQuery({
     queryKey: ['team-members'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('team_members')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: true });
-
-      if (error) throw error;
+      const data = await fetchActiveTeamMembers();
       return data as TeamMember[];
     },
   });

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect, createContext, useContext } from 'react';
 import { User, Session } from '@supabase/supabase-js';
-import { supabase, clearSupabaseAuthCookies } from '@/integrations/supabase';
+import { getSupabaseBrowserClient, clearSupabaseAuthCookies } from '@/integrations/supabase';
+
+const supabase = getSupabaseBrowserClient();
 
 interface AuthContextType {
   user: User | null;

--- a/src/integrations/supabase.ts
+++ b/src/integrations/supabase.ts
@@ -1,13 +1,54 @@
-import { createClient, type Session } from '@supabase/supabase-js';
+import { createClient, type Session, type SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from './supabase/types';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL;
-const SUPABASE_ANON_KEY =
-  import.meta.env.VITE_SUPABASE_ANON_KEY ||
-  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+type TypedClient = SupabaseClient<Database>;
 
 const isBrowser = typeof window !== 'undefined';
+const browserEnv =
+  typeof import.meta !== 'undefined' && typeof import.meta.env !== 'undefined'
+    ? (import.meta.env as Record<string, string | undefined>)
+    : ({} as Record<string, string | undefined>);
+const serverEnv =
+  typeof process !== 'undefined' && typeof process.env !== 'undefined'
+    ? (process.env as Record<string, string | undefined>)
+    : {};
+
+const getEnvValue = (...keys: string[]) => {
+  for (const key of keys) {
+    const browserValue = browserEnv[key];
+    if (browserValue) {
+      return browserValue;
+    }
+
+    const serverValue = serverEnv[key];
+    if (serverValue) {
+      return serverValue;
+    }
+  }
+  return undefined;
+};
+
+const SUPABASE_URL = getEnvValue('VITE_SUPABASE_URL', 'SUPABASE_URL');
+if (!SUPABASE_URL) {
+  throw new Error('Supabase URL environment variable is not set.');
+}
+
+const SUPABASE_ANON_KEY = getEnvValue(
+  'VITE_SUPABASE_ANON_KEY',
+  'VITE_SUPABASE_PUBLISHABLE_KEY',
+  'SUPABASE_ANON_KEY',
+  'SUPABASE_PUBLISHABLE_KEY'
+);
+if (!SUPABASE_ANON_KEY) {
+  throw new Error('Supabase anon key environment variable is not set.');
+}
+
 const DEFAULT_COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days
+
+const STORAGE_KEY = 'sb-monynha-auth';
+const ACCESS_TOKEN_COOKIE = 'sb-monynha-access-token';
+const REFRESH_TOKEN_COOKIE = 'sb-monynha-refresh-token';
+const EXPIRES_AT_COOKIE = 'sb-monynha-session-exp';
 
 const escapeCookieName = (name: string) =>
   name.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, '\\$&');
@@ -34,13 +75,19 @@ const setCookie = (
   const maxAge =
     options?.maxAgeSeconds ?? Math.max(0, Math.round((expires.getTime() - Date.now()) / 1000));
 
-  document.cookie = `${name}=${encodeURIComponent(value)}; Path=/; Expires=${expires.toUTCString()}; Max-Age=${maxAge}; SameSite=Lax${secure ? '; Secure' : ''}`;
+  document.cookie = `${name}=${encodeURIComponent(
+    value
+  )}; Path=/; Expires=${expires.toUTCString()}; Max-Age=${maxAge}; SameSite=Lax${
+    secure ? '; Secure' : ''
+  }`;
 };
 
 const removeCookie = (name: string) => {
   if (!isBrowser) return;
   const secure = window.location.protocol === 'https:';
-  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; SameSite=Lax${secure ? '; Secure' : ''}`;
+  document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT; Max-Age=0; SameSite=Lax${
+    secure ? '; Secure' : ''
+  }`;
 };
 
 const parseSessionExpiry = (value: string) => {
@@ -55,11 +102,6 @@ const parseSessionExpiry = (value: string) => {
   return undefined;
 };
 
-const STORAGE_KEY = 'sb-monynha-auth';
-const ACCESS_TOKEN_COOKIE = 'sb-monynha-access-token';
-const REFRESH_TOKEN_COOKIE = 'sb-monynha-refresh-token';
-const EXPIRES_AT_COOKIE = 'sb-monynha-session-exp';
-
 const cookieStorage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = {
   getItem: (key) => getCookie(key),
   setItem: (key, value) => {
@@ -69,15 +111,19 @@ const cookieStorage: Pick<Storage, 'getItem' | 'setItem' | 'removeItem'> = {
   removeItem: (key) => removeCookie(key),
 };
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: {
-    storage: cookieStorage,
-    storageKey: STORAGE_KEY,
-    persistSession: true,
-    autoRefreshToken: true,
-    detectSessionInUrl: true,
-  },
-});
+let browserClient: TypedClient | null = null;
+let authListenersRegistered = false;
+
+const createBrowserClient = (): TypedClient =>
+  createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      storage: cookieStorage,
+      storageKey: STORAGE_KEY,
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
+  });
 
 const syncSessionCookies = (session: Session | null) => {
   if (!session) {
@@ -104,15 +150,30 @@ const syncSessionCookies = (session: Session | null) => {
   }
 };
 
-if (isBrowser) {
-  void supabase.auth.getSession().then(({ data: { session } }) => {
+const registerAuthListeners = (client: TypedClient) => {
+  if (!isBrowser || authListenersRegistered) {
+    return;
+  }
+
+  authListenersRegistered = true;
+
+  void client.auth.getSession().then(({ data: { session } }) => {
     syncSessionCookies(session);
   });
 
-  supabase.auth.onAuthStateChange((_event, session) => {
+  client.auth.onAuthStateChange((_event, session) => {
     syncSessionCookies(session);
   });
-}
+};
+
+export const getSupabaseBrowserClient = (): TypedClient => {
+  if (!browserClient) {
+    browserClient = createBrowserClient();
+    registerAuthListeners(browserClient);
+  }
+
+  return browserClient;
+};
 
 export const clearSupabaseAuthCookies = () => {
   removeCookie(STORAGE_KEY);
@@ -120,3 +181,67 @@ export const clearSupabaseAuthCookies = () => {
   removeCookie(REFRESH_TOKEN_COOKIE);
   removeCookie(EXPIRES_AT_COOKIE);
 };
+
+export interface SupabaseServerClientOptions {
+  accessToken?: string;
+  fetch?: typeof fetch;
+  headers?: Record<string, string>;
+}
+
+export const createSupabaseServerClient = (
+  options: SupabaseServerClientOptions = {}
+): TypedClient => {
+  const { accessToken, fetch: customFetch, headers } = options;
+
+  const globalHeaders =
+    accessToken || headers
+      ? {
+          ...(headers ?? {}),
+          ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+        }
+      : undefined;
+
+  return createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: Boolean(accessToken),
+      detectSessionInUrl: false,
+    },
+    global: {
+      ...(globalHeaders ? { headers: globalHeaders } : {}),
+      ...(customFetch ? { fetch: customFetch } : {}),
+    },
+  });
+};
+
+const getServiceRoleKey = () => {
+  if (isBrowser) {
+    throw new Error('Service role key is only available on the server.');
+  }
+
+  const key =
+    serverEnv.SUPABASE_SERVICE_ROLE_KEY ??
+    serverEnv.SUPABASE_SERVICE_KEY ??
+    serverEnv.SERVICE_ROLE_KEY;
+
+  if (!key) {
+    throw new Error('SUPABASE_SERVICE_ROLE_KEY environment variable is not set.');
+  }
+
+  return key;
+};
+
+export const createSupabaseServiceRoleClient = (): TypedClient => {
+  const serviceRoleKey = getServiceRoleKey();
+
+  return createClient<Database>(SUPABASE_URL, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+  });
+};
+
+export type { Database };
+export type { TypedClient as SupabaseClientType };

--- a/src/lib/__tests__/supabaseQueries.test.ts
+++ b/src/lib/__tests__/supabaseQueries.test.ts
@@ -1,0 +1,227 @@
+import { jest } from '@jest/globals';
+
+jest.mock('@/integrations/supabase', () => ({
+  getSupabaseBrowserClient: jest.fn(() => {
+    throw new Error('getSupabaseBrowserClient should not be used in tests');
+  }),
+  clearSupabaseAuthCookies: jest.fn(),
+  createSupabaseServerClient: jest.fn(),
+  createSupabaseServiceRoleClient: jest.fn(),
+}));
+
+import {
+  fetchActiveSolutions,
+  fetchSolutionBySlug,
+} from '../solutions';
+import { fetchActiveRepositories } from '../repositories';
+import { fetchPublishedBlogPosts } from '../blogPosts';
+import { fetchActiveHomepageFeatures } from '../homepageFeatures';
+import { fetchActiveTeamMembers } from '../teamMembers';
+import { fetchProfileByUserId } from '../profiles';
+import { createLead, fetchLeadsForAdmin } from '../leads';
+import {
+  subscribeToNewsletter,
+  fetchNewsletterSubscribersForAdmin,
+} from '../newsletterSubscribers';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/integrations/supabase/types';
+
+interface BuilderOverrides {
+  selectResult?: { data: unknown; error: unknown };
+  maybeSingleResult?: { data: unknown; error: unknown };
+  insertResult?: { data?: unknown; error: unknown };
+}
+
+type TypedClient = SupabaseClient<Database>;
+
+type BuilderMock = {
+  select: jest.Mock;
+  eq: jest.Mock;
+  order: jest.Mock;
+  limit: jest.Mock;
+  maybeSingle: jest.Mock;
+  insert: jest.Mock;
+  then: (onFulfilled: (value: unknown) => unknown, onRejected?: (reason: unknown) => unknown) => Promise<unknown>;
+  catch: (onRejected: (reason: unknown) => unknown) => Promise<unknown>;
+};
+
+const createQueryBuilderMock = (overrides?: BuilderOverrides) => {
+  const selectResult = overrides?.selectResult ?? { data: [], error: null };
+  const maybeSingleResult = overrides?.maybeSingleResult ?? { data: null, error: null };
+  const insertResult = overrides?.insertResult ?? { data: null, error: null };
+
+  const builder: Partial<BuilderMock> = {};
+
+  builder.select = jest.fn(() => builder);
+  builder.eq = jest.fn(() => builder);
+  builder.order = jest.fn(() => builder);
+  builder.limit = jest.fn(() => builder);
+  builder.maybeSingle = jest.fn(() => Promise.resolve(maybeSingleResult));
+  builder.insert = jest.fn(() => Promise.resolve(insertResult));
+  builder.then = (onFulfilled, onRejected) =>
+    Promise.resolve(selectResult).then(onFulfilled, onRejected);
+  builder.catch = (onRejected) => Promise.resolve(selectResult).catch(onRejected);
+
+  return builder as BuilderMock;
+};
+
+const createSupabaseClientMock = (overrides?: BuilderOverrides) => {
+  const builder = createQueryBuilderMock(overrides);
+  const from = jest.fn(() => builder);
+  return { client: ({ from } as unknown) as TypedClient, builder, from };
+};
+
+describe('Supabase query helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('applies active filter and ordering when fetching solutions', async () => {
+    const { client, builder, from } = createSupabaseClientMock();
+
+    await fetchActiveSolutions({ client, ascending: true });
+
+    expect(from).toHaveBeenCalledWith('solutions');
+    expect(builder.select).toHaveBeenCalledWith(
+      'id, title, description, slug, image_url, features, active, created_at, updated_at'
+    );
+    expect(builder.eq).toHaveBeenCalledWith('active', true);
+    expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: true });
+  });
+
+  it('applies limit when provided for solutions', async () => {
+    const { client, builder } = createSupabaseClientMock();
+
+    await fetchActiveSolutions({ client, limit: 2 });
+
+    expect(builder.limit).toHaveBeenCalledWith(2);
+  });
+
+  it('filters solutions by slug and active status', async () => {
+    const { client, builder, from } = createSupabaseClientMock({
+      maybeSingleResult: { data: null, error: null },
+    });
+
+    await fetchSolutionBySlug('demo-slug', client);
+
+    expect(from).toHaveBeenCalledWith('solutions');
+    expect(builder.eq.mock.calls).toContainEqual(['slug', 'demo-slug']);
+    expect(builder.eq.mock.calls).toContainEqual(['active', true]);
+  });
+
+  it('filters active repositories sorted by creation date', async () => {
+    const { client, builder, from } = createSupabaseClientMock();
+
+    await fetchActiveRepositories({ client, ascending: false });
+
+    expect(from).toHaveBeenCalledWith('repositories');
+    expect(builder.eq).toHaveBeenCalledWith('active', true);
+    expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('fetches published blog posts ordered by update date', async () => {
+    const { client, builder, from } = createSupabaseClientMock();
+
+    await fetchPublishedBlogPosts(client);
+
+    expect(from).toHaveBeenCalledWith('blog_posts');
+    expect(builder.eq).toHaveBeenCalledWith('published', true);
+    expect(builder.order).toHaveBeenCalledWith('updated_at', { ascending: false });
+  });
+
+  it('filters homepage features by active status and order index', async () => {
+    const { client, builder, from } = createSupabaseClientMock();
+
+    await fetchActiveHomepageFeatures(client);
+
+    expect(from).toHaveBeenCalledWith('homepage_features');
+    expect(builder.eq).toHaveBeenCalledWith('active', true);
+    expect(builder.order).toHaveBeenCalledWith('order_index', { ascending: true });
+  });
+
+  it('fetches active team members ordered by creation date', async () => {
+    const { client, builder, from } = createSupabaseClientMock();
+
+    await fetchActiveTeamMembers(client);
+
+    expect(from).toHaveBeenCalledWith('team_members');
+    expect(builder.eq).toHaveBeenCalledWith('active', true);
+    expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: true });
+  });
+
+  it('fetches profile by user id respecting RLS', async () => {
+    const { client, builder, from } = createSupabaseClientMock({
+      maybeSingleResult: { data: null, error: null },
+    });
+
+    await fetchProfileByUserId('user-123', client);
+
+    expect(from).toHaveBeenCalledWith('profiles');
+    expect(builder.eq).toHaveBeenCalledWith('user_id', 'user-123');
+  });
+
+  it('sanitizes and inserts leads through public endpoint', async () => {
+    const { client, builder, from } = createSupabaseClientMock({
+      insertResult: { data: null, error: null },
+    });
+
+    await createLead(
+      {
+        name: ' Jane Doe ',
+        email: ' jane@example.com ',
+        message: ' Interested in a project ',
+        company: ' ',
+        project: 'Automation',
+      },
+      client
+    );
+
+    expect(from).toHaveBeenCalledWith('leads');
+    expect(builder.insert).toHaveBeenCalledWith([
+      {
+        name: 'Jane Doe',
+        email: 'jane@example.com',
+        message: 'Interested in a project',
+        company: null,
+        project: 'Automation',
+      },
+    ]);
+  });
+
+  it('uses service role client to fetch leads for admins', async () => {
+    const { client, builder, from } = createSupabaseClientMock();
+
+    await fetchLeadsForAdmin(client);
+
+    expect(from).toHaveBeenCalledWith('leads');
+    expect(builder.select).toHaveBeenCalledWith(
+      'id, name, email, company, project, message, created_at'
+    );
+    expect(builder.order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('subscribes newsletter users with trimmed email', async () => {
+    const { client, builder, from } = createSupabaseClientMock({
+      insertResult: { data: null, error: null },
+    });
+
+    await subscribeToNewsletter(' user@example.com ', client);
+
+    expect(from).toHaveBeenCalledWith('newsletter_subscribers');
+    expect(builder.insert).toHaveBeenCalledWith([
+      {
+        email: 'user@example.com',
+      },
+    ]);
+  });
+
+  it('fetches newsletter subscribers ordered by subscription date', async () => {
+    const { client, builder, from } = createSupabaseClientMock();
+
+    await fetchNewsletterSubscribersForAdmin(client);
+
+    expect(from).toHaveBeenCalledWith('newsletter_subscribers');
+    expect(builder.select).toHaveBeenCalledWith('id, email, active, subscribed_at');
+    expect(builder.order).toHaveBeenCalledWith('subscribed_at', { ascending: false });
+  });
+});

--- a/src/lib/blogPosts.ts
+++ b/src/lib/blogPosts.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type BlogPostRecord = Database['public']['Tables']['blog_posts']['Row'];
+export type BlogPostInsert = Database['public']['Tables']['blog_posts']['Insert'];
+export type BlogPostUpdate = Database['public']['Tables']['blog_posts']['Update'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const BLOG_POST_FIELDS =
+  'id, slug, title, excerpt, content, image_url, published, created_at, updated_at';
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchPublishedBlogPosts = async (client?: TypedClient): Promise<BlogPostRecord[]> => {
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('blog_posts')
+    .select(BLOG_POST_FIELDS)
+    .eq('published', true)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};
+
+export const fetchBlogPostBySlug = async (
+  slug: string,
+  client?: TypedClient
+): Promise<BlogPostRecord | null> => {
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('blog_posts')
+    .select(BLOG_POST_FIELDS)
+    .eq('slug', slug)
+    .eq('published', true)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+};

--- a/src/lib/homepageFeatures.ts
+++ b/src/lib/homepageFeatures.ts
@@ -1,0 +1,32 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type HomepageFeatureRecord = Database['public']['Tables']['homepage_features']['Row'];
+export type HomepageFeatureInsert = Database['public']['Tables']['homepage_features']['Insert'];
+export type HomepageFeatureUpdate = Database['public']['Tables']['homepage_features']['Update'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const HOMEPAGE_FEATURE_FIELDS =
+  'id, title, description, icon, url, order_index, active, created_at, updated_at';
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveHomepageFeatures = async (
+  client?: TypedClient
+): Promise<HomepageFeatureRecord[]> => {
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('homepage_features')
+    .select(HOMEPAGE_FEATURE_FIELDS)
+    .eq('active', true)
+    .order('order_index', { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/leads.ts
+++ b/src/lib/leads.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type LeadRecord = Database['public']['Tables']['leads']['Row'];
+export type LeadInsert = Database['public']['Tables']['leads']['Insert'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const LEAD_FIELDS =
+  'id, name, email, company, project, message, created_at';
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export interface CreateLeadPayload {
+  name: string;
+  email: string;
+  message: string;
+  company?: string | null;
+  project?: string | null;
+}
+
+const sanitizeOptionalField = (value?: string | null) => {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+export const createLead = async (
+  payload: CreateLeadPayload,
+  client?: TypedClient
+): Promise<void> => {
+  const supabase = resolveClient(client);
+
+  const entry: LeadInsert = {
+    name: payload.name.trim(),
+    email: payload.email.trim(),
+    message: payload.message.trim(),
+    company: sanitizeOptionalField(payload.company),
+    project: sanitizeOptionalField(payload.project),
+  };
+
+  const { error } = await supabase.from('leads').insert([entry]);
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const fetchLeadsForAdmin = async (
+  client: TypedClient
+): Promise<LeadRecord[]> => {
+  const { data, error } = await client
+    .from('leads')
+    .select(LEAD_FIELDS)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/newsletterSubscribers.ts
+++ b/src/lib/newsletterSubscribers.ts
@@ -1,0 +1,47 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type NewsletterSubscriberRecord =
+  Database['public']['Tables']['newsletter_subscribers']['Row'];
+export type NewsletterSubscriberInsert =
+  Database['public']['Tables']['newsletter_subscribers']['Insert'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const NEWSLETTER_FIELDS = 'id, email, active, subscribed_at';
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const subscribeToNewsletter = async (
+  email: string,
+  client?: TypedClient
+): Promise<void> => {
+  const supabase = resolveClient(client);
+  const sanitizedEmail = email.trim();
+
+  const entry: NewsletterSubscriberInsert = {
+    email: sanitizedEmail,
+  };
+
+  const { error } = await supabase.from('newsletter_subscribers').insert([entry]);
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const fetchNewsletterSubscribersForAdmin = async (
+  client: TypedClient
+): Promise<NewsletterSubscriberRecord[]> => {
+  const { data, error } = await client
+    .from('newsletter_subscribers')
+    .select(NEWSLETTER_FIELDS)
+    .order('subscribed_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type ProfileRecord = Database['public']['Tables']['profiles']['Row'];
+export type ProfileInsert = Database['public']['Tables']['profiles']['Insert'];
+export type ProfileUpdate = Database['public']['Tables']['profiles']['Update'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const PROFILE_FIELDS =
+  'id, user_id, name, email, role, avatar_url, created_at, updated_at';
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchProfileByUserId = async (
+  userId: string,
+  client?: TypedClient
+): Promise<ProfileRecord | null> => {
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select(PROFILE_FIELDS)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+};
+
+export const isUserAdmin = (profile: ProfileRecord | null | undefined) =>
+  profile?.role === 'admin';

--- a/src/lib/repositories.ts
+++ b/src/lib/repositories.ts
@@ -1,0 +1,38 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type RepositoryRecord = Database['public']['Tables']['repositories']['Row'];
+export type RepositoryInsert = Database['public']['Tables']['repositories']['Insert'];
+export type RepositoryUpdate = Database['public']['Tables']['repositories']['Update'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const REPOSITORY_FIELDS =
+  'id, name, description, github_url, demo_url, tags, active, created_at, updated_at';
+
+export interface FetchRepositoriesOptions {
+  client?: TypedClient;
+  ascending?: boolean;
+}
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveRepositories = async (
+  options: FetchRepositoriesOptions = {}
+): Promise<RepositoryRecord[]> => {
+  const { client, ascending = false } = options;
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('repositories')
+    .select(REPOSITORY_FIELDS)
+    .eq('active', true)
+    .order('created_at', { ascending });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/siteSettings.ts
+++ b/src/lib/siteSettings.ts
@@ -1,0 +1,32 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type SiteSettingRecord = Database['public']['Tables']['site_settings']['Row'];
+export type SiteSettingInsert = Database['public']['Tables']['site_settings']['Insert'];
+export type SiteSettingUpdate = Database['public']['Tables']['site_settings']['Update'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const SITE_SETTING_FIELDS = 'id, key, value, description, created_at, updated_at';
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchSiteSettingByKey = async (
+  key: string,
+  client?: TypedClient
+): Promise<SiteSettingRecord | null> => {
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('site_settings')
+    .select(SITE_SETTING_FIELDS)
+    .eq('key', key)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+};

--- a/src/lib/solutions.ts
+++ b/src/lib/solutions.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type SolutionRecord = Database['public']['Tables']['solutions']['Row'];
+export type SolutionInsert = Database['public']['Tables']['solutions']['Insert'];
+export type SolutionUpdate = Database['public']['Tables']['solutions']['Update'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const SOLUTION_FIELDS =
+  'id, title, description, slug, image_url, features, active, created_at, updated_at';
+
+export interface FetchSolutionsOptions {
+  client?: TypedClient;
+  limit?: number;
+  ascending?: boolean;
+}
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveSolutions = async (
+  options: FetchSolutionsOptions = {}
+): Promise<SolutionRecord[]> => {
+  const { client, limit, ascending = true } = options;
+  const supabase = resolveClient(client);
+
+  let query = supabase
+    .from('solutions')
+    .select(SOLUTION_FIELDS)
+    .eq('active', true)
+    .order('created_at', { ascending });
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};
+
+export const fetchSolutionBySlug = async (
+  slug: string,
+  client?: TypedClient
+): Promise<SolutionRecord | null> => {
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('solutions')
+    .select(SOLUTION_FIELDS)
+    .eq('slug', slug)
+    .eq('active', true)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+};

--- a/src/lib/teamMembers.ts
+++ b/src/lib/teamMembers.ts
@@ -1,0 +1,30 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type TeamMemberRecord = Database['public']['Tables']['team_members']['Row'];
+export type TeamMemberInsert = Database['public']['Tables']['team_members']['Insert'];
+export type TeamMemberUpdate = Database['public']['Tables']['team_members']['Update'];
+
+type TypedClient = SupabaseClient<Database>;
+
+const TEAM_MEMBER_FIELDS =
+  'id, name, role, bio, image_url, linkedin_url, active, created_at, updated_at';
+
+const resolveClient = (client?: TypedClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveTeamMembers = async (client?: TypedClient): Promise<TeamMemberRecord[]> => {
+  const supabase = resolveClient(client);
+
+  const { data, error } = await supabase
+    .from('team_members')
+    .select(TEAM_MEMBER_FIELDS)
+    .eq('active', true)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Link, useNavigate, useLocation } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import {
@@ -18,6 +18,8 @@ import Loading from '@/components/Loading';
 import { ArrowLeft, Eye, EyeOff, Loader2 } from 'lucide-react';
 
 type AuthTab = 'signin' | 'signup';
+
+const supabase = getSupabaseBrowserClient();
 
 const Auth = () => {
   const [activeTab, setActiveTab] = useState<AuthTab>('signin');

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,7 +5,7 @@ import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import NewsletterSection from '@/components/NewsletterSection';
 import { ArrowRight, Clock, User } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
+import { fetchPublishedBlogPosts } from '@/lib/blogPosts';
 import { useTranslation, Trans } from 'react-i18next';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -41,18 +41,9 @@ const Blog = () => {
   } = useQuery({
     queryKey: ['blog_posts'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('blog_posts')
-        .select('id, slug, title, excerpt, image_url, updated_at')
-        .eq('published', true)
-        .order('updated_at', { ascending: false });
+      const data = await fetchPublishedBlogPosts();
 
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return (
-        data?.map((post, index) => ({
+      return data.map((post, index) => ({
           title: post.title,
           excerpt: post.excerpt || 'Read more about this topic...',
           image:
@@ -68,8 +59,7 @@ const Blog = () => {
           category: 'AI Insights',
           featured: index === 0,
           slug: post.slug,
-        })) || []
-      );
+        }));
     },
   });
 

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import { Mail, Phone, MapPin, Send, CheckCircle } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
+import { createLead } from '@/lib/leads';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
@@ -85,25 +85,13 @@ const Contact = () => {
     }
 
     try {
-      const { error } = await supabase.from('leads').insert([
-        {
-          name: formData.name,
-          email: formData.email,
-          company: formData.company || null,
-          project: formData.project || null,
-          message: formData.message,
-        },
-      ]);
-
-      if (error) {
-        console.error('Error submitting form:', error);
-        toast({
-          title: t('contact.toasts.errorTitle'),
-          description: t('contact.toasts.errorDescription'),
-          variant: 'destructive',
-        });
-        return;
-      }
+      await createLead({
+        name: formData.name,
+        email: formData.email,
+        company: formData.company || null,
+        project: formData.project || null,
+        message: formData.message,
+      });
 
       setIsSubmitted(true);
       toast({

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -18,7 +18,8 @@ import {
 } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase';
+import { fetchActiveHomepageFeatures } from '@/lib/homepageFeatures';
+import { fetchActiveSolutions } from '@/lib/solutions';
 import { useMemo } from 'react';
 
 const fallbackSolutions = [
@@ -55,13 +56,7 @@ const Index = () => {
   const { data: features, isLoading: featuresLoading } = useQuery({
     queryKey: ['homepage-features'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('homepage_features')
-        .select('*')
-        .eq('active', true)
-        .order('order_index', { ascending: true });
-
-      if (error) throw error;
+      const data = await fetchActiveHomepageFeatures();
 
       // Map to the expected format with icon components
       const iconMap: Record<string, LucideIcon> = {
@@ -86,14 +81,7 @@ const Index = () => {
   const { data: solutions, isLoading: solutionsLoading } = useQuery({
     queryKey: ['solutions-preview'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('solutions')
-        .select('*')
-        .eq('active', true)
-        .limit(2)
-        .order('created_at', { ascending: true });
-
-      if (error) throw error;
+      const data = await fetchActiveSolutions({ limit: 2, ascending: true });
 
       return data.map((solution, index) => ({
         name: solution.title,

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -13,7 +13,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { supabase } from '@/integrations/supabase';
+import { fetchActiveRepositories } from '@/lib/repositories';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 
@@ -36,19 +36,7 @@ const Projects = () => {
     isError,
   } = useQuery({
     queryKey: ['repositories'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('repositories')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: false });
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return data || [];
-    },
+    queryFn: async () => fetchActiveRepositories({ ascending: false }),
   });
 
   const formatDate = (dateString: string) => {

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -23,7 +23,7 @@ import {
   Calendar,
   Settings,
 } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
+import { fetchActiveSolutions } from '@/lib/solutions';
 import { useTranslation } from 'react-i18next';
 
 const fallbackSolutions = [
@@ -104,16 +104,9 @@ const Solutions = () => {
   } = useQuery({
     queryKey: ['solutions'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('solutions')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: true });
-      if (error) {
-        throw new Error(error.message);
-      }
-      return (
-        data?.map((solution, index) => {
+      const data = await fetchActiveSolutions({ ascending: true });
+
+      return data.map((solution, index) => {
           const getFeatures = (slug: string) => {
             if (slug === 'boteco-pro') {
               return [
@@ -187,8 +180,7 @@ const Solutions = () => {
             color:
               solution.slug === 'boteco-pro' ? 'brand-purple' : 'brand-pink',
           };
-        }) || []
-      );
+        });
     },
   });
 


### PR DESCRIPTION
## Summary
- centralize Supabase client creation for browser, server, and service-role contexts while keeping auth cookies in sync
- add typed data access helpers and migrate pages/components to use them instead of raw Supabase queries
- expose service-role API routes for admin reads and add Jest-based tests verifying query filters

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9add1acc08322812634cd9acf6ce0