### PR TITLE
Refactor solutions data fetching to use GitHub API

### DIFF
--- a/src/data/solutions.ts
+++ b/src/data/solutions.ts
@@ -7,6 +7,15 @@ export const gradientOptions = [
   'from-brand-orange to-brand-pink',
 ];
 
+export const normalizeSolutionSlug = (value: string): string =>
+  value
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .replace(/[^\w-]+/g, '-')
+    .replace(/--+/g, '-')
+    .toLowerCase()
+    .replace(/^-+|-+$/g, '');
+
 export const fallbackSolutions: SolutionContent[] = [
   {
     title: 'Boteco Pro',
@@ -43,6 +52,8 @@ export const fallbackSolutions: SolutionContent[] = [
 export const fallbackSolutionsMap = fallbackSolutions.reduce<
   Record<string, SolutionContent>
 >((accumulator, solution) => {
+  const normalizedSlug = normalizeSolutionSlug(solution.slug);
   accumulator[solution.slug] = solution;
+  accumulator[normalizedSlug] = solution;
   return accumulator;
 }, {});


### PR DESCRIPTION
## Summary
- replace Supabase-backed queries on the solutions listing and detail pages with GitHub API fetch calls
- add mapping utilities that transform GitHub repository responses into solution content while keeping fallback gradients and features
- normalize fallback slug handling so GitHub repository names can reuse existing imagery and copy

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9bf92292c8322b895620872f7eb2e