### PR TITLE
refactor: centralize supabase access and typed queries

### DIFF
--- a/api/admin/dashboard.ts
+++ b/api/admin/dashboard.ts
@@ -1,0 +1,84 @@
+import {
+  createSupabaseServiceRoleClient,
+  type TypedSupabaseClient,
+} from '../../src/integrations/supabase';
+import { fetchLeadsForAdmin } from '../../src/lib/leads';
+import { fetchNewsletterSubscribersForAdmin } from '../../src/lib/newsletter';
+import { fetchProfileByUserId } from '../../src/lib/profiles';
+
+interface ApiRequest {
+  method?: string;
+  headers: Record<string, string | string[] | undefined>;
+}
+
+interface ApiResponse {
+  status: (statusCode: number) => ApiResponse;
+  json: (body: unknown) => void;
+}
+
+const extractBearerToken = (authorization?: string | string[]): string | null => {
+  const header = Array.isArray(authorization) ? authorization[0] : authorization;
+  if (!header) {
+    return null;
+  }
+
+  const [scheme, token] = header.split(' ');
+  if (!token || scheme.toLowerCase() !== 'bearer') {
+    return null;
+  }
+
+  return token.trim();
+};
+
+const sendError = (res: ApiResponse, statusCode: number, message: string) => {
+  res.status(statusCode).json({ error: message });
+};
+
+const fetchAdminData = async (
+  client: TypedSupabaseClient
+): Promise<{ leads: Awaited<ReturnType<typeof fetchLeadsForAdmin>>; subscribers: Awaited<ReturnType<typeof fetchNewsletterSubscribersForAdmin>>; }> => {
+  const [leads, subscribers] = await Promise.all([
+    fetchLeadsForAdmin(client),
+    fetchNewsletterSubscribersForAdmin(client),
+  ]);
+
+  return { leads, subscribers };
+};
+
+export default async function handler(req: ApiRequest, res: ApiResponse) {
+  if (req.method !== 'GET') {
+    sendError(res, 405, 'Method not allowed');
+    return;
+  }
+
+  const token = extractBearerToken(req.headers.authorization);
+
+  if (!token) {
+    sendError(res, 401, 'Cabeçalho de autorização ausente ou inválido.');
+    return;
+  }
+
+  try {
+    const adminClient = createSupabaseServiceRoleClient();
+    const { data: userData, error: userError } = await adminClient.auth.getUser(token);
+
+    if (userError || !userData?.user) {
+      sendError(res, 401, 'Token de acesso inválido.');
+      return;
+    }
+
+    const profile = await fetchProfileByUserId(userData.user.id, adminClient);
+
+    if (!profile || profile.role !== 'admin') {
+      sendError(res, 403, 'Acesso não autorizado.');
+      return;
+    }
+
+    const { leads, subscribers } = await fetchAdminData(adminClient);
+
+    res.status(200).json({ leads, subscribers });
+  } catch (error) {
+    console.error('Erro ao carregar dados administrativos', error);
+    sendError(res, 500, 'Erro interno ao carregar dados administrativos.');
+  }
+}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "cleanup-lovable": "tsx scripts/cleanup-lovable.ts",
     "preview": "vite preview",
     "test": "jest --passWithNoTests",
+    "test:supabase-permissions": "tsx scripts/test-supabase-permissions.ts",
     "format": "prettier --write .",
     "prepare": "husky install"
   },

--- a/scripts/test-supabase-permissions.ts
+++ b/scripts/test-supabase-permissions.ts
@@ -1,0 +1,141 @@
+import {
+  createSupabaseServerClient,
+  createSupabaseServiceRoleClient,
+  type TypedSupabaseClient,
+} from '../src/integrations/supabase';
+import { fetchActiveSolutions } from '../src/lib/solutions';
+import { createLead, fetchLeadsForAdmin } from '../src/lib/leads';
+import {
+  fetchNewsletterSubscribersForAdmin,
+  subscribeToNewsletter,
+} from '../src/lib/newsletter';
+
+const log = console.log;
+const warn = console.warn;
+
+const withClient = async <T>(
+  label: string,
+  action: (client: TypedSupabaseClient) => Promise<T>,
+  clientFactory: () => TypedSupabaseClient
+) => {
+  try {
+    log(`\n[${label}]`);
+    const client = clientFactory();
+    const result = await action(client);
+    return result;
+  } catch (error) {
+    warn(`Falha em ${label}:`, error);
+    return null;
+  }
+};
+
+const runVisitorChecks = async () => {
+  const visitorClient = createSupabaseServerClient();
+  await withClient('Visitante - leitura de soluções ativas', async (client) => {
+    const solutions = await fetchActiveSolutions({}, client);
+    log(`Soluções públicas disponíveis: ${solutions.length}`);
+    return solutions;
+  }, () => visitorClient);
+
+  if (process.env.SUPABASE_TEST_MODE === 'true') {
+    await withClient('Visitante - criação de lead', async (client) => {
+      await createLead(
+        {
+          name: 'Teste Visitante',
+          email: `visitante-${Date.now()}@example.com`,
+          message: 'Lead gerado durante teste automatizado.',
+          company: null,
+          project: null,
+        },
+        client
+      );
+      log('Lead de teste criado com sucesso.');
+    }, () => visitorClient);
+
+    await withClient('Visitante - inscrição em newsletter', async (client) => {
+      try {
+        await subscribeToNewsletter(`newsletter-${Date.now()}@example.com`, client);
+        log('Assinatura de newsletter realizada.');
+      } catch (error) {
+        warn('Assinatura de newsletter falhou (possivelmente e-mail duplicado).', error);
+      }
+    }, () => visitorClient);
+  } else {
+    warn('SUPABASE_TEST_MODE != "true" - inserções de visitante foram ignoradas.');
+  }
+};
+
+const runUserChecks = async () => {
+  const email = process.env.SUPABASE_TEST_USER_EMAIL;
+  const password = process.env.SUPABASE_TEST_USER_PASSWORD;
+
+  if (!email || !password) {
+    warn('Credenciais de usuário de teste ausentes. Ignorando verificações de usuário autenticado.');
+    return;
+  }
+
+  const anonClient = createSupabaseServerClient({ persistSession: true });
+  const { data: authData, error } = await anonClient.auth.signInWithPassword({
+    email,
+    password,
+  });
+
+  if (error || !authData.session) {
+    warn('Não foi possível autenticar usuário de teste.', error);
+    return;
+  }
+
+  const userClient = createSupabaseServerClient({
+    accessToken: authData.session.access_token,
+  });
+
+  await withClient(
+    'Usuário autenticado - tentativa de leitura de leads',
+    async (client) => {
+      try {
+        const leads = await fetchLeadsForAdmin(client);
+        log(`Usuário autenticado obteve ${leads.length} leads (verificar política de RLS).`);
+      } catch (clientError) {
+        warn('Leitura de leads bloqueada para usuário autenticado (esperado se não admin).', clientError);
+      }
+    },
+    () => userClient
+  );
+};
+
+const runAdminChecks = async () => {
+  if (!process.env.SUPABASE_SERVICE_ROLE_KEY) {
+    warn('SUPABASE_SERVICE_ROLE_KEY não configurado. Ignorando verificações administrativas.');
+    return;
+  }
+
+  const adminClient = createSupabaseServiceRoleClient();
+  await withClient('Admin - leitura de leads', fetchLeadsForAdmin, () => adminClient);
+  await withClient(
+    'Admin - leitura de assinantes da newsletter',
+    fetchNewsletterSubscribersForAdmin,
+    () => adminClient
+  );
+};
+
+const run = async () => {
+  const supabaseUrl =
+    process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL || process.env.SUPABASE_PROJECT_URL;
+  const anonKey = process.env.VITE_SUPABASE_ANON_KEY || process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !anonKey) {
+    warn('Variáveis de ambiente do Supabase não encontradas. Ignorando testes de permissão.');
+    return;
+  }
+
+  log('Iniciando verificação de permissões do Supabase...');
+  await runVisitorChecks();
+  await runUserChecks();
+  await runAdminChecks();
+  log('\nVerificação concluída.');
+};
+
+void run().catch((error) => {
+  console.error('Falha na verificação de permissões do Supabase', error);
+  process.exitCode = 1;
+});

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -2,18 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { supabase } from '@/integrations/supabase';
-import { Linkedin, Mail } from 'lucide-react';
+import { Linkedin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-
-interface TeamMember {
-  id: string;
-  name: string;
-  role: string;
-  bio: string | null;
-  image_url: string | null;
-  linkedin_url: string | null;
-}
+import { fetchActiveTeamMembers, type TeamMember } from '@/lib/team-members';
 
 const TeamSection = () => {
   const { t } = useTranslation();
@@ -24,16 +15,7 @@ const TeamSection = () => {
     error,
   } = useQuery({
     queryKey: ['team-members'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('team_members')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: true });
-
-      if (error) throw error;
-      return data as TeamMember[];
-    },
+    queryFn: async () => fetchActiveTeamMembers(),
   });
 
   if (isLoading) {

--- a/src/integrations/supabase.ts
+++ b/src/integrations/supabase.ts
@@ -1,14 +1,70 @@
-import { createClient } from '@supabase/supabase-js';
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
 import type { Database } from '@/integrations/supabase/types';
 
-const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string;
-const SUPABASE_ANON_KEY =
-  (import.meta.env.VITE_SUPABASE_ANON_KEY ||
-    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY) as string;
+type EnvRecord = Record<string, string | undefined>;
 
 const AUTH_COOKIE_PREFIX = 'monynha_supabase_';
 const AUTH_STORAGE_KEY = 'auth_token';
 const DEFAULT_MAX_AGE = 60 * 60 * 24 * 30; // 30 days
+
+const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
+
+const collectEnvironment = (): EnvRecord => {
+  const env: EnvRecord = {};
+
+  if (typeof import.meta !== 'undefined') {
+    const meta = import.meta as ImportMeta & { env?: EnvRecord };
+    if (meta.env) {
+      for (const [key, value] of Object.entries(meta.env)) {
+        if (typeof value === 'string' && value.length > 0) {
+          env[key] = value;
+        }
+      }
+    }
+  }
+
+  if (typeof process !== 'undefined' && typeof process.env !== 'undefined') {
+    const processEnv = process.env as EnvRecord;
+    for (const [key, value] of Object.entries(processEnv)) {
+      if (typeof value === 'string' && value.length > 0 && env[key] === undefined) {
+        env[key] = value;
+      }
+    }
+  }
+
+  return env;
+};
+
+const ENVIRONMENT = collectEnvironment();
+
+const getEnvValue = (...keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = ENVIRONMENT[key];
+    if (typeof value === 'string' && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const SUPABASE_URL = getEnvValue('VITE_SUPABASE_URL', 'SUPABASE_URL');
+const SUPABASE_ANON_KEY = getEnvValue(
+  'VITE_SUPABASE_ANON_KEY',
+  'VITE_SUPABASE_PUBLISHABLE_KEY',
+  'SUPABASE_ANON_KEY'
+);
+
+if (!SUPABASE_URL) {
+  throw new Error(
+    'Supabase URL is not configured. Set VITE_SUPABASE_URL (client) or SUPABASE_URL (server).'
+  );
+}
+
+if (!SUPABASE_ANON_KEY) {
+  throw new Error(
+    'Supabase anonymous key is not configured. Set VITE_SUPABASE_ANON_KEY or SUPABASE_ANON_KEY.'
+  );
+}
 
 class CookieStorage implements Storage {
   private readonly path: string;
@@ -31,7 +87,7 @@ class CookieStorage implements Storage {
   }
 
   getItem(key: string): string | null {
-    if (typeof document === 'undefined') return null;
+    if (!isBrowser) return null;
     const cookieName = this.getCookieName(key);
     const entry = this.getCookies().find(({ name }) => name === cookieName);
     if (!entry) return null;
@@ -44,7 +100,7 @@ class CookieStorage implements Storage {
   }
 
   removeItem(key: string): void {
-    if (typeof document === 'undefined') return;
+    if (!isBrowser) return;
     const cookieName = this.getCookieName(key);
     const secureSuffix =
       typeof window !== 'undefined' && window.location.protocol === 'https:'
@@ -55,7 +111,7 @@ class CookieStorage implements Storage {
   }
 
   setItem(key: string, value: string): void {
-    if (typeof document === 'undefined') return;
+    if (!isBrowser) return;
     const cookieName = this.getCookieName(key);
     const secureSuffix =
       typeof window !== 'undefined' && window.location.protocol === 'https:'
@@ -70,7 +126,7 @@ class CookieStorage implements Storage {
   }
 
   private getCookies(): Array<{ name: string; value: string }> {
-    if (typeof document === 'undefined' || !document.cookie) {
+    if (!isBrowser || !document.cookie) {
       return [];
     }
 
@@ -90,20 +146,102 @@ class CookieStorage implements Storage {
   }
 }
 
-const isBrowser = typeof window !== 'undefined' && typeof document !== 'undefined';
+export type TypedSupabaseClient = SupabaseClient<Database>;
 
 const cookieStorage = isBrowser
   ? new CookieStorage(AUTH_COOKIE_PREFIX, { path: '/', maxAge: DEFAULT_MAX_AGE })
   : undefined;
 
-export const supabase = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
-  auth: {
-    storage: cookieStorage,
-    storageKey: AUTH_STORAGE_KEY,
-    persistSession: true,
-    autoRefreshToken: true,
-  },
-});
+const createBrowserClient = (): TypedSupabaseClient =>
+  createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      storage: cookieStorage,
+      storageKey: AUTH_STORAGE_KEY,
+      persistSession: true,
+      autoRefreshToken: true,
+      detectSessionInUrl: true,
+    },
+  });
+
+let browserClient: TypedSupabaseClient | null = null;
+
+export const getSupabaseBrowserClient = (): TypedSupabaseClient => {
+  if (!isBrowser) {
+    throw new Error('Supabase browser client requested outside browser context.');
+  }
+
+  if (!browserClient) {
+    browserClient = createBrowserClient();
+  }
+
+  return browserClient;
+};
+
+export interface ServerClientOptions {
+  accessToken?: string;
+  fetch?: typeof fetch;
+  persistSession?: boolean;
+}
+
+export const createSupabaseServerClient = ({
+  accessToken,
+  fetch: fetchImplementation,
+  persistSession = false,
+}: ServerClientOptions = {}): TypedSupabaseClient => {
+  return createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession,
+      autoRefreshToken: persistSession,
+      detectSessionInUrl: false,
+    },
+    global: {
+      headers: accessToken ? { Authorization: `Bearer ${accessToken}` } : undefined,
+      fetch: fetchImplementation ?? (typeof fetch === 'function' ? fetch : undefined),
+    },
+  });
+};
+
+const resolveServiceRoleKey = (): string => {
+  const key = getEnvValue('SUPABASE_SERVICE_ROLE_KEY');
+  if (!key) {
+    throw new Error('Supabase service role key is not configured.');
+  }
+  return key;
+};
+
+export interface ServiceRoleClientOptions {
+  fetch?: typeof fetch;
+}
+
+export const createSupabaseServiceRoleClient = ({
+  fetch: fetchImplementation,
+}: ServiceRoleClientOptions = {}): TypedSupabaseClient => {
+  if (isBrowser) {
+    throw new Error('Service role client must only be created server-side.');
+  }
+
+  return createClient<Database>(SUPABASE_URL, resolveServiceRoleKey(), {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+      detectSessionInUrl: false,
+    },
+    global: {
+      fetch: fetchImplementation ?? (typeof fetch === 'function' ? fetch : undefined),
+    },
+  });
+};
+
+let supabaseInstance: TypedSupabaseClient | null = null;
+
+export const getSupabaseClient = (): TypedSupabaseClient => {
+  if (!supabaseInstance) {
+    supabaseInstance = isBrowser ? createBrowserClient() : createSupabaseServerClient();
+  }
+  return supabaseInstance;
+};
+
+export const supabase = getSupabaseClient();
 
 export const clearSupabaseSession = () => {
   if (cookieStorage) {

--- a/src/lib/blog-posts.ts
+++ b/src/lib/blog-posts.ts
@@ -1,0 +1,42 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type BlogPost = Database['public']['Tables']['blog_posts']['Row'];
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchPublishedBlogPosts = async (
+  client?: TypedSupabaseClient
+): Promise<BlogPost[]> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('blog_posts')
+    .select('*')
+    .eq('published', true)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load blog posts: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+
+export const fetchPublishedBlogPostBySlug = async (
+  slug: string,
+  client?: TypedSupabaseClient
+): Promise<BlogPost | null> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('blog_posts')
+    .select('*')
+    .eq('published', true)
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load blog post: ${error.message}`);
+  }
+
+  return data ?? null;
+};

--- a/src/lib/homepage-features.ts
+++ b/src/lib/homepage-features.ts
@@ -1,0 +1,23 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type HomepageFeature = Database['public']['Tables']['homepage_features']['Row'];
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveHomepageFeatures = async (
+  client?: TypedSupabaseClient
+): Promise<HomepageFeature[]> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('homepage_features')
+    .select('*')
+    .eq('active', true)
+    .order('order_index', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load homepage features: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/leads.ts
+++ b/src/lib/leads.ts
@@ -1,0 +1,40 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type Lead = Database['public']['Tables']['leads']['Row'];
+export type LeadInsert = Database['public']['Tables']['leads']['Insert'];
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const createLead = async (
+  payload: LeadInsert,
+  client?: TypedSupabaseClient
+): Promise<Lead> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('leads')
+    .insert([{ ...payload }])
+    .select('*')
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to create lead: ${error.message}`);
+  }
+
+  return data;
+};
+
+export const fetchLeadsForAdmin = async (
+  client: TypedSupabaseClient
+): Promise<Lead[]> => {
+  const { data, error } = await client
+    .from('leads')
+    .select('*')
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load leads: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -1,0 +1,39 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type NewsletterSubscriber = Database['public']['Tables']['newsletter_subscribers']['Row'];
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const subscribeToNewsletter = async (
+  email: string,
+  client?: TypedSupabaseClient
+): Promise<NewsletterSubscriber> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('newsletter_subscribers')
+    .insert([{ email }])
+    .select('*')
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};
+
+export const fetchNewsletterSubscribersForAdmin = async (
+  client: TypedSupabaseClient
+): Promise<NewsletterSubscriber[]> => {
+  const { data, error } = await client
+    .from('newsletter_subscribers')
+    .select('*')
+    .order('subscribed_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load newsletter subscribers: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,24 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type Profile = Database['public']['Tables']['profiles']['Row'];
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchProfileByUserId = async (
+  userId: string,
+  client?: TypedSupabaseClient
+): Promise<Profile | null> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load profile: ${error.message}`);
+  }
+
+  return data ?? null;
+};

--- a/src/lib/repositories.ts
+++ b/src/lib/repositories.ts
@@ -1,0 +1,23 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type Repository = Database['public']['Tables']['repositories']['Row'];
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveRepositories = async (
+  client?: TypedSupabaseClient
+): Promise<Repository[]> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('repositories')
+    .select('*')
+    .eq('active', true)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to load repositories: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/solutions.ts
+++ b/src/lib/solutions.ts
@@ -1,0 +1,63 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type Solution = Database['public']['Tables']['solutions']['Row'];
+
+export interface FetchSolutionsOptions {
+  limit?: number;
+  ascending?: boolean;
+}
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveSolutions = async (
+  options: FetchSolutionsOptions = {},
+  client?: TypedSupabaseClient
+): Promise<Solution[]> => {
+  const supabase = getClient(client);
+
+  let query = supabase
+    .from('solutions')
+    .select('*')
+    .eq('active', true)
+    .order('created_at', { ascending: options.ascending ?? true });
+
+  if (typeof options.limit === 'number') {
+    query = query.limit(options.limit);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    throw new Error(`Failed to load solutions: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+
+export const fetchActiveSolutionBySlug = async (
+  slug: string,
+  client?: TypedSupabaseClient
+): Promise<Solution | null> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('solutions')
+    .select('*')
+    .eq('active', true)
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to load solution: ${error.message}`);
+  }
+
+  return data ?? null;
+};
+
+export const extractSolutionFeatures = (solution: Solution): string[] => {
+  const { features } = solution;
+  if (Array.isArray(features)) {
+    return features.filter((feature): feature is string => typeof feature === 'string');
+  }
+  return [];
+};

--- a/src/lib/team-members.ts
+++ b/src/lib/team-members.ts
@@ -1,0 +1,23 @@
+import { getSupabaseBrowserClient, type TypedSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type TeamMember = Database['public']['Tables']['team_members']['Row'];
+
+const getClient = (client?: TypedSupabaseClient) => client ?? getSupabaseBrowserClient();
+
+export const fetchActiveTeamMembers = async (
+  client?: TypedSupabaseClient
+): Promise<TeamMember[]> => {
+  const supabase = getClient(client);
+  const { data, error } = await supabase
+    .from('team_members')
+    .select('*')
+    .eq('active', true)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to load team members: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,10 +5,10 @@ import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import NewsletterSection from '@/components/NewsletterSection';
 import { ArrowRight, Clock, User } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
-import { useTranslation, Trans } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { fetchPublishedBlogPosts, type BlogPost } from '@/lib/blog-posts';
 import {
   Breadcrumb,
   BreadcrumbList,
@@ -41,35 +41,25 @@ const Blog = () => {
   } = useQuery({
     queryKey: ['blog_posts'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('blog_posts')
-        .select('id, slug, title, excerpt, image_url, updated_at')
-        .eq('published', true)
-        .order('updated_at', { ascending: false });
+      const posts = await fetchPublishedBlogPosts();
 
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return (
-        data?.map((post, index) => ({
-          title: post.title,
-          excerpt: post.excerpt || 'Read more about this topic...',
-          image:
-            post.image_url ||
-            'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
-          author: 'Monynha Softwares Team',
-          date: new Date(post.updated_at).toLocaleDateString('pt-BR', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          }),
-          readTime: '5 min read',
-          category: 'AI Insights',
-          featured: index === 0,
-          slug: post.slug,
-        })) || []
-      );
+      return posts.map((post: BlogPost, index) => ({
+        title: post.title,
+        excerpt: post.excerpt || 'Read more about this topic...',
+        image:
+          post.image_url ||
+          'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
+        author: 'Monynha Softwares Team',
+        date: new Date(post.updated_at).toLocaleDateString('pt-BR', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        }),
+        readTime: '5 min read',
+        category: 'AI Insights',
+        featured: index === 0,
+        slug: post.slug,
+      }));
     },
   });
 

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -6,7 +6,6 @@ import { Textarea } from '@/components/ui/textarea';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import { Mail, Phone, MapPin, Send, CheckCircle } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
@@ -19,6 +18,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { createLead } from '@/lib/leads';
 
 const projectTypes = [
   'Custom AI Assistant',
@@ -85,25 +85,13 @@ const Contact = () => {
     }
 
     try {
-      const { error } = await supabase.from('leads').insert([
-        {
-          name: formData.name,
-          email: formData.email,
-          company: formData.company || null,
-          project: formData.project || null,
-          message: formData.message,
-        },
-      ]);
-
-      if (error) {
-        console.error('Error submitting form:', error);
-        toast({
-          title: t('contact.toasts.errorTitle'),
-          description: t('contact.toasts.errorDescription'),
-          variant: 'destructive',
-        });
-        return;
-      }
+      await createLead({
+        name: formData.name,
+        email: formData.email,
+        company: formData.company || null,
+        project: formData.project || null,
+        message: formData.message,
+      });
 
       setIsSubmitted(true);
       toast({

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase';
-import type { Database } from '@/integrations/supabase/types';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
@@ -27,11 +25,12 @@ import Loading from '@/components/Loading';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { AlertTriangle, Loader2, LogOut, RefreshCcw } from 'lucide-react';
-
-type Profile = Database['public']['Tables']['profiles']['Row'];
-type Lead = Database['public']['Tables']['leads']['Row'];
-type NewsletterSubscriber =
-  Database['public']['Tables']['newsletter_subscribers']['Row'];
+import {
+  fetchProfileByUserId,
+  type Profile,
+} from '@/lib/profiles';
+import type { Lead } from '@/lib/leads';
+import type { NewsletterSubscriber } from '@/lib/newsletter';
 
 const formatDate = (value: string | null | undefined) => {
   if (!value) return '—';
@@ -45,7 +44,7 @@ const formatDate = (value: string | null | undefined) => {
 };
 
 const Dashboard = () => {
-  const { user, signOut } = useAuth();
+  const { user, session, signOut } = useAuth();
   const { toast } = useToast();
   const navigate = useNavigate();
 
@@ -73,15 +72,7 @@ const Dashboard = () => {
     }
 
     try {
-      const { data: profileData, error: profileError } = await supabase
-        .from('profiles')
-        .select('*')
-        .eq('user_id', user.id)
-        .maybeSingle();
-
-      if (profileError) {
-        throw profileError;
-      }
+      const profileData = await fetchProfileByUserId(user.id);
 
       const resolvedProfile: Profile =
         profileData ??
@@ -103,32 +94,41 @@ const Dashboard = () => {
       }
 
       if (resolvedProfile.role === 'admin') {
+        if (!session?.access_token) {
+          throw new Error('Token de acesso não encontrado para operações administrativas.');
+        }
+
         if (isMounted.current) {
           setIsFetchingAdminData(true);
         }
 
-        const [leadsResponse, newsletterResponse] = await Promise.all([
-          supabase
-            .from('leads')
-            .select('*')
-            .order('created_at', { ascending: false }),
-          supabase
-            .from('newsletter_subscribers')
-            .select('*')
-            .order('subscribed_at', { ascending: false }),
-        ]);
+        const response = await fetch('/api/admin/dashboard', {
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+          },
+        });
 
-        if (leadsResponse.error) {
-          throw leadsResponse.error;
+        if (!response.ok) {
+          let errorMessage = 'Não foi possível carregar os dados administrativos.';
+          try {
+            const payload = (await response.json()) as { error?: string } | undefined;
+            if (payload?.error) {
+              errorMessage = payload.error;
+            }
+          } catch (parseError) {
+            console.error('Erro ao interpretar resposta administrativa', parseError);
+          }
+          throw new Error(errorMessage);
         }
 
-        if (newsletterResponse.error) {
-          throw newsletterResponse.error;
-        }
+        const payload = (await response.json()) as {
+          leads?: Lead[];
+          subscribers?: NewsletterSubscriber[];
+        };
 
         if (isMounted.current) {
-          setLeads(leadsResponse.data ?? []);
-          setSubscribers(newsletterResponse.data ?? []);
+          setLeads(payload.leads ?? []);
+          setSubscribers(payload.subscribers ?? []);
         }
       } else if (isMounted.current) {
         setLeads([]);
@@ -154,7 +154,7 @@ const Dashboard = () => {
         setIsFetchingAdminData(false);
       }
     }
-  }, [toast, user]);
+  }, [session, toast, user]);
 
   useEffect(() => {
     void loadDashboard();

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -13,19 +13,9 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { supabase } from '@/integrations/supabase';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
-
-interface Repository {
-  id: string;
-  name: string;
-  description: string;
-  github_url: string;
-  demo_url: string | null;
-  tags: string[];
-  created_at: string;
-}
+import { fetchActiveRepositories, type Repository } from '@/lib/repositories';
 
 const Projects = () => {
   const { t } = useTranslation();
@@ -36,19 +26,7 @@ const Projects = () => {
     isError,
   } = useQuery({
     queryKey: ['repositories'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('repositories')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: false });
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return data || [];
-    },
+    queryFn: async () => fetchActiveRepositories(),
   });
 
   const formatDate = (dateString: string) => {

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -23,8 +23,8 @@ import {
   Calendar,
   Settings,
 } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
 import { useTranslation } from 'react-i18next';
+import { fetchActiveSolutions, type Solution } from '@/lib/solutions';
 
 const fallbackSolutions = [
   {
@@ -104,91 +104,80 @@ const Solutions = () => {
   } = useQuery({
     queryKey: ['solutions'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('solutions')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: true });
-      if (error) {
-        throw new Error(error.message);
-      }
-      return (
-        data?.map((solution, index) => {
-          const getFeatures = (slug: string) => {
-            if (slug === 'boteco-pro') {
-              return [
-                {
-                  icon: BarChart3,
-                  title: 'Real-time Analytics',
-                  description:
-                    'Track sales, inventory, and customer behavior in real-time',
-                },
-                {
-                  icon: Users,
-                  title: 'Staff Management',
-                  description: 'Efficient scheduling and performance tracking',
-                },
-                {
-                  icon: Zap,
-                  title: 'Quick Order Processing',
-                  description: 'Streamlined POS system with mobile integration',
-                },
-                {
-                  icon: Shield,
-                  title: 'Secure Payments',
-                  description: 'Multiple payment methods with fraud protection',
-                },
-              ];
-            } else {
-              return [
-                {
-                  icon: Brain,
-                  title: 'Machine Learning',
-                  description:
-                    'Continuously learns and adapts to your workflow',
-                },
-                {
-                  icon: MessageSquare,
-                  title: 'Natural Language',
-                  description: 'Communicate naturally with voice and text',
-                },
-                {
-                  icon: Calendar,
-                  title: 'Task Automation',
-                  description: 'Automate scheduling, reminders, and follow-ups',
-                },
-                {
-                  icon: Settings,
-                  title: 'Custom Integration',
-                  description: 'Seamlessly integrates with your existing tools',
-                },
-              ];
-            }
-          };
+      const data = await fetchActiveSolutions({ ascending: true });
+      return data.map((solution: Solution) => {
+        const getFeatures = (slug: string) => {
+          if (slug === 'boteco-pro') {
+            return [
+              {
+                icon: BarChart3,
+                title: 'Real-time Analytics',
+                description:
+                  'Track sales, inventory, and customer behavior in real-time',
+              },
+              {
+                icon: Users,
+                title: 'Staff Management',
+                description: 'Efficient scheduling and performance tracking',
+              },
+              {
+                icon: Zap,
+                title: 'Quick Order Processing',
+                description: 'Streamlined POS system with mobile integration',
+              },
+              {
+                icon: Shield,
+                title: 'Secure Payments',
+                description: 'Multiple payment methods with fraud protection',
+              },
+            ];
+          }
 
-          return {
-            name: solution.title,
-            tagline:
-              solution.slug === 'boteco-pro'
-                ? 'Restaurant & Bar Management System'
-                : 'Personalized AI Assistant',
-            description: solution.description,
-            slug: solution.slug,
-            image:
-              solution.image_url ||
-              (solution.slug === 'boteco-pro'
-                ? 'https://images.unsplash.com/photo-1514933651103-005eec06c04b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80'
-                : 'https://images.unsplash.com/photo-1677442136019-21780ecad995?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80'),
-            features: getFeatures(solution.slug),
-            gradient:
-              solution.slug === 'boteco-pro'
-                ? 'from-brand-purple to-brand-blue'
-                : 'from-brand-pink to-brand-orange',
-            color:
-              solution.slug === 'boteco-pro' ? 'brand-purple' : 'brand-pink',
-          };
-        }) || []
-      );
+          return [
+            {
+              icon: Brain,
+              title: 'Machine Learning',
+              description: 'Continuously learns and adapts to your workflow',
+            },
+            {
+              icon: MessageSquare,
+              title: 'Natural Language',
+              description: 'Communicate naturally with voice and text',
+            },
+            {
+              icon: Calendar,
+              title: 'Task Automation',
+              description: 'Automate scheduling, reminders, and follow-ups',
+            },
+            {
+              icon: Settings,
+              title: 'Custom Integration',
+              description: 'Seamlessly integrates with your existing tools',
+            },
+          ];
+        };
+
+        return {
+          name: solution.title,
+          tagline:
+            solution.slug === 'boteco-pro'
+              ? 'Restaurant & Bar Management System'
+              : 'Personalized AI Assistant',
+          description: solution.description,
+          slug: solution.slug,
+          image:
+            solution.image_url ||
+            (solution.slug === 'boteco-pro'
+              ? 'https://images.unsplash.com/photo-1514933651103-005eec06c04b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80'
+              : 'https://images.unsplash.com/photo-1677442136019-21780ecad995?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80'),
+          features: getFeatures(solution.slug),
+          gradient:
+            solution.slug === 'boteco-pro'
+              ? 'from-brand-purple to-brand-blue'
+              : 'from-brand-pink to-brand-orange',
+          color: solution.slug === 'boteco-pro' ? 'brand-purple' : 'brand-pink',
+        };
+      });
     },
   });
 


### PR DESCRIPTION
## Summary
- centralize Supabase client creation with shared helpers for browser, server and service-role use
- add typed data access modules for public tables and update React screens/components to consume them
- expose an admin dashboard API using the service role and add a Supabase permission check script

## Testing
- npm run lint
- npm run test
- npm run test:supabase-permissions

------
https://chatgpt.com/codex/tasks/task_e_68c9afc010c883228a25e2de6f48c97a