### PR TITLE
refactor: centralize supabase clients and typed queries

### DIFF
--- a/api/admin-dashboard.ts
+++ b/api/admin-dashboard.ts
@@ -1,0 +1,83 @@
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { createServerSupabaseClient, createServiceRoleSupabaseClient } from '../src/integrations/supabase';
+import { fetchProfileByUserId } from '../src/lib/profiles';
+import { fetchLeads } from '../src/lib/leads';
+import { fetchNewsletterSubscribers } from '../src/lib/newsletter-subscribers';
+
+interface AdminRequest extends IncomingMessage {
+  method?: string;
+  headers: IncomingMessage['headers'] & {
+    authorization?: string;
+    Authorization?: string;
+  };
+}
+
+const sendJson = (res: ServerResponse, status: number, payload: unknown) => {
+  res.statusCode = status;
+  res.setHeader('Content-Type', 'application/json');
+  res.end(JSON.stringify(payload));
+};
+
+const extractAccessToken = (req: AdminRequest): string | null => {
+  const authorizationHeader =
+    req.headers.authorization ?? req.headers.Authorization ?? '';
+
+  if (typeof authorizationHeader !== 'string') {
+    return null;
+  }
+
+  const trimmed = authorizationHeader.trim();
+  if (!trimmed.toLowerCase().startsWith('bearer ')) {
+    return null;
+  }
+
+  return trimmed.slice(7).trim();
+};
+
+const handleRequest = async (req: AdminRequest, res: ServerResponse) => {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    return sendJson(res, 405, { error: 'Method not allowed' });
+  }
+
+  const accessToken = extractAccessToken(req);
+  if (!accessToken) {
+    return sendJson(res, 401, { error: 'Missing or invalid Authorization header' });
+  }
+
+  try {
+    const serverClient = createServerSupabaseClient(accessToken);
+    const { data: authData, error: userError } = await serverClient.auth.getUser(accessToken);
+
+    if (userError || !authData?.user) {
+      return sendJson(res, 401, { error: 'Invalid or expired session token' });
+    }
+
+    const profile = await fetchProfileByUserId(authData.user.id, {
+      client: serverClient,
+    });
+
+    if (!profile || profile.role !== 'admin') {
+      return sendJson(res, 403, { error: 'Access denied' });
+    }
+
+    const serviceClient = createServiceRoleSupabaseClient();
+
+    const [leads, newsletterSubscribers] = await Promise.all([
+      fetchLeads({ client: serviceClient }),
+      fetchNewsletterSubscribers({ client: serviceClient, includeInactive: true }),
+    ]);
+
+    return sendJson(res, 200, {
+      leads,
+      newsletterSubscribers,
+    });
+  } catch (error) {
+    console.error('Failed to process admin dashboard request', error);
+    return sendJson(res, 500, { error: 'Internal server error' });
+  }
+};
+
+export default async function handler(req: AdminRequest, res: ServerResponse) {
+  await handleRequest(req, res);
+}

--- a/scripts/test-supabase-permissions.ts
+++ b/scripts/test-supabase-permissions.ts
@@ -1,0 +1,183 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import type { Database } from '@/integrations/supabase/types';
+
+const getEnv = (...keys: string[]): string | undefined => {
+  for (const key of keys) {
+    const value = process.env[key];
+    if (value && value.length > 0) {
+      return value;
+    }
+  }
+  return undefined;
+};
+
+const SUPABASE_URL = getEnv('SUPABASE_URL', 'VITE_SUPABASE_URL');
+const SUPABASE_ANON_KEY = getEnv(
+  'SUPABASE_ANON_KEY',
+  'VITE_SUPABASE_ANON_KEY',
+  'VITE_SUPABASE_PUBLISHABLE_KEY'
+);
+const SUPABASE_SERVICE_ROLE_KEY = getEnv('SUPABASE_SERVICE_ROLE_KEY');
+const TEST_USER_EMAIL = getEnv('SUPABASE_TEST_USER_EMAIL');
+const TEST_USER_PASSWORD = getEnv('SUPABASE_TEST_USER_PASSWORD');
+
+if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+  console.warn('Supabase URL/Anon key not provided. Skipping permission checks.');
+  process.exit(0);
+}
+
+const results: Array<{ name: string; status: 'pass' | 'fail' | 'skip'; details?: string }> = [];
+
+const anonClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+const expectSuccess = async (name: string, fn: () => Promise<void>) => {
+  try {
+    await fn();
+    results.push({ name, status: 'pass' });
+  } catch (error) {
+    const message =
+      error instanceof Error
+        ? error.message
+        : typeof error === 'object'
+          ? JSON.stringify(error)
+          : String(error);
+    results.push({ name, status: 'fail', details: message });
+  }
+};
+
+const expectFailure = async (name: string, fn: () => Promise<void>) => {
+  try {
+    await fn();
+    results.push({
+      name,
+      status: 'fail',
+      details: 'Operation succeeded unexpectedly',
+    });
+  } catch {
+    results.push({ name, status: 'pass' });
+  }
+};
+
+await expectSuccess('Visitor can read active solutions', async () => {
+  const { error } = await anonClient.from('solutions').select('id').limit(1);
+  if (error) {
+    throw error;
+  }
+});
+
+await expectFailure('Visitor cannot read leads', async () => {
+  const { error } = await anonClient.from('leads').select('id').limit(1);
+  if (!error) {
+    throw new Error('Expected row level security error');
+  }
+  throw error;
+});
+
+await expectSuccess('Visitor can insert lead', async () => {
+  const { error } = await anonClient.from('leads').insert({
+    name: 'Test Lead',
+    email: `test-${Date.now()}@example.com`,
+    message: 'Automated permission check',
+    company: null,
+    project: null,
+  });
+  if (error) {
+    throw error;
+  }
+});
+
+let userClient: SupabaseClient<Database> | null = null;
+if (TEST_USER_EMAIL && TEST_USER_PASSWORD) {
+  const { data: signInData, error: signInError } = await anonClient.auth.signInWithPassword({
+    email: TEST_USER_EMAIL,
+    password: TEST_USER_PASSWORD,
+  });
+
+  if (signInError || !signInData.session) {
+    results.push({
+      name: 'Authenticated user login',
+      status: 'fail',
+      details: signInError?.message ?? 'Unable to retrieve session',
+    });
+  } else {
+    userClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+      auth: { persistSession: false, autoRefreshToken: false },
+      global: {
+        headers: {
+          Authorization: `Bearer ${signInData.session.access_token}`,
+        },
+      },
+    });
+
+    await expectSuccess('User can read own profile', async () => {
+      const { data, error } = await userClient!
+        .from('profiles')
+        .select('id')
+        .eq('user_id', signInData.session!.user.id)
+        .maybeSingle();
+      if (error) {
+        throw error;
+      }
+      if (!data) {
+        throw new Error('Profile not found');
+      }
+    });
+
+    await expectFailure('Authenticated user cannot read leads', async () => {
+      const { error } = await userClient!
+        .from('leads')
+        .select('id')
+        .limit(1);
+      if (!error) {
+        throw new Error('Expected row level security error');
+      }
+      throw error;
+    });
+  }
+} else {
+  results.push({
+    name: 'Authenticated user permissions',
+    status: 'skip',
+    details: 'SUPABASE_TEST_USER_EMAIL/PASSWORD not provided',
+  });
+}
+
+if (SUPABASE_SERVICE_ROLE_KEY) {
+  const serviceClient = createClient<Database>(
+    SUPABASE_URL,
+    SUPABASE_SERVICE_ROLE_KEY,
+    { auth: { persistSession: false, autoRefreshToken: false } }
+  );
+
+  await expectSuccess('Service role can read leads', async () => {
+    const { error } = await serviceClient.from('leads').select('id').limit(1);
+    if (error) {
+      throw error;
+    }
+  });
+} else {
+  results.push({
+    name: 'Service role permissions',
+    status: 'skip',
+    details: 'SUPABASE_SERVICE_ROLE_KEY not provided',
+  });
+}
+
+const hasFailure = results.some((result) => result.status === 'fail');
+
+for (const result of results) {
+  const prefix =
+    result.status === 'pass'
+      ? 'PASS'
+      : result.status === 'fail'
+        ? 'FAIL'
+        : 'SKIP';
+  const suffix = result.details ? ` - ${result.details}` : '';
+  console.log(`[${prefix}] ${result.name}${suffix}`);
+}
+
+if (hasFailure) {
+  console.warn('One or more permission checks failed. Review the log above for details.');
+}

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { supabase } from '@/integrations/supabase';
+import { subscribeToNewsletter } from '@/lib/newsletter-subscribers';
 import { useToast } from '@/hooks/use-toast';
 import { Mail, CheckCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -30,28 +30,7 @@ const NewsletterSection = () => {
     }
 
     try {
-      const { error } = await supabase
-        .from('newsletter_subscribers')
-        .insert([{ email: email.trim() }]);
-
-      if (error) {
-        if (error.code === '23505') {
-          // Unique constraint violation
-          toast({
-            title: t('newsletterSection.alreadySubscribedTitle'),
-            description: t('newsletterSection.alreadySubscribedDescription'),
-            variant: 'destructive',
-          });
-        } else {
-          toast({
-            title: t('newsletterSection.errorTitle'),
-            description: t('newsletterSection.errorDescription'),
-            variant: 'destructive',
-          });
-        }
-        setIsSubmitting(false);
-        return;
-      }
+      await subscribeToNewsletter(email);
 
       setIsSubscribed(true);
       toast({
@@ -60,11 +39,26 @@ const NewsletterSection = () => {
       });
     } catch (error) {
       console.error('Newsletter subscription error:', error);
-      toast({
-        title: t('newsletterSection.errorTitle'),
-        description: t('newsletterSection.errorDescription'),
-        variant: 'destructive',
-      });
+
+      const isUniqueConstraintError =
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error as { code?: string }).code === '23505';
+
+      if (isUniqueConstraintError) {
+        toast({
+          title: t('newsletterSection.alreadySubscribedTitle'),
+          description: t('newsletterSection.alreadySubscribedDescription'),
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: t('newsletterSection.errorTitle'),
+          description: t('newsletterSection.errorDescription'),
+          variant: 'destructive',
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -2,18 +2,9 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { supabase } from '@/integrations/supabase';
+import { fetchActiveTeamMembers, type TeamMember } from '@/lib/team-members';
 import { Linkedin, Mail } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-
-interface TeamMember {
-  id: string;
-  name: string;
-  role: string;
-  bio: string | null;
-  image_url: string | null;
-  linkedin_url: string | null;
-}
 
 const TeamSection = () => {
   const { t } = useTranslation();
@@ -22,18 +13,9 @@ const TeamSection = () => {
     data: members,
     isLoading,
     error,
-  } = useQuery({
+  } = useQuery<TeamMember[]>({
     queryKey: ['team-members'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('team_members')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: true });
-
-      if (error) throw error;
-      return data as TeamMember[];
-    },
+    queryFn: () => fetchActiveTeamMembers(),
   });
 
   if (isLoading) {

--- a/src/lib/admin.ts
+++ b/src/lib/admin.ts
@@ -1,0 +1,44 @@
+import type { Lead } from '@/lib/leads';
+import type { NewsletterSubscriber } from '@/lib/newsletter-subscribers';
+
+export interface AdminDashboardData {
+  leads: Lead[];
+  newsletterSubscribers: NewsletterSubscriber[];
+}
+
+export const fetchAdminDashboardData = async (
+  accessToken: string
+): Promise<AdminDashboardData> => {
+  if (!accessToken) {
+    throw new Error('Missing access token for admin dashboard request.');
+  }
+
+  const response = await fetch('/api/admin-dashboard', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+    credentials: 'include',
+  });
+
+  if (!response.ok) {
+    let message = `Request failed with status ${response.status}`;
+    try {
+      const payload = (await response.json()) as { error?: string };
+      if (payload?.error) {
+        message = payload.error;
+      }
+    } catch {
+      // Ignore JSON parsing errors and use the default message
+    }
+
+    throw new Error(message);
+  }
+
+  const data = (await response.json()) as AdminDashboardData;
+
+  return {
+    leads: data.leads ?? [],
+    newsletterSubscribers: data.newsletterSubscribers ?? [],
+  };
+};

--- a/src/lib/blog-posts.ts
+++ b/src/lib/blog-posts.ts
@@ -1,0 +1,48 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase';
+import type { Database, Tables } from '@/integrations/supabase/types';
+
+export type BlogPost = Tables<'blog_posts'>;
+
+export interface FetchBlogPostsOptions {
+  client?: SupabaseClient<Database>;
+  limit?: number;
+  includeUnpublished?: boolean;
+}
+
+const ORDER_COLUMN: keyof BlogPost = 'updated_at';
+
+const fetchBlogPostsInternal = async (
+  options: FetchBlogPostsOptions
+): Promise<BlogPost[]> => {
+  const { client = supabase, limit, includeUnpublished = false } = options;
+
+  let query = client.from('blog_posts').select('*');
+
+  if (!includeUnpublished) {
+    query = query.eq('published', true);
+  }
+
+  query = query.order(ORDER_COLUMN, { ascending: false });
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query.returns<BlogPost[]>();
+
+  if (error) {
+    throw new Error(`Failed to fetch blog posts: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+
+export const fetchBlogPosts = async (
+  options: FetchBlogPostsOptions = {}
+): Promise<BlogPost[]> => fetchBlogPostsInternal(options);
+
+export const fetchPublishedBlogPosts = async (
+  options: Omit<FetchBlogPostsOptions, 'includeUnpublished'> = {}
+): Promise<BlogPost[]> =>
+  fetchBlogPostsInternal({ ...options, includeUnpublished: false });

--- a/src/lib/homepage-features.ts
+++ b/src/lib/homepage-features.ts
@@ -1,0 +1,48 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase';
+import type { Database, Tables } from '@/integrations/supabase/types';
+
+export type HomepageFeature = Tables<'homepage_features'>;
+
+export interface FetchHomepageFeaturesOptions {
+  client?: SupabaseClient<Database>;
+  limit?: number;
+  includeInactive?: boolean;
+}
+
+const ORDER_COLUMN: keyof HomepageFeature = 'order_index';
+
+const fetchHomepageFeaturesInternal = async (
+  options: FetchHomepageFeaturesOptions
+): Promise<HomepageFeature[]> => {
+  const { client = supabase, limit, includeInactive = false } = options;
+
+  let query = client.from('homepage_features').select('*');
+
+  if (!includeInactive) {
+    query = query.eq('active', true);
+  }
+
+  query = query.order(ORDER_COLUMN, { ascending: true });
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query.returns<HomepageFeature[]>();
+
+  if (error) {
+    throw new Error(`Failed to fetch homepage features: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+
+export const fetchHomepageFeatures = async (
+  options: FetchHomepageFeaturesOptions = {}
+): Promise<HomepageFeature[]> => fetchHomepageFeaturesInternal(options);
+
+export const fetchActiveHomepageFeatures = async (
+  options: Omit<FetchHomepageFeaturesOptions, 'includeInactive'> = {}
+): Promise<HomepageFeature[]> =>
+  fetchHomepageFeaturesInternal({ ...options, includeInactive: false });

--- a/src/lib/leads.ts
+++ b/src/lib/leads.ts
@@ -1,0 +1,60 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase';
+import type { Database, Tables, TablesInsert } from '@/integrations/supabase/types';
+
+export type Lead = Tables<'leads'>;
+export type LeadInsert = TablesInsert<'leads'>;
+
+export interface LeadQueryOptions {
+  client?: SupabaseClient<Database>;
+  limit?: number;
+}
+
+export interface CreateLeadOptions {
+  client?: SupabaseClient<Database>;
+}
+
+const ORDER_COLUMN: keyof Lead = 'created_at';
+
+export const createLead = async (
+  payload: LeadInsert,
+  options: CreateLeadOptions = {}
+): Promise<void> => {
+  const { client = supabase } = options;
+
+  const normalizedPayload: LeadInsert = {
+    ...payload,
+    company: payload.company ?? null,
+    project: payload.project ?? null,
+  };
+
+  const { error } = await client
+    .from('leads')
+    .insert([normalizedPayload]);
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const fetchLeads = async (
+  options: LeadQueryOptions = {}
+): Promise<Lead[]> => {
+  const { client = supabase, limit } = options;
+
+  let query = client.from('leads').select('*');
+
+  query = query.order(ORDER_COLUMN, { ascending: false });
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query.returns<Lead[]>();
+
+  if (error) {
+    throw new Error(`Failed to fetch leads: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/newsletter-subscribers.ts
+++ b/src/lib/newsletter-subscribers.ts
@@ -1,0 +1,64 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase';
+import type { Database, Tables, TablesInsert } from '@/integrations/supabase/types';
+
+export type NewsletterSubscriber = Tables<'newsletter_subscribers'>;
+export type NewsletterSubscriberInsert = TablesInsert<'newsletter_subscribers'>;
+
+export interface NewsletterQueryOptions {
+  client?: SupabaseClient<Database>;
+  limit?: number;
+  includeInactive?: boolean;
+}
+
+export interface SubscribeToNewsletterOptions {
+  client?: SupabaseClient<Database>;
+}
+
+const ORDER_COLUMN: keyof NewsletterSubscriber = 'subscribed_at';
+
+export const subscribeToNewsletter = async (
+  email: string,
+  options: SubscribeToNewsletterOptions = {}
+): Promise<void> => {
+  const { client = supabase } = options;
+  const normalizedEmail = email.trim().toLowerCase();
+
+  const payload: NewsletterSubscriberInsert = {
+    email: normalizedEmail,
+  };
+
+  const { error } = await client
+    .from('newsletter_subscribers')
+    .insert([payload]);
+
+  if (error) {
+    throw error;
+  }
+};
+
+export const fetchNewsletterSubscribers = async (
+  options: NewsletterQueryOptions = {}
+): Promise<NewsletterSubscriber[]> => {
+  const { client = supabase, limit, includeInactive = false } = options;
+
+  let query = client.from('newsletter_subscribers').select('*');
+
+  if (!includeInactive) {
+    query = query.eq('active', true);
+  }
+
+  query = query.order(ORDER_COLUMN, { ascending: false });
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query.returns<NewsletterSubscriber[]>();
+
+  if (error) {
+    throw new Error(`Failed to fetch newsletter subscribers: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,35 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase';
+import type { Database, Tables } from '@/integrations/supabase/types';
+
+export type Profile = Tables<'profiles'>;
+
+export interface ProfileQueryOptions {
+  client?: SupabaseClient<Database>;
+}
+
+export const fetchProfileByUserId = async (
+  userId: string,
+  options: ProfileQueryOptions = {}
+): Promise<Profile | null> => {
+  if (!userId) {
+    throw new Error('User ID is required to fetch profile data.');
+  }
+
+  const { client = supabase } = options;
+
+  const { data, error } = await client
+    .from('profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(`Failed to fetch profile: ${error.message}`);
+  }
+
+  return data ?? null;
+};
+
+export const isUserAdmin = (profile: Profile | null | undefined): boolean =>
+  profile?.role === 'admin';

--- a/src/lib/repositories.ts
+++ b/src/lib/repositories.ts
@@ -1,0 +1,40 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase';
+import type { Database, Tables } from '@/integrations/supabase/types';
+
+export type Repository = Tables<'repositories'>;
+
+export interface FetchRepositoriesOptions {
+  client?: SupabaseClient<Database>;
+  limit?: number;
+  includeInactive?: boolean;
+}
+
+/**
+ * Retrieves repositories respecting row-level security policies.
+ */
+export const fetchRepositories = async (
+  options: FetchRepositoriesOptions = {}
+): Promise<Repository[]> => {
+  const { client = supabase, limit, includeInactive = false } = options;
+
+  let query = client.from('repositories').select('*');
+
+  if (!includeInactive) {
+    query = query.eq('active', true);
+  }
+
+  query = query.order('created_at', { ascending: false });
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query.returns<Repository[]>();
+
+  if (error) {
+    throw new Error(`Failed to fetch repositories: ${error.message}`);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/team-members.ts
+++ b/src/lib/team-members.ts
@@ -1,0 +1,48 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { supabase } from '@/integrations/supabase';
+import type { Database, Tables } from '@/integrations/supabase/types';
+
+export type TeamMember = Tables<'team_members'>;
+
+export interface FetchTeamMembersOptions {
+  client?: SupabaseClient<Database>;
+  limit?: number;
+  includeInactive?: boolean;
+}
+
+const DEFAULT_ORDER_COLUMN: keyof TeamMember = 'created_at';
+
+const fetchTeamMembersInternal = async (
+  options: FetchTeamMembersOptions
+): Promise<TeamMember[]> => {
+  const { client = supabase, limit, includeInactive = false } = options;
+
+  let query = client.from('team_members').select('*');
+
+  if (!includeInactive) {
+    query = query.eq('active', true);
+  }
+
+  query = query.order(DEFAULT_ORDER_COLUMN, { ascending: true });
+
+  if (typeof limit === 'number') {
+    query = query.limit(limit);
+  }
+
+  const { data, error } = await query.returns<TeamMember[]>();
+
+  if (error) {
+    throw new Error(`Failed to fetch team members: ${error.message}`);
+  }
+
+  return data ?? [];
+};
+
+export const fetchTeamMembers = async (
+  options: FetchTeamMembersOptions = {}
+): Promise<TeamMember[]> => fetchTeamMembersInternal(options);
+
+export const fetchActiveTeamMembers = async (
+  options: Omit<FetchTeamMembersOptions, 'includeInactive'> = {}
+): Promise<TeamMember[]> =>
+  fetchTeamMembersInternal({ ...options, includeInactive: false });

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,7 +5,7 @@ import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import NewsletterSection from '@/components/NewsletterSection';
 import { ArrowRight, Clock, User } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
+import { fetchPublishedBlogPosts } from '@/lib/blog-posts';
 import { useTranslation, Trans } from 'react-i18next';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -41,35 +41,28 @@ const Blog = () => {
   } = useQuery({
     queryKey: ['blog_posts'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('blog_posts')
-        .select('id, slug, title, excerpt, image_url, updated_at')
-        .eq('published', true)
-        .order('updated_at', { ascending: false });
+      const posts = await fetchPublishedBlogPosts();
 
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return (
-        data?.map((post, index) => ({
-          title: post.title,
-          excerpt: post.excerpt || 'Read more about this topic...',
-          image:
-            post.image_url ||
-            'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
-          author: 'Monynha Softwares Team',
-          date: new Date(post.updated_at).toLocaleDateString('pt-BR', {
+      return posts.map((post, index) => ({
+        title: post.title,
+        excerpt: post.excerpt || 'Read more about this topic...',
+        image:
+          post.image_url ||
+          'https://images.unsplash.com/photo-1555396273-367ea4eb4db5?ixlib=rb-4.0.3&auto=format&fit=crop&w=800&q=80',
+        author: 'Monynha Softwares Team',
+        date: new Date(post.updated_at || post.created_at).toLocaleDateString(
+          'pt-BR',
+          {
             year: 'numeric',
             month: 'long',
             day: 'numeric',
-          }),
-          readTime: '5 min read',
-          category: 'AI Insights',
-          featured: index === 0,
-          slug: post.slug,
-        })) || []
-      );
+          }
+        ),
+        readTime: '5 min read',
+        category: 'AI Insights',
+        featured: index === 0,
+        slug: post.slug,
+      }));
     },
   });
 

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -6,7 +6,7 @@ import { Textarea } from '@/components/ui/textarea';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import { Mail, Phone, MapPin, Send, CheckCircle } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
+import { createLead } from '@/lib/leads';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
@@ -85,25 +85,13 @@ const Contact = () => {
     }
 
     try {
-      const { error } = await supabase.from('leads').insert([
-        {
-          name: formData.name,
-          email: formData.email,
-          company: formData.company || null,
-          project: formData.project || null,
-          message: formData.message,
-        },
-      ]);
-
-      if (error) {
-        console.error('Error submitting form:', error);
-        toast({
-          title: t('contact.toasts.errorTitle'),
-          description: t('contact.toasts.errorDescription'),
-          variant: 'destructive',
-        });
-        return;
-      }
+      await createLead({
+        name: formData.name,
+        email: formData.email,
+        company: formData.company || null,
+        project: formData.project || null,
+        message: formData.message,
+      });
 
       setIsSubmitted(true);
       toast({

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -20,7 +20,6 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { supabase } from '@/integrations/supabase';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useRepositorySync from '@/hooks/useRepositorySync';
@@ -29,18 +28,9 @@ import {
   getFallbackSolutions,
   mapGitHubRepoToContent,
 } from '@/lib/solutions';
+import { fetchRepositories, type Repository } from '@/lib/repositories';
 import type { GitHubRepository } from '@/lib/solutions';
 import type { SolutionContent } from '@/types/solutions';
-
-interface Repository {
-  id: string;
-  name: string;
-  description: string;
-  github_url: string;
-  demo_url: string | null;
-  tags: string[] | null;
-  created_at: string;
-}
 
 const GITHUB_REPOS_URL =
   'https://api.github.com/orgs/Monynha-Softwares/repos?per_page=100';
@@ -55,19 +45,7 @@ const Projects = () => {
     isError: repositoriesError,
   } = useQuery<Repository[]>({
     queryKey: ['repositories'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('repositories')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: false });
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return (data ?? []) as Repository[];
-    },
+    queryFn: () => fetchRepositories(),
   });
 
   const {


### PR DESCRIPTION
## Summary
- centralize Supabase client helpers for browser, server, and service role flows
- add typed database query utilities and update components/pages to consume them
- expose an admin dashboard API backed by the service role and add a Supabase permission check script

## Testing
- npm run lint
- npm run test
- npx tsx scripts/test-supabase-permissions.ts

------
https://chatgpt.com/codex/tasks/task_e_68c9d4ca3d8c8322929a6bb5e8fa7f27