### PR TITLE
Refactor projects and solutions data sources

### DIFF
--- a/src/lib/solutions.ts
+++ b/src/lib/solutions.ts
@@ -4,6 +4,8 @@ import {
   gradientOptions,
   normalizeSolutionSlug,
 } from '@/data/solutions';
+import { supabase } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
 import type { SolutionContent } from '@/types/solutions';
 
 export interface GitHubRepository {
@@ -27,6 +29,8 @@ export interface GitHubRepository {
   html_url: string;
 }
 
+type SupabaseSolutionRow = Database['public']['Tables']['solutions']['Row'];
+
 const uniqueNonEmpty = (values: Array<string | null | undefined>): string[] => {
   const seen = new Set<string>();
   const result: string[] = [];
@@ -46,6 +50,41 @@ const uniqueNonEmpty = (values: Array<string | null | undefined>): string[] => {
   }
 
   return result;
+};
+
+const coerceToStringArray = (value: unknown): string[] => {
+  if (!value) {
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return uniqueNonEmpty(
+      value.map((item) => {
+        if (typeof item === 'string') {
+          return item;
+        }
+
+        if (typeof item === 'number' || typeof item === 'boolean') {
+          return String(item);
+        }
+
+        return null;
+      })
+    );
+  }
+
+  if (typeof value === 'string') {
+    try {
+      const parsed = JSON.parse(value);
+      if (Array.isArray(parsed)) {
+        return coerceToStringArray(parsed);
+      }
+    } catch {
+      return uniqueNonEmpty([value]);
+    }
+  }
+
+  return [];
 };
 
 const formatDate = (value: string | null | undefined): string | null => {
@@ -127,6 +166,37 @@ export const mapGitHubRepoToContent = (
   };
 };
 
+export const mapSupabaseSolutionToContent = (
+  solution: SupabaseSolutionRow,
+  index: number
+): SolutionContent => {
+  const normalizedSlug = normalizeSolutionSlug(solution.slug);
+  const fallback =
+    fallbackSolutionsMap[normalizedSlug] ?? fallbackSolutionsMap[solution.slug];
+
+  const gradient =
+    fallback?.gradient ?? gradientOptions[index % gradientOptions.length];
+
+  const parsedFeatures = coerceToStringArray(solution.features);
+
+  const features =
+    parsedFeatures.length > 0
+      ? parsedFeatures
+      : fallback?.features
+        ? [...fallback.features]
+        : [];
+
+  return {
+    id: solution.id,
+    title: solution.title,
+    description: solution.description,
+    slug: solution.slug,
+    imageUrl: solution.image_url ?? fallback?.imageUrl ?? null,
+    features,
+    gradient,
+  };
+};
+
 export const getFallbackSolution = (
   slug: string
 ): SolutionContent | undefined => {
@@ -153,3 +223,21 @@ export const getFallbackSolutions = (): SolutionContent[] =>
     ...solution,
     features: [...solution.features],
   }));
+
+export const fetchSupabaseSolutions = async (): Promise<SolutionContent[]> => {
+  const { data, error } = await supabase
+    .from('solutions')
+    .select('*')
+    .eq('active', true)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  const rows = data ?? [];
+
+  return rows.map((solution, index) =>
+    mapSupabaseSolutionToContent(solution, index)
+  );
+};

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -1,5 +1,12 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { Github, ExternalLink, Calendar } from 'lucide-react';
+import {
+  Github,
+  ExternalLink,
+  Calendar,
+  ArrowRight,
+  CheckCircle,
+} from 'lucide-react';
 import Layout from '../components/Layout';
 import Meta from '@/components/Meta';
 import { Button } from '@/components/ui/button';
@@ -17,6 +24,13 @@ import { supabase } from '@/integrations/supabase';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useRepositorySync from '@/hooks/useRepositorySync';
+import {
+  fetchSupabaseSolutions,
+  getFallbackSolutions,
+  mapGitHubRepoToContent,
+} from '@/lib/solutions';
+import type { GitHubRepository } from '@/lib/solutions';
+import type { SolutionContent } from '@/types/solutions';
 
 interface Repository {
   id: string;
@@ -24,9 +38,12 @@ interface Repository {
   description: string;
   github_url: string;
   demo_url: string | null;
-  tags: string[];
+  tags: string[] | null;
   created_at: string;
 }
+
+const GITHUB_REPOS_URL =
+  'https://api.github.com/orgs/Monynha-Softwares/repos?per_page=100';
 
 const Projects = () => {
   const { t } = useTranslation();
@@ -34,9 +51,9 @@ const Projects = () => {
 
   const {
     data: repositories = [],
-    isLoading,
-    isError,
-  } = useQuery({
+    isLoading: repositoriesLoading,
+    isError: repositoriesError,
+  } = useQuery<Repository[]>({
     queryKey: ['repositories'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -49,19 +66,116 @@ const Projects = () => {
         throw new Error(error.message);
       }
 
-      return data || [];
+      return (data ?? []) as Repository[];
     },
   });
 
-  const formatDate = (dateString: string) => {
-    return new Date(dateString).toLocaleDateString('en-US', {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  };
+  const {
+    data: supabaseSolutions = [],
+    isLoading: supabaseSolutionsLoading,
+    isError: supabaseSolutionsError,
+  } = useQuery<SolutionContent[]>({
+    queryKey: ['solutions'],
+    queryFn: fetchSupabaseSolutions,
+    staleTime: 1000 * 60 * 10,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
 
-  if (isLoading) {
+  const {
+    data: githubSolutions = [],
+    isLoading: githubSolutionsLoading,
+    isError: githubSolutionsError,
+  } = useQuery<SolutionContent[]>({
+    queryKey: ['github-projects'],
+    queryFn: async () => {
+      const response = await fetch(GITHUB_REPOS_URL, {
+        headers: {
+          Accept: 'application/vnd.github+json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`GitHub API responded with ${response.status}`);
+      }
+
+      const repositories: GitHubRepository[] = await response.json();
+
+      const toTimestamp = (repository: GitHubRepository) => {
+        const reference =
+          repository.pushed_at ?? repository.updated_at ?? repository.created_at;
+        const timestamp = new Date(reference).getTime();
+        return Number.isNaN(timestamp) ? 0 : timestamp;
+      };
+
+      const activeRepositories = repositories.filter(
+        (repository) =>
+          !repository.private && !repository.archived && !repository.disabled
+      );
+
+      const sortedRepositories = activeRepositories
+        .slice()
+        .sort((a, b) => toTimestamp(b) - toTimestamp(a));
+
+      return sortedRepositories.map((repository, index) =>
+        mapGitHubRepoToContent(repository, index)
+      );
+    },
+    staleTime: 1000 * 60 * 10,
+    retry: 1,
+    keepPreviousData: true,
+    refetchOnWindowFocus: false,
+  });
+
+  const memoizedFallbackSolutions = useMemo(
+    () => getFallbackSolutions(),
+    []
+  );
+
+  const combinedSolutions = useMemo(() => {
+    const seen = new Set<string>();
+    const merged: SolutionContent[] = [];
+
+    const addSolution = (solution: SolutionContent) => {
+      if (!solution) {
+        return;
+      }
+
+      const key = solution.slug
+        ? solution.slug.toLowerCase()
+        : solution.title.toLowerCase();
+
+      if (seen.has(key)) {
+        return;
+      }
+
+      seen.add(key);
+      merged.push({
+        ...solution,
+        features: [...solution.features],
+      });
+    };
+
+    supabaseSolutions.forEach(addSolution);
+    githubSolutions.forEach(addSolution);
+
+    if (merged.length === 0) {
+      return memoizedFallbackSolutions.map((solution) => ({
+        ...solution,
+        features: [...solution.features],
+      }));
+    }
+
+    return merged;
+  }, [supabaseSolutions, githubSolutions, memoizedFallbackSolutions]);
+
+  const solutionsLoading = supabaseSolutionsLoading && githubSolutionsLoading;
+  const solutionsError = supabaseSolutionsError && githubSolutionsError;
+
+  const isPageLoading =
+    repositoriesLoading || (supabaseSolutionsLoading && githubSolutionsLoading);
+
+  if (isPageLoading) {
     return (
       <Layout>
         <Meta
@@ -83,7 +197,14 @@ const Projects = () => {
     );
   }
 
-  if (isError) {
+  const formatDate = (dateString: string) =>
+    new Date(dateString).toLocaleDateString('en-US', {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+
+  if (repositoriesError && solutionsError) {
     return (
       <Layout>
         <Meta
@@ -144,81 +265,204 @@ const Projects = () => {
           </p>
         </div>
 
-        {/* Projects Grid */}
-        <div className="grid md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
-          {repositories.map((repo) => (
-            <Card key={repo.id} className="card-hover border-0 shadow-soft">
-              <CardHeader className="pb-4">
-                <div className="flex items-start justify-between">
-                  <CardTitle className="text-xl font-semibold text-neutral-900 mb-2">
-                    {repo.name}
-                  </CardTitle>
-                  <div className="flex items-center text-sm text-neutral-500 gap-1">
-                    <Calendar className="w-4 h-4" />
-                    {formatDate(repo.created_at)}
-                  </div>
-                </div>
-                <p className="text-neutral-600 leading-relaxed">
-                  {repo.description}
-                </p>
-              </CardHeader>
+        {/* Solutions Section */}
+        <section className="mb-20">
+          <div className="max-w-6xl mx-auto">
+            <div className="text-center mb-12">
+              <h2 className="text-3xl font-bold text-neutral-900 mb-4">
+                {t('solutionsPage.title')}
+              </h2>
+              <p className="text-neutral-600 max-w-3xl mx-auto">
+                {t('solutionsPage.description')}
+              </p>
+            </div>
 
-              <CardContent className="pt-0">
-                {/* Tags */}
-                {repo.tags && repo.tags.length > 0 && (
-                  <div className="flex flex-wrap gap-2 mb-6">
-                    {repo.tags.map((tag, index) => (
-                      <Badge
-                        key={index}
-                        variant="secondary"
-                        className="text-xs font-medium bg-neutral-100 text-neutral-700 hover:bg-neutral-200 transition-all ease-in-out duration-300"
-                      >
-                        {tag}
-                      </Badge>
-                    ))}
-                  </div>
-                )}
-
-                {/* Action Buttons */}
-                <div className="flex gap-3">
-                  <Button
-                    asChild
-                    variant="default"
-                    className="flex-1 bg-gradient-to-r from-brand-purple to-brand-blue hover:shadow-soft-lg transition-all ease-in-out duration-300"
+            {solutionsLoading ? (
+              <div className="text-center text-neutral-500">
+                Loading solutions...
+              </div>
+            ) : (
+              <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
+                {combinedSolutions.map((solution) => (
+                  <Card
+                    key={solution.id ?? solution.slug}
+                    className="border-0 shadow-soft-lg flex flex-col overflow-hidden"
                   >
-                    <a
-                      href={repo.github_url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-center gap-2"
-                    >
-                      <Github className="w-4 h-4" />
-                      {t('projects.viewGithub')}
-                    </a>
-                  </Button>
+                    {solution.imageUrl && (
+                      <div className="relative h-48 w-full overflow-hidden">
+                        <img
+                          src={solution.imageUrl}
+                          alt={solution.title}
+                          loading="lazy"
+                          className="h-full w-full object-cover"
+                        />
+                        <div
+                          className={`absolute inset-x-0 bottom-0 h-1 bg-gradient-to-r ${solution.gradient}`}
+                        />
+                      </div>
+                    )}
+                    <CardContent className="p-8 flex flex-col flex-1">
+                      <div
+                        className={`h-1 w-16 bg-gradient-to-r ${solution.gradient} rounded-full mb-6`}
+                      />
+                      <Link to={`/solutions/${solution.slug}`} className="group">
+                        <h2 className="text-2xl font-semibold text-neutral-900 group-hover:text-brand-blue transition-colors">
+                          {solution.title}
+                        </h2>
+                      </Link>
+                      <p className="text-neutral-600 mt-4 leading-relaxed flex-1">
+                        {solution.description}
+                      </p>
 
-                  {repo.demo_url && (
-                    <Button
-                      asChild
-                      variant="outline"
-                      className="flex-1 border-neutral-200 hover:border-brand-blue hover:text-brand-blue transition-all ease-in-out duration-300"
-                    >
-                      <a
-                        href={repo.demo_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="flex items-center justify-center gap-2"
+                      {solution.features.length > 0 && (
+                        <ul className="mt-8 space-y-3">
+                          {solution.features.map((feature, featureIndex) => (
+                            <li
+                              key={`${solution.slug}-feature-${featureIndex}`}
+                              className="flex items-start gap-3"
+                            >
+                              <span
+                                className={`mt-1 inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-r ${solution.gradient}`}
+                              >
+                                <CheckCircle className="h-4 w-4 text-white" />
+                              </span>
+                              <span className="text-sm text-neutral-600 leading-relaxed">
+                                {feature}
+                              </span>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+
+                      <div className="mt-10 flex flex-col sm:flex-row gap-3">
+                        <Button
+                          asChild
+                          variant="outline"
+                          className="flex-1 border-neutral-200 hover:border-brand-blue hover:text-brand-blue transition-colors"
+                        >
+                          <Link
+                            to={`/solutions/${solution.slug}`}
+                            className="flex items-center justify-center"
+                          >
+                            {t('index.learnMore')}
+                          </Link>
+                        </Button>
+                        <Button
+                          asChild
+                          className="flex-1 bg-gradient-to-r from-brand-purple to-brand-blue hover:shadow-soft-lg transition-all"
+                        >
+                          <Link
+                            to="/contact"
+                            className="flex items-center justify-center gap-2"
+                          >
+                            {t('solutionsPage.requestDemo')}
+                            <ArrowRight className="h-4 w-4" />
+                          </Link>
+                        </Button>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            {solutionsError && (
+              <p className="text-sm text-red-500 text-center mt-6">
+                Error loading solutions
+              </p>
+            )}
+          </div>
+        </section>
+
+        {/* Projects Grid */}
+        <section>
+          {repositoriesError && repositories.length === 0 ? (
+            <div className="text-center text-red-500">
+              Error loading projects
+            </div>
+          ) : (
+            <div className="grid md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-6xl mx-auto">
+              {repositories.map((repo) => (
+                <Card key={repo.id} className="card-hover border-0 shadow-soft">
+                  <CardHeader className="pb-4">
+                    <div className="flex items-start justify-between">
+                      <CardTitle className="text-xl font-semibold text-neutral-900 mb-2">
+                        {repo.name}
+                      </CardTitle>
+                      <div className="flex items-center text-sm text-neutral-500 gap-1">
+                        <Calendar className="w-4 h-4" />
+                        {formatDate(repo.created_at)}
+                      </div>
+                    </div>
+                    <p className="text-neutral-600 leading-relaxed">
+                      {repo.description}
+                    </p>
+                  </CardHeader>
+
+                  <CardContent className="pt-0">
+                    {/* Tags */}
+                    {repo.tags && repo.tags.length > 0 && (
+                      <div className="flex flex-wrap gap-2 mb-6">
+                        {repo.tags.map((tag, index) => (
+                          <Badge
+                            key={index}
+                            variant="secondary"
+                            className="text-xs font-medium bg-neutral-100 text-neutral-700 hover:bg-neutral-200 transition-all ease-in-out duration-300"
+                          >
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Action Buttons */}
+                    <div className="flex gap-3">
+                      <Button
+                        asChild
+                        variant="default"
+                        className="flex-1 bg-gradient-to-r from-brand-purple to-brand-blue hover:shadow-soft-lg transition-all ease-in-out duration-300"
                       >
-                        <ExternalLink className="w-4 h-4" />
-                        {t('projects.liveDemo')}
-                      </a>
-                    </Button>
-                  )}
-                </div>
-              </CardContent>
-            </Card>
-          ))}
-        </div>
+                        <a
+                          href={repo.github_url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="flex items-center justify-center gap-2"
+                        >
+                          <Github className="w-4 h-4" />
+                          {t('projects.viewGithub')}
+                        </a>
+                      </Button>
+
+                      {repo.demo_url && (
+                        <Button
+                          asChild
+                          variant="outline"
+                          className="flex-1 border-neutral-200 hover:border-brand-blue hover:text-brand-blue transition-all ease-in-out duration-300"
+                        >
+                          <a
+                            href={repo.demo_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="flex items-center justify-center gap-2"
+                          >
+                            <ExternalLink className="w-4 h-4" />
+                            {t('projects.liveDemo')}
+                          </a>
+                        </Button>
+                      )}
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          )}
+
+          {repositoriesError && repositories.length > 0 && (
+            <p className="text-sm text-red-500 text-center mt-6">
+              Error loading additional projects
+            </p>
+          )}
+        </section>
 
         {/* Call to Action */}
         <div className="text-center mt-16">

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -15,15 +15,8 @@ import {
 } from '@/components/ui/breadcrumb';
 import { ArrowRight, CheckCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-import {
-  getFallbackSolutions,
-  mapGitHubRepoToContent,
-} from '@/lib/solutions';
-import type { GitHubRepository } from '@/lib/solutions';
+import { getFallbackSolutions, fetchSupabaseSolutions } from '@/lib/solutions';
 import type { SolutionContent } from '@/types/solutions';
-
-const GITHUB_REPOS_URL =
-  'https://api.github.com/orgs/Monynha-Softwares/repos?per_page=100';
 
 const Solutions = () => {
   const { t } = useTranslation();
@@ -39,42 +32,9 @@ const Solutions = () => {
     isError,
   } = useQuery<SolutionContent[]>({
     queryKey: ['solutions'],
-    queryFn: async () => {
-      const response = await fetch(GITHUB_REPOS_URL, {
-        headers: {
-          Accept: 'application/vnd.github+json',
-        },
-      });
-
-      if (!response.ok) {
-        throw new Error(`GitHub API responded with ${response.status}`);
-      }
-
-      const repositories: GitHubRepository[] = await response.json();
-
-      const toTimestamp = (repository: GitHubRepository) => {
-        const reference =
-          repository.pushed_at ?? repository.updated_at ?? repository.created_at;
-        const timestamp = new Date(reference).getTime();
-        return Number.isNaN(timestamp) ? 0 : timestamp;
-      };
-
-      const activeRepositories = repositories.filter(
-        (repository) =>
-          !repository.private && !repository.archived && !repository.disabled
-      );
-
-      const sortedRepositories = activeRepositories
-        .slice()
-        .sort((a, b) => toTimestamp(b) - toTimestamp(a));
-
-      return sortedRepositories.map((repository, index) =>
-        mapGitHubRepoToContent(repository, index)
-      );
-    },
+    queryFn: fetchSupabaseSolutions,
     staleTime: 1000 * 60 * 10,
     retry: 1,
-    keepPreviousData: true,
     refetchOnWindowFocus: false,
   });
 


### PR DESCRIPTION
## Summary
- add Supabase solution mapping helpers to reuse database content alongside fallbacks
- refactor the Solutions page to query Supabase solutions instead of GitHub data
- extend the Projects page to combine Supabase solutions with GitHub repositories while keeping curated listings

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9cb90de088322baecc4d401036cf8