### PR TITLE
Refactor solutions and projects pages

### DIFF
--- a/src/components/solutions/SolutionCardGrid.tsx
+++ b/src/components/solutions/SolutionCardGrid.tsx
@@ -1,0 +1,141 @@
+import { Link } from 'react-router-dom';
+import { ArrowRight, CheckCircle } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import type { SolutionContent } from '@/types/solutions';
+
+interface SolutionCardGridProps {
+  solutions: SolutionContent[];
+  learnMoreLabel: string;
+  requestDemoLabel: string;
+  requestDemoHref?: string;
+}
+
+const SolutionCardGrid = ({
+  solutions,
+  learnMoreLabel,
+  requestDemoLabel,
+  requestDemoHref = '/contact',
+}: SolutionCardGridProps) => {
+  if (solutions.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+      {solutions.map((solution) => {
+        const key = solution.id ?? solution.slug;
+        const isExternal = Boolean(solution.githubUrl);
+
+        const titleContent = (
+          <h2 className="text-2xl font-semibold text-neutral-900 group-hover:text-brand-blue transition-colors">
+            {solution.title}
+          </h2>
+        );
+
+        const title = isExternal ? (
+          <a
+            href={solution.githubUrl ?? '#'}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="group"
+          >
+            {titleContent}
+          </a>
+        ) : (
+          <Link to={`/solutions/${solution.slug}`} className="group">
+            {titleContent}
+          </Link>
+        );
+
+        return (
+          <Card key={key} className="border-0 shadow-soft-lg flex flex-col overflow-hidden">
+            {solution.imageUrl && (
+              <div className="relative h-48 w-full overflow-hidden">
+                <img
+                  src={solution.imageUrl}
+                  alt={solution.title}
+                  loading="lazy"
+                  className="h-full w-full object-cover"
+                />
+                <div
+                  className={`absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r ${solution.gradient}`}
+                />
+              </div>
+            )}
+            <CardContent className="p-8 flex flex-col flex-1">
+              <div
+                className={`h-1 w-16 bg-gradient-to-r ${solution.gradient} rounded-full mb-6`}
+              />
+              {title}
+              <p className="text-neutral-600 mt-4 leading-relaxed flex-1">
+                {solution.description}
+              </p>
+
+              {solution.features.length > 0 && (
+                <ul className="mt-8 space-y-3">
+                  {solution.features.map((feature, featureIndex) => (
+                    <li
+                      key={`${solution.slug}-feature-${featureIndex}`}
+                      className="flex items-start gap-3"
+                    >
+                      <span
+                        className={`mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-r ${solution.gradient}`}
+                      >
+                        <CheckCircle className="h-4 w-4 text-white" />
+                      </span>
+                      <span className="text-sm text-neutral-600 leading-relaxed">
+                        {feature}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              )}
+
+              <div className="mt-10 flex flex-col sm:flex-row gap-3">
+                <Button
+                  asChild
+                  variant="outline"
+                  className="flex-1 border-neutral-200 hover:border-brand-blue hover:text-brand-blue transition-colors"
+                >
+                  {isExternal ? (
+                    <a
+                      href={solution.githubUrl ?? '#'}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="flex items-center justify-center"
+                    >
+                      {learnMoreLabel}
+                    </a>
+                  ) : (
+                    <Link
+                      to={`/solutions/${solution.slug}`}
+                      className="flex items-center justify-center"
+                    >
+                      {learnMoreLabel}
+                    </Link>
+                  )}
+                </Button>
+                <Button
+                  asChild
+                  className="flex-1 bg-gradient-to-r from-brand-purple to-brand-blue hover:shadow-soft-lg transition-all"
+                >
+                  <Link
+                    to={requestDemoHref}
+                    className="flex items-center justify-center gap-2"
+                  >
+                    {requestDemoLabel}
+                    <ArrowRight className="h-4 w-4" />
+                  </Link>
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        );
+      })}
+    </div>
+  );
+};
+
+export default SolutionCardGrid;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -82,7 +82,11 @@
     "notFound": "Solution not found",
     "customTitle": "Need a Custom Solution?",
     "customDescription": "We also create bespoke software solutions tailored to your specific business needs. Let's discuss how we can build something unique for you.",
-    "discuss": "Discuss Custom Project"
+    "discuss": "Discuss Custom Project",
+    "emptyState": {
+      "title": "No solutions available right now",
+      "description": "We're updating our portfolio. Check back soon or contact us to discuss your project."
+    }
   },
   "about": {
     "title": "About Monynha Softwares Agency",
@@ -211,7 +215,8 @@
     "liveDemo": "Live Demo",
     "like": "Like our projects?",
     "likeDescription": "Get in touch to craft a custom solution for your business.",
-    "contactUs": "Contact Us"
+    "contactUs": "Contact Us",
+    "githubError": "We couldn't reach GitHub right now. Showing our featured solutions instead."
   },
   "notFound": {
     "oops": "Oops! Page not found",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -82,7 +82,11 @@
     "notFound": "Solución no encontrada",
     "customTitle": "¿Necesitas una Solución Personalizada?",
     "customDescription": "También creamos soluciones a medida para tus necesidades específicas. Conversemos sobre cómo construir algo único para ti.",
-    "discuss": "Discutir Proyecto"
+    "discuss": "Discutir Proyecto",
+    "emptyState": {
+      "title": "No hay soluciones disponibles en este momento",
+      "description": "Estamos actualizando nuestro portafolio. Vuelve pronto o contáctanos para hablar de tu proyecto."
+    }
   },
   "about": {
     "title": "Sobre Monynha Softwares Agency",
@@ -209,7 +213,8 @@
     "liveDemo": "Demo en Vivo",
     "like": "¿Te gustan nuestros proyectos?",
     "likeDescription": "Ponte en contacto para crear una solución personalizada para tu negocio.",
-    "contactUs": "Contáctanos"
+    "contactUs": "Contáctanos",
+    "githubError": "No pudimos acceder a GitHub en este momento. Mostramos nuestras soluciones destacadas."
   },
   "notFound": {
     "oops": "¡Vaya! Página no encontrada",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -82,7 +82,11 @@
     "notFound": "Solution introuvable",
     "customTitle": "Besoin d'une solution personnalisée ?",
     "customDescription": "Nous créons également des solutions sur mesure adaptées à vos besoins spécifiques. Discutons de la manière de construire quelque chose d'unique pour vous.",
-    "discuss": "Discuter du projet"
+    "discuss": "Discuter du projet",
+    "emptyState": {
+      "title": "Aucune solution disponible pour le moment",
+      "description": "Nous mettons à jour notre portfolio. Revenez bientôt ou contactez-nous pour parler de votre projet."
+    }
   },
   "about": {
     "title": "À propos de Monynha Softwares Agency",
@@ -209,7 +213,8 @@
     "liveDemo": "Démo en ligne",
     "like": "Vous aimez nos projets ?",
     "likeDescription": "Contactez-nous pour créer une solution personnalisée pour votre entreprise.",
-    "contactUs": "Nous contacter"
+    "contactUs": "Nous contacter",
+    "githubError": "Impossible d'accéder à GitHub pour le moment. Nous affichons nos solutions phares à la place."
   },
   "notFound": {
     "oops": "Oups ! Page introuvable",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -82,7 +82,11 @@
     "notFound": "Solução não encontrada",
     "customTitle": "Precisa de uma Solução Personalizada?",
     "customDescription": "Também criamos soluções sob medida para suas necessidades específicas de negócio. Vamos conversar sobre como construir algo único para você.",
-    "discuss": "Discutir Projeto"
+    "discuss": "Discutir Projeto",
+    "emptyState": {
+      "title": "Nenhuma solução disponível no momento",
+      "description": "Estamos atualizando nosso portfólio. Volte em breve ou fale conosco sobre o seu projeto."
+    }
   },
   "about": {
     "title": "Sobre a Monynha Softwares Agency",
@@ -209,7 +213,8 @@
     "liveDemo": "Demo ao Vivo",
     "like": "Gostou dos projetos?",
     "likeDescription": "Entre em contato para criar uma solução personalizada para seu negócio.",
-    "contactUs": "Fale Conosco"
+    "contactUs": "Fale Conosco",
+    "githubError": "Não conseguimos acessar o GitHub agora. Exibindo nossas soluções em destaque."
   },
   "notFound": {
     "oops": "Ops! Página não encontrada",

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -1,6 +1,4 @@
-import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
@@ -13,73 +11,42 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { ArrowRight, CheckCircle } from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import {
-  getFallbackSolutions,
-  mapGitHubRepoToContent,
-} from '@/lib/solutions';
-import type { GitHubRepository } from '@/lib/solutions';
+import SolutionCardGrid from '@/components/solutions/SolutionCardGrid';
+import { supabase } from '@/integrations/supabase';
+import { mapSupabaseSolutions } from '@/lib/solutions';
 import type { SolutionContent } from '@/types/solutions';
-
-const GITHUB_REPOS_URL =
-  'https://api.github.com/orgs/Monynha-Softwares/repos?per_page=100';
 
 const Solutions = () => {
   const { t } = useTranslation();
-
-  const memoizedFallbackSolutions = useMemo(
-    () => getFallbackSolutions(),
-    []
-  );
 
   const {
     data: solutions = [],
     isLoading,
     isError,
   } = useQuery<SolutionContent[]>({
-    queryKey: ['solutions'],
+    queryKey: ['solutions', 'supabase'],
     queryFn: async () => {
-      const response = await fetch(GITHUB_REPOS_URL, {
-        headers: {
-          Accept: 'application/vnd.github+json',
-        },
-      });
+      const { data, error } = await supabase
+        .from('solutions')
+        .select('*')
+        .eq('active', true)
+        .order('created_at', { ascending: true });
 
-      if (!response.ok) {
-        throw new Error(`GitHub API responded with ${response.status}`);
+      if (error) {
+        throw new Error(error.message);
       }
 
-      const repositories: GitHubRepository[] = await response.json();
+      if (!data) {
+        return [];
+      }
 
-      const toTimestamp = (repository: GitHubRepository) => {
-        const reference =
-          repository.pushed_at ?? repository.updated_at ?? repository.created_at;
-        const timestamp = new Date(reference).getTime();
-        return Number.isNaN(timestamp) ? 0 : timestamp;
-      };
-
-      const activeRepositories = repositories.filter(
-        (repository) =>
-          !repository.private && !repository.archived && !repository.disabled
-      );
-
-      const sortedRepositories = activeRepositories
-        .slice()
-        .sort((a, b) => toTimestamp(b) - toTimestamp(a));
-
-      return sortedRepositories.map((repository, index) =>
-        mapGitHubRepoToContent(repository, index)
-      );
+      return mapSupabaseSolutions(data);
     },
-    staleTime: 1000 * 60 * 10,
-    retry: 1,
-    keepPreviousData: true,
-    refetchOnWindowFocus: false,
   });
 
-  const displaySolutions =
-    solutions.length > 0 ? solutions : memoizedFallbackSolutions;
+  const hasSolutions = solutions.length > 0;
 
   if (isLoading) {
     return (
@@ -156,88 +123,31 @@ const Solutions = () => {
       {/* Solutions Detail */}
       <section className="py-24 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
-            {displaySolutions.map((solution) => (
-              <Card
-                key={solution.id ?? solution.slug}
-                className="border-0 shadow-soft-lg flex flex-col overflow-hidden"
+          {hasSolutions ? (
+            <SolutionCardGrid
+              solutions={solutions}
+              learnMoreLabel={t('index.learnMore')}
+              requestDemoLabel={t('solutionsPage.requestDemo')}
+            />
+          ) : (
+            <div className="text-center max-w-2xl mx-auto">
+              <h2 className="text-2xl font-semibold text-neutral-900 mb-4">
+                {t('solutionsPage.emptyState.title')}
+              </h2>
+              <p className="text-neutral-600 mb-8">
+                {t('solutionsPage.emptyState.description')}
+              </p>
+              <Button
+                asChild
+                className="bg-gradient-to-r from-brand-purple to-brand-blue"
               >
-                {solution.imageUrl && (
-                  <div className="relative h-48 w-full overflow-hidden">
-                    <img
-                      src={solution.imageUrl}
-                      alt={solution.title}
-                      loading="lazy"
-                      className="h-full w-full object-cover"
-                    />
-                    <div
-                      className={`absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r ${solution.gradient}`}
-                    />
-                  </div>
-                )}
-                <CardContent className="p-8 flex flex-col flex-1">
-                  <div
-                    className={`h-1 w-16 bg-gradient-to-r ${solution.gradient} rounded-full mb-6`}
-                  />
-                  <Link to={`/solutions/${solution.slug}`} className="group">
-                    <h2 className="text-2xl font-semibold text-neutral-900 group-hover:text-brand-blue transition-colors">
-                      {solution.title}
-                    </h2>
-                  </Link>
-                  <p className="text-neutral-600 mt-4 leading-relaxed flex-1">
-                    {solution.description}
-                  </p>
-
-                  {solution.features.length > 0 && (
-                    <ul className="mt-8 space-y-3">
-                      {solution.features.map((feature, featureIndex) => (
-                        <li
-                          key={`${solution.slug}-feature-${featureIndex}`}
-                          className="flex items-start gap-3"
-                        >
-                          <span
-                            className={`mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-r ${solution.gradient}`}
-                          >
-                            <CheckCircle className="h-4 w-4 text-white" />
-                          </span>
-                          <span className="text-sm text-neutral-600 leading-relaxed">
-                            {feature}
-                          </span>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-
-                  <div className="mt-10 flex flex-col sm:flex-row gap-3">
-                    <Button
-                      asChild
-                      variant="outline"
-                      className="flex-1 border-neutral-200 hover:border-brand-blue hover:text-brand-blue transition-colors"
-                    >
-                      <Link
-                        to={`/solutions/${solution.slug}`}
-                        className="flex items-center justify-center"
-                      >
-                        {t('index.learnMore')}
-                      </Link>
-                    </Button>
-                    <Button
-                      asChild
-                      className="flex-1 bg-gradient-to-r from-brand-purple to-brand-blue hover:shadow-soft-lg transition-all"
-                    >
-                      <Link
-                        to="/contact"
-                        className="flex items-center justify-center gap-2"
-                      >
-                        {t('solutionsPage.requestDemo')}
-                        <ArrowRight className="h-4 w-4" />
-                      </Link>
-                    </Button>
-                  </div>
-                </CardContent>
-              </Card>
-            ))}
-          </div>
+                <Link to="/contact" className="flex items-center gap-2">
+                  {t('solutionsPage.discuss')}
+                  <ArrowRight className="h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+          )}
         </div>
       </section>
 

--- a/src/types/solutions.ts
+++ b/src/types/solutions.ts
@@ -6,4 +6,5 @@ export interface SolutionContent {
   imageUrl?: string | null;
   features: string[];
   gradient: string;
+  githubUrl?: string | null;
 }


### PR DESCRIPTION
## Summary
- load solutions from Supabase using a shared card grid component and localized empty state messaging
- add GitHub solution retrieval to the projects page with fallbacks and updated helper utilities
- update the solution detail route and translations to reflect the Supabase data model

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9cb90de088322baecc4d401036cf8