### PR TITLE
refactor: centralize Supabase access and typed queries

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "sitemap": "tsx scripts/generate-sitemap.ts",
     "cleanup-lovable": "tsx scripts/cleanup-lovable.ts",
+    "test:supabase": "tsx scripts/test-supabase-permissions.ts",
     "preview": "vite preview",
     "test": "jest --passWithNoTests",
     "format": "prettier --write .",

--- a/scripts/test-supabase-permissions.ts
+++ b/scripts/test-supabase-permissions.ts
@@ -1,0 +1,219 @@
+import { randomUUID } from 'crypto';
+import {
+  createSupabaseServerClient,
+  createSupabaseServiceRoleClient,
+} from '@/integrations/supabase';
+import { fetchSolutionsRows } from '@/lib/solutions';
+import { fetchActiveHomepageFeatures } from '@/lib/homepageFeatures';
+import { fetchActiveTeamMembers } from '@/lib/teamMembers';
+import { createLead, fetchLeads } from '@/lib/leads';
+import {
+  subscribeToNewsletter,
+  fetchNewsletterSubscribers,
+} from '@/lib/newsletterSubscribers';
+import { fetchProfileByUserId } from '@/lib/profiles';
+
+type AsyncTask = () => Promise<void>;
+
+const cleanupTasks: AsyncTask[] = [];
+const failures: string[] = [];
+
+const logResult = (label: string, status: 'ok' | 'fail', detail?: string) => {
+  const symbol = status === 'ok' ? '✅' : '❌';
+  if (detail) {
+    console.log(`${symbol} ${label}: ${detail}`);
+  } else {
+    console.log(`${symbol} ${label}`);
+  }
+};
+
+const expectSuccess = async (label: string, fn: () => Promise<void>) => {
+  try {
+    await fn();
+    logResult(label, 'ok');
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : JSON.stringify(error, null, 2);
+    logResult(label, 'fail', message);
+    failures.push(`${label}: ${message}`);
+  }
+};
+
+const expectForbidden = async (label: string, fn: () => Promise<void>) => {
+  try {
+    await fn();
+    const message = `${label} should be forbidden but succeeded.`;
+    logResult(label, 'fail', message);
+    failures.push(message);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : JSON.stringify(error, null, 2);
+    logResult(label, 'ok', message);
+  }
+};
+
+const run = async () => {
+  console.log('🔐 Running Supabase permission checks...');
+
+  const visitorClient = createSupabaseServerClient();
+  const serviceRoleClient = createSupabaseServiceRoleClient();
+
+  const leadEmail = `visitor-${randomUUID()}@example.com`;
+  const newsletterEmail = `newsletter-${randomUUID()}@example.com`;
+
+  await expectSuccess('visitor: fetch active solutions', async () => {
+    await fetchSolutionsRows({ client: visitorClient });
+  });
+
+  await expectSuccess('visitor: fetch homepage features', async () => {
+    await fetchActiveHomepageFeatures(visitorClient);
+  });
+
+  await expectSuccess('visitor: fetch team members', async () => {
+    await fetchActiveTeamMembers(visitorClient);
+  });
+
+  await expectSuccess('visitor: submit lead', async () => {
+    await createLead(
+      {
+        name: 'Visitor Example',
+        email: leadEmail,
+        message: 'Test lead generated during permission checks.',
+        company: null,
+        project: null,
+      },
+      visitorClient
+    );
+
+    cleanupTasks.push(async () => {
+      await serviceRoleClient.from('leads').delete().eq('email', leadEmail);
+    });
+  });
+
+  await expectSuccess('visitor: subscribe to newsletter', async () => {
+    await subscribeToNewsletter(newsletterEmail, visitorClient);
+
+    cleanupTasks.push(async () => {
+      await serviceRoleClient
+        .from('newsletter_subscribers')
+        .delete()
+        .eq('email', newsletterEmail);
+    });
+  });
+
+  await expectForbidden('visitor: fetch leads', async () => {
+    await fetchLeads(visitorClient);
+  });
+
+  await expectForbidden('visitor: fetch newsletter subscribers', async () => {
+    await fetchNewsletterSubscribers(visitorClient);
+  });
+
+  const testEmail = `user-${randomUUID()}@example.com`;
+  const testPassword = `P@ssw0rd-${randomUUID().slice(0, 8)}`;
+
+  const { data: createdUser, error: createUserError } =
+    await serviceRoleClient.auth.admin.createUser({
+      email: testEmail,
+      password: testPassword,
+      email_confirm: true,
+    });
+
+  if (createUserError) {
+    throw createUserError;
+  }
+
+  const userId = createdUser?.user?.id;
+
+  if (!userId) {
+    throw new Error('Unable to determine ID of the created test user.');
+  }
+
+  cleanupTasks.push(async () => {
+    await serviceRoleClient.from('profiles').delete().eq('user_id', userId);
+    await serviceRoleClient.auth.admin.deleteUser(userId);
+  });
+
+  const { error: upsertProfileError } = await serviceRoleClient
+    .from('profiles')
+    .upsert(
+      {
+        user_id: userId,
+        email: testEmail,
+        name: 'Permission Test User',
+        role: 'user',
+      },
+      { onConflict: 'user_id' }
+    );
+
+  if (upsertProfileError) {
+    throw upsertProfileError;
+  }
+
+  const { data: signInData, error: signInError } =
+    await visitorClient.auth.signInWithPassword({
+      email: testEmail,
+      password: testPassword,
+    });
+
+  if (signInError) {
+    throw signInError;
+  }
+
+  const accessToken = signInData.session?.access_token;
+
+  if (!accessToken) {
+    throw new Error('Authentication succeeded but no access token was returned.');
+  }
+
+  const userClient = createSupabaseServerClient(accessToken);
+
+  await expectSuccess('user: fetch own profile', async () => {
+    await fetchProfileByUserId(userId, userClient);
+  });
+
+  await expectForbidden('user: fetch leads', async () => {
+    await fetchLeads(userClient);
+  });
+
+  const { error: promoteError } = await serviceRoleClient
+    .from('profiles')
+    .update({ role: 'admin' })
+    .eq('user_id', userId);
+
+  if (promoteError) {
+    throw promoteError;
+  }
+
+  await expectSuccess('admin: fetch leads', async () => {
+    await fetchLeads(userClient);
+  });
+
+  await expectSuccess('admin: fetch newsletter subscribers', async () => {
+    await fetchNewsletterSubscribers(userClient);
+  });
+
+  if (failures.length > 0) {
+    const message = failures.join('\n - ');
+    throw new Error(`Permission checks failed:\n - ${message}`);
+  }
+
+  console.log('🎉 All Supabase permission checks passed.');
+};
+
+run()
+  .catch((error) => {
+    console.error('Supabase permission checks failed.');
+    console.error(error instanceof Error ? error.stack ?? error.message : error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    for (const task of cleanupTasks.reverse()) {
+      try {
+        await task();
+      } catch (error) {
+        console.error('Cleanup task failed:', error);
+      }
+    }
+  });
+

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -2,18 +2,14 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { supabase } from '@/integrations/supabase';
 import { Linkedin, Mail } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import {
+  fetchActiveTeamMembers,
+  type TeamMemberRow,
+} from '@/lib/teamMembers';
 
-interface TeamMember {
-  id: string;
-  name: string;
-  role: string;
-  bio: string | null;
-  image_url: string | null;
-  linkedin_url: string | null;
-}
+type TeamMember = TeamMemberRow;
 
 const TeamSection = () => {
   const { t } = useTranslation();
@@ -24,16 +20,7 @@ const TeamSection = () => {
     error,
   } = useQuery({
     queryKey: ['team-members'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('team_members')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: true });
-
-      if (error) throw error;
-      return data as TeamMember[];
-    },
+    queryFn: () => fetchActiveTeamMembers(),
   });
 
   if (isLoading) {

--- a/src/lib/blogPosts.ts
+++ b/src/lib/blogPosts.ts
@@ -1,0 +1,25 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type BlogPostRow = Database['public']['Tables']['blog_posts']['Row'];
+
+const BLOG_POST_COLUMNS =
+  'id, slug, title, excerpt, image_url, updated_at, published';
+
+export const fetchPublishedBlogPosts = async (
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<BlogPostRow[]> => {
+  const { data, error } = await client
+    .from('blog_posts')
+    .select(BLOG_POST_COLUMNS)
+    .eq('published', true)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch blog posts: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+

--- a/src/lib/homepageFeatures.ts
+++ b/src/lib/homepageFeatures.ts
@@ -1,0 +1,26 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type HomepageFeatureRow =
+  Database['public']['Tables']['homepage_features']['Row'];
+
+const HOMEPAGE_FEATURE_COLUMNS =
+  'id, title, description, icon, url, order_index, active';
+
+export const fetchActiveHomepageFeatures = async (
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<HomepageFeatureRow[]> => {
+  const { data, error } = await client
+    .from('homepage_features')
+    .select(HOMEPAGE_FEATURE_COLUMNS)
+    .eq('active', true)
+    .order('order_index', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch homepage features: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+

--- a/src/lib/leads.ts
+++ b/src/lib/leads.ts
@@ -1,0 +1,52 @@
+import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
+import { getSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type LeadRow = Database['public']['Tables']['leads']['Row'];
+export type LeadInsert = Database['public']['Tables']['leads']['Insert'];
+
+const LEAD_COLUMNS = 'id, name, email, company, project, message, created_at';
+
+const sanitizeLeadInsert = (payload: LeadInsert): LeadInsert => ({
+  name: payload.name?.trim() ?? '',
+  email: payload.email?.trim() ?? '',
+  company: payload.company?.trim() || null,
+  project: payload.project?.trim() || null,
+  message: payload.message?.trim() ?? '',
+});
+
+export class LeadMutationError extends Error {
+  constructor(message: string, readonly cause?: PostgrestError) {
+    super(message);
+    this.name = 'LeadMutationError';
+  }
+}
+
+export const createLead = async (
+  payload: LeadInsert,
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<void> => {
+  const lead = sanitizeLeadInsert(payload);
+
+  const { error } = await client.from('leads').insert([lead]);
+
+  if (error) {
+    throw new LeadMutationError('Failed to submit lead form.', error);
+  }
+};
+
+export const fetchLeads = async (
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<LeadRow[]> => {
+  const { data, error } = await client
+    .from('leads')
+    .select(LEAD_COLUMNS)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch leads: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+

--- a/src/lib/newsletterSubscribers.ts
+++ b/src/lib/newsletterSubscribers.ts
@@ -1,0 +1,54 @@
+import type { SupabaseClient, PostgrestError } from '@supabase/supabase-js';
+import { getSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type NewsletterSubscriberRow =
+  Database['public']['Tables']['newsletter_subscribers']['Row'];
+
+const NEWSLETTER_COLUMNS = 'id, email, active, subscribed_at';
+
+const normalizeEmail = (email: string): string => email.trim().toLowerCase();
+
+export class NewsletterSubscriptionError extends Error {
+  constructor(message: string, readonly cause?: PostgrestError) {
+    super(message);
+    this.name = 'NewsletterSubscriptionError';
+  }
+
+  get code(): string | undefined {
+    return this.cause?.code;
+  }
+}
+
+export const subscribeToNewsletter = async (
+  email: string,
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<void> => {
+  const normalizedEmail = normalizeEmail(email);
+  const { error } = await client
+    .from('newsletter_subscribers')
+    .insert([{ email: normalizedEmail }]);
+
+  if (error) {
+    throw new NewsletterSubscriptionError(
+      'Failed to subscribe to the newsletter.',
+      error
+    );
+  }
+};
+
+export const fetchNewsletterSubscribers = async (
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<NewsletterSubscriberRow[]> => {
+  const { data, error } = await client
+    .from('newsletter_subscribers')
+    .select(NEWSLETTER_COLUMNS)
+    .order('subscribed_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch newsletter subscribers: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,26 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
+const PROFILE_COLUMNS =
+  'id, user_id, email, name, role, avatar_url, created_at, updated_at';
+
+export const fetchProfileByUserId = async (
+  userId: string,
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<ProfileRow | null> => {
+  const { data, error } = await client
+    .from('profiles')
+    .select(PROFILE_COLUMNS)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to fetch profile: ${error.message}`);
+  }
+
+  return data ?? null;
+};
+

--- a/src/lib/repositories.ts
+++ b/src/lib/repositories.ts
@@ -1,0 +1,25 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type RepositoryRow = Database['public']['Tables']['repositories']['Row'];
+
+const DEFAULT_REPOSITORY_COLUMNS =
+  'id, name, description, github_url, demo_url, tags, active, created_at, updated_at';
+
+export const fetchActiveRepositories = async (
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<RepositoryRow[]> => {
+  const { data, error } = await client
+    .from('repositories')
+    .select(DEFAULT_REPOSITORY_COLUMNS)
+    .eq('active', true)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(`Failed to fetch repositories: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+

--- a/src/lib/teamMembers.ts
+++ b/src/lib/teamMembers.ts
@@ -1,0 +1,25 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabaseClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type TeamMemberRow = Database['public']['Tables']['team_members']['Row'];
+
+const TEAM_MEMBER_COLUMNS =
+  'id, name, role, bio, image_url, linkedin_url, active, created_at';
+
+export const fetchActiveTeamMembers = async (
+  client: SupabaseClient<Database> = getSupabaseClient()
+): Promise<TeamMemberRow[]> => {
+  const { data, error } = await client
+    .from('team_members')
+    .select(TEAM_MEMBER_COLUMNS)
+    .eq('active', true)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(`Failed to fetch team members: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,7 +5,6 @@ import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import NewsletterSection from '@/components/NewsletterSection';
 import { ArrowRight, Clock, User } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
 import { useTranslation, Trans } from 'react-i18next';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -17,6 +16,10 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import {
+  fetchPublishedBlogPosts,
+  type BlogPostRow,
+} from '@/lib/blogPosts';
 
 const Blog = () => {
   const { t } = useTranslation();
@@ -41,35 +44,25 @@ const Blog = () => {
   } = useQuery({
     queryKey: ['blog_posts'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('blog_posts')
-        .select('id, slug, title, excerpt, image_url, updated_at')
-        .eq('published', true)
-        .order('updated_at', { ascending: false });
+      const posts = await fetchPublishedBlogPosts();
 
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return (
-        data?.map((post, index) => ({
-          title: post.title,
-          excerpt: post.excerpt || 'Read more about this topic...',
-          image:
-            post.image_url ||
-            'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
-          author: 'Monynha Softwares Team',
-          date: new Date(post.updated_at).toLocaleDateString('pt-BR', {
-            year: 'numeric',
-            month: 'long',
-            day: 'numeric',
-          }),
-          readTime: '5 min read',
-          category: 'AI Insights',
-          featured: index === 0,
-          slug: post.slug,
-        })) || []
-      );
+      return posts.map((post: BlogPostRow, index) => ({
+        title: post.title,
+        excerpt: post.excerpt || 'Read more about this topic...',
+        image:
+          post.image_url ||
+          'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
+        author: 'Monynha Softwares Team',
+        date: new Date(post.updated_at).toLocaleDateString('pt-BR', {
+          year: 'numeric',
+          month: 'long',
+          day: 'numeric',
+        }),
+        readTime: '5 min read',
+        category: 'AI Insights',
+        featured: index === 0,
+        slug: post.slug,
+      }));
     },
   });
 

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -20,7 +20,6 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { supabase } from '@/integrations/supabase';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useRepositorySync from '@/hooks/useRepositorySync';
@@ -31,16 +30,12 @@ import {
 } from '@/lib/solutions';
 import type { GitHubRepository } from '@/lib/solutions';
 import type { SolutionContent } from '@/types/solutions';
+import {
+  fetchActiveRepositories,
+  type RepositoryRow,
+} from '@/lib/repositories';
 
-interface Repository {
-  id: string;
-  name: string;
-  description: string;
-  github_url: string;
-  demo_url: string | null;
-  tags: string[] | null;
-  created_at: string;
-}
+type Repository = RepositoryRow;
 
 const GITHUB_REPOS_URL =
   'https://api.github.com/orgs/Monynha-Softwares/repos?per_page=100';
@@ -55,19 +50,7 @@ const Projects = () => {
     isError: repositoriesError,
   } = useQuery<Repository[]>({
     queryKey: ['repositories'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('repositories')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: false });
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return (data ?? []) as Repository[];
-    },
+    queryFn: () => fetchActiveRepositories(),
   });
 
   const {


### PR DESCRIPTION
## Summary
- refactor the Supabase integration to expose browser, server, and service-role clients with unified environment handling
- add typed data access helpers for each public schema table and update pages/components to consume the typed queries with enforced RLS filters
- introduce a service-role permission validation script and npm alias to exercise visitor, user, and admin scenarios

## Testing
- npm run lint
- npm run test
- npm run build
- npm run test:supabase

------
https://chatgpt.com/codex/tasks/task_e_68c9d4ca3d8c8322929a6bb5e8fa7f27