### PR TITLE
Refactor Supabase integration and add typed queries

### DIFF
--- a/api/admin-dashboard.ts
+++ b/api/admin-dashboard.ts
@@ -1,0 +1,102 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node';
+import { createSupabaseServiceRoleClient } from '../src/integrations/supabase';
+
+const getAccessToken = (request: VercelRequest): string | null => {
+  const header = request.headers.authorization || request.headers.Authorization;
+
+  if (!header) {
+    return null;
+  }
+
+  const raw = Array.isArray(header) ? header[0] : header;
+
+  if (!raw || typeof raw !== 'string') {
+    return null;
+  }
+
+  const [scheme, token] = raw.split(' ');
+  if (scheme?.toLowerCase() !== 'bearer' || !token) {
+    return null;
+  }
+
+  return token.trim();
+};
+
+export default async function handler(
+  request: VercelRequest,
+  response: VercelResponse
+) {
+  if (request.method !== 'GET') {
+    response.setHeader('Allow', 'GET');
+    return response.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  const accessToken = getAccessToken(request);
+
+  if (!accessToken) {
+    return response
+      .status(401)
+      .json({ error: 'Token de autenticação ausente.' });
+  }
+
+  try {
+    const supabaseAdmin = createSupabaseServiceRoleClient();
+
+    const {
+      data: { user },
+      error: authError,
+    } = await supabaseAdmin.auth.getUser(accessToken);
+
+    if (authError || !user) {
+      return response.status(401).json({ error: 'Sessão inválida.' });
+    }
+
+    const { data: profile, error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .select('role')
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (profileError) {
+      throw profileError;
+    }
+
+    if (!profile || profile.role !== 'admin') {
+      return response.status(403).json({ error: 'Acesso não autorizado.' });
+    }
+
+    const [leadsResponse, subscribersResponse] = await Promise.all([
+      supabaseAdmin
+        .from('leads')
+        .select('*')
+        .order('created_at', { ascending: false }),
+      supabaseAdmin
+        .from('newsletter_subscribers')
+        .select('*')
+        .order('subscribed_at', { ascending: false }),
+    ]);
+
+    if (leadsResponse.error) {
+      throw leadsResponse.error;
+    }
+
+    if (subscribersResponse.error) {
+      throw subscribersResponse.error;
+    }
+
+    response.setHeader('Cache-Control', 'private, max-age=0, no-store');
+
+    return response.status(200).json({
+      leads: leadsResponse.data ?? [],
+      subscribers: subscribersResponse.data ?? [],
+    });
+  } catch (error) {
+    console.error('Failed to load admin dashboard data', error);
+    const message =
+      error instanceof Error
+        ? error.message
+        : 'Erro ao carregar dados administrativos.';
+
+    return response.status(500).json({ error: message });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "sitemap": "tsx scripts/generate-sitemap.ts",
     "cleanup-lovable": "tsx scripts/cleanup-lovable.ts",
+    "test:supabase": "tsx scripts/validate-supabase-policies.ts",
     "preview": "vite preview",
     "test": "jest --passWithNoTests",
     "format": "prettier --write .",

--- a/scripts/validate-supabase-policies.ts
+++ b/scripts/validate-supabase-policies.ts
@@ -1,0 +1,189 @@
+import { createClient } from '@supabase/supabase-js';
+import {
+  SUPABASE_URL,
+  SUPABASE_ANON_KEY,
+  createSupabaseServerClient,
+  createSupabaseServiceRoleClient,
+} from '../src/integrations/supabase';
+import type { Database } from '../src/integrations/supabase/types';
+
+interface TestResult {
+  name: string;
+  success: boolean;
+  detail?: string;
+}
+
+const logResult = ({ name, success, detail }: TestResult) => {
+  const status = success ? '✅' : '❌';
+  const message = detail ? ` - ${detail}` : '';
+  console.log(`${status} ${name}${message}`);
+};
+
+const runVisitorTests = async () => {
+  const client = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  try {
+    const { error } = await client
+      .from('solutions')
+      .select('id')
+      .eq('active', true)
+      .limit(1);
+
+    if (error) {
+      logResult({ name: 'Visitante pode ler solutions', success: false, detail: error.message });
+    } else {
+      logResult({ name: 'Visitante pode ler solutions', success: true });
+    }
+  } catch (error) {
+    logResult({
+      name: 'Visitante pode ler solutions',
+      success: false,
+      detail: error instanceof Error ? error.message : 'Erro desconhecido',
+    });
+  }
+
+  try {
+    const { error } = await client.from('leads').select('id').limit(1);
+
+    if (error) {
+      logResult({ name: 'Visitante NÃO pode ler leads', success: true });
+    } else {
+      logResult({
+        name: 'Visitante NÃO pode ler leads',
+        success: false,
+        detail: 'Consulta retornou sucesso inesperado',
+      });
+    }
+  } catch (error) {
+    logResult({ name: 'Visitante NÃO pode ler leads', success: true });
+  }
+};
+
+const runUserTests = async () => {
+  const email = process.env.SUPABASE_TEST_USER_EMAIL;
+  const password = process.env.SUPABASE_TEST_USER_PASSWORD;
+
+  if (!email || !password) {
+    console.warn('⚠️ SUPABASE_TEST_USER_EMAIL/SUPABASE_TEST_USER_PASSWORD não definidos. Pulando testes de usuário.');
+    return;
+  }
+
+  const authClient = createClient<Database>(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: { persistSession: false, autoRefreshToken: false },
+  });
+
+  const {
+    data: { session },
+    error: signInError,
+  } = await authClient.auth.signInWithPassword({ email, password });
+
+  if (signInError || !session) {
+    const reason = signInError?.message ?? 'Falha ao autenticar usuário de teste';
+    logResult({ name: 'Login usuário de teste', success: false, detail: reason });
+    return;
+  }
+
+  logResult({ name: 'Login usuário de teste', success: true });
+
+  const client = createSupabaseServerClient({ accessToken: session.access_token });
+
+  try {
+    const { error } = await client
+      .from('profiles')
+      .select('id')
+      .eq('user_id', session.user.id)
+      .maybeSingle();
+
+    if (error) {
+      logResult({ name: 'Usuário lê seu perfil', success: false, detail: error.message });
+    } else {
+      logResult({ name: 'Usuário lê seu perfil', success: true });
+    }
+  } catch (error) {
+    logResult({
+      name: 'Usuário lê seu perfil',
+      success: false,
+      detail: error instanceof Error ? error.message : 'Erro desconhecido',
+    });
+  }
+
+  try {
+    const { error } = await client.from('leads').select('id').limit(1);
+
+    if (error) {
+      logResult({ name: 'Usuário NÃO pode ler leads', success: true });
+    } else {
+      logResult({
+        name: 'Usuário NÃO pode ler leads',
+        success: false,
+        detail: 'Consulta retornou sucesso inesperado',
+      });
+    }
+  } catch (error) {
+    logResult({ name: 'Usuário NÃO pode ler leads', success: true });
+  }
+};
+
+const runAdminTests = async () => {
+  const serviceRoleKey =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ?? process.env.SUPABASE_SERVICE_KEY;
+
+  if (!serviceRoleKey) {
+    console.warn(
+      '⚠️ SUPABASE_SERVICE_ROLE_KEY não definido. Pulando testes administrativos.'
+    );
+    return;
+  }
+
+  try {
+    const serviceClient = createSupabaseServiceRoleClient(serviceRoleKey);
+
+    const [leadsResponse, subscribersResponse] = await Promise.all([
+      serviceClient.from('leads').select('id').limit(1),
+      serviceClient.from('newsletter_subscribers').select('id').limit(1),
+    ]);
+
+    if (leadsResponse.error) {
+      logResult({
+        name: 'Admin pode ler leads',
+        success: false,
+        detail: leadsResponse.error.message,
+      });
+    } else {
+      logResult({ name: 'Admin pode ler leads', success: true });
+    }
+
+    if (subscribersResponse.error) {
+      logResult({
+        name: 'Admin pode ler inscritos newsletter',
+        success: false,
+        detail: subscribersResponse.error.message,
+      });
+    } else {
+      logResult({ name: 'Admin pode ler inscritos newsletter', success: true });
+    }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'Erro desconhecido';
+    logResult({ name: 'Admin pode ler leads', success: false, detail });
+    logResult({
+      name: 'Admin pode ler inscritos newsletter',
+      success: false,
+      detail,
+    });
+  }
+};
+
+const main = async () => {
+  console.log('Iniciando verificação de políticas Supabase...');
+  await runVisitorTests();
+  await runUserTests();
+  await runAdminTests();
+  console.log('Verificação concluída.');
+};
+
+main().catch((error) => {
+  console.error('Falha ao executar testes de políticas Supabase', error);
+  process.exit(1);
+});

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -2,10 +2,11 @@ import { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
-import { supabase } from '@/integrations/supabase';
 import { useToast } from '@/hooks/use-toast';
 import { Mail, CheckCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
+import type { PostgrestError } from '@supabase/supabase-js';
+import { subscribeToNewsletter } from '@/lib/newsletter';
 
 const NewsletterSection = () => {
   const { t } = useTranslation();
@@ -30,28 +31,7 @@ const NewsletterSection = () => {
     }
 
     try {
-      const { error } = await supabase
-        .from('newsletter_subscribers')
-        .insert([{ email: email.trim() }]);
-
-      if (error) {
-        if (error.code === '23505') {
-          // Unique constraint violation
-          toast({
-            title: t('newsletterSection.alreadySubscribedTitle'),
-            description: t('newsletterSection.alreadySubscribedDescription'),
-            variant: 'destructive',
-          });
-        } else {
-          toast({
-            title: t('newsletterSection.errorTitle'),
-            description: t('newsletterSection.errorDescription'),
-            variant: 'destructive',
-          });
-        }
-        setIsSubmitting(false);
-        return;
-      }
+      await subscribeToNewsletter(email);
 
       setIsSubscribed(true);
       toast({
@@ -60,11 +40,24 @@ const NewsletterSection = () => {
       });
     } catch (error) {
       console.error('Newsletter subscription error:', error);
-      toast({
-        title: t('newsletterSection.errorTitle'),
-        description: t('newsletterSection.errorDescription'),
-        variant: 'destructive',
-      });
+      const isUniqueViolation =
+        typeof error === 'object' &&
+        error !== null &&
+        (error as PostgrestError).code === '23505';
+
+      if (isUniqueViolation) {
+        toast({
+          title: t('newsletterSection.alreadySubscribedTitle'),
+          description: t('newsletterSection.alreadySubscribedDescription'),
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: t('newsletterSection.errorTitle'),
+          description: t('newsletterSection.errorDescription'),
+          variant: 'destructive',
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -2,18 +2,12 @@ import { useQuery } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
-import { supabase } from '@/integrations/supabase';
-import { Linkedin, Mail } from 'lucide-react';
+import { Linkedin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
-
-interface TeamMember {
-  id: string;
-  name: string;
-  role: string;
-  bio: string | null;
-  image_url: string | null;
-  linkedin_url: string | null;
-}
+import {
+  fetchActiveTeamMembers,
+  type TeamMemberRow,
+} from '@/lib/team-members';
 
 const TeamSection = () => {
   const { t } = useTranslation();
@@ -22,18 +16,9 @@ const TeamSection = () => {
     data: members,
     isLoading,
     error,
-  } = useQuery({
+  } = useQuery<TeamMemberRow[]>({
     queryKey: ['team-members'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('team_members')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: true });
-
-      if (error) throw error;
-      return data as TeamMember[];
-    },
+    queryFn: fetchActiveTeamMembers,
   });
 
   if (isLoading) {

--- a/src/lib/blog-posts.ts
+++ b/src/lib/blog-posts.ts
@@ -1,0 +1,24 @@
+import type { SupabaseDatabaseClient } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type BlogPostRow = Pick<
+  Database['public']['Tables']['blog_posts']['Row'],
+  'id' | 'slug' | 'title' | 'excerpt' | 'image_url' | 'updated_at'
+>;
+
+export const fetchPublishedBlogPosts = async (
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<BlogPostRow[]> => {
+  const { data, error } = await client
+    .from('blog_posts')
+    .select('id, slug, title, excerpt, image_url, updated_at')
+    .eq('published', true)
+    .order('updated_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/homepage-features.ts
+++ b/src/lib/homepage-features.ts
@@ -1,0 +1,25 @@
+import type { SupabaseDatabaseClient } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+type HomepageFeatureRow = Database['public']['Tables']['homepage_features']['Row'];
+
+type HomepageFeature = HomepageFeatureRow;
+
+export const fetchActiveHomepageFeatures = async (
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<HomepageFeature[]> => {
+  const { data, error } = await client
+    .from('homepage_features')
+    .select('*')
+    .eq('active', true)
+    .order('order_index', { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};
+
+export type { HomepageFeature };

--- a/src/lib/leads.ts
+++ b/src/lib/leads.ts
@@ -1,0 +1,26 @@
+import type { SupabaseDatabaseClient } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type LeadRow = Database['public']['Tables']['leads']['Row'];
+export type LeadInsert = Database['public']['Tables']['leads']['Insert'];
+
+export const createLead = async (
+  payload: LeadInsert,
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<void> => {
+  const sanitizedPayload: LeadInsert = {
+    ...payload,
+    email: payload.email.trim(),
+    name: payload.name.trim(),
+    message: payload.message.trim(),
+    company: payload.company?.trim() || null,
+    project: payload.project?.trim() || null,
+  };
+
+  const { error } = await client.from('leads').insert([sanitizedPayload]);
+
+  if (error) {
+    throw error;
+  }
+};

--- a/src/lib/newsletter.ts
+++ b/src/lib/newsletter.ts
@@ -1,0 +1,32 @@
+import type { SupabaseDatabaseClient } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type NewsletterSubscriberRow =
+  Database['public']['Tables']['newsletter_subscribers']['Row'];
+export type NewsletterSubscriberInsert =
+  Database['public']['Tables']['newsletter_subscribers']['Insert'];
+
+export const subscribeToNewsletter = async (
+  email: string,
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<void> => {
+  const normalizedEmail = email.trim().toLowerCase();
+
+  if (!normalizedEmail) {
+    throw new Error('O e-mail é obrigatório.');
+  }
+
+  const payload: NewsletterSubscriberInsert = {
+    email: normalizedEmail,
+    active: true,
+  };
+
+  const { error } = await client
+    .from('newsletter_subscribers')
+    .insert([payload]);
+
+  if (error) {
+    throw error;
+  }
+};

--- a/src/lib/profiles.ts
+++ b/src/lib/profiles.ts
@@ -1,0 +1,26 @@
+import type { SupabaseDatabaseClient } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
+export const fetchProfileByUserId = async (
+  userId: string,
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<ProfileRow | null> => {
+  if (!userId) {
+    return null;
+  }
+
+  const { data, error } = await client
+    .from('profiles')
+    .select('*')
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? null;
+};

--- a/src/lib/repositories.ts
+++ b/src/lib/repositories.ts
@@ -1,0 +1,21 @@
+import type { SupabaseDatabaseClient } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type RepositoryRow = Database['public']['Tables']['repositories']['Row'];
+
+export const fetchActiveRepositories = async (
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<RepositoryRow[]> => {
+  const { data, error } = await client
+    .from('repositories')
+    .select('*')
+    .eq('active', true)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/lib/solutions.ts
+++ b/src/lib/solutions.ts
@@ -4,7 +4,10 @@ import {
   gradientOptions,
   normalizeSolutionSlug,
 } from '@/data/solutions';
-import { supabase } from '@/integrations/supabase';
+import {
+  getSupabaseBrowserClient,
+  type SupabaseDatabaseClient,
+} from '@/integrations/supabase';
 import type { Database } from '@/integrations/supabase/types';
 import type { SolutionContent } from '@/types/solutions';
 
@@ -29,7 +32,7 @@ export interface GitHubRepository {
   html_url: string;
 }
 
-type SupabaseSolutionRow = Database['public']['Tables']['solutions']['Row'];
+export type SupabaseSolutionRow = Database['public']['Tables']['solutions']['Row'];
 
 const uniqueNonEmpty = (values: Array<string | null | undefined>): string[] => {
   const seen = new Set<string>();
@@ -224,8 +227,10 @@ export const getFallbackSolutions = (): SolutionContent[] =>
     features: [...solution.features],
   }));
 
-export const fetchSupabaseSolutions = async (): Promise<SolutionContent[]> => {
-  const { data, error } = await supabase
+export const fetchSupabaseSolutions = async (
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<SolutionContent[]> => {
+  const { data, error } = await client
     .from('solutions')
     .select('*')
     .eq('active', true)

--- a/src/lib/team-members.ts
+++ b/src/lib/team-members.ts
@@ -1,0 +1,21 @@
+import type { SupabaseDatabaseClient } from '@/integrations/supabase';
+import { getSupabaseBrowserClient } from '@/integrations/supabase';
+import type { Database } from '@/integrations/supabase/types';
+
+export type TeamMemberRow = Database['public']['Tables']['team_members']['Row'];
+
+export const fetchActiveTeamMembers = async (
+  client: SupabaseDatabaseClient = getSupabaseBrowserClient()
+): Promise<TeamMemberRow[]> => {
+  const { data, error } = await client
+    .from('team_members')
+    .select('*')
+    .eq('active', true)
+    .order('created_at', { ascending: true });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data ?? [];
+};

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -5,7 +5,6 @@ import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import NewsletterSection from '@/components/NewsletterSection';
 import { ArrowRight, Clock, User } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
 import { useTranslation, Trans } from 'react-i18next';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
@@ -17,6 +16,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { fetchPublishedBlogPosts } from '@/lib/blog-posts';
 
 const Blog = () => {
   const { t } = useTranslation();
@@ -41,18 +41,9 @@ const Blog = () => {
   } = useQuery({
     queryKey: ['blog_posts'],
     queryFn: async () => {
-      const { data, error } = await supabase
-        .from('blog_posts')
-        .select('id, slug, title, excerpt, image_url, updated_at')
-        .eq('published', true)
-        .order('updated_at', { ascending: false });
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
+      const data = await fetchPublishedBlogPosts();
       return (
-        data?.map((post, index) => ({
+        data.map((post, index) => ({
           title: post.title,
           excerpt: post.excerpt || 'Read more about this topic...',
           image:
@@ -68,7 +59,7 @@ const Blog = () => {
           category: 'AI Insights',
           featured: index === 0,
           slug: post.slug,
-        })) || []
+        }))
       );
     },
   });

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -6,7 +6,6 @@ import { Textarea } from '@/components/ui/textarea';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import { Mail, Phone, MapPin, Send, CheckCircle } from 'lucide-react';
-import { supabase } from '@/integrations/supabase';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
@@ -19,6 +18,7 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
+import { createLead } from '@/lib/leads';
 
 const projectTypes = [
   'Custom AI Assistant',
@@ -85,25 +85,13 @@ const Contact = () => {
     }
 
     try {
-      const { error } = await supabase.from('leads').insert([
-        {
-          name: formData.name,
-          email: formData.email,
-          company: formData.company || null,
-          project: formData.project || null,
-          message: formData.message,
-        },
-      ]);
-
-      if (error) {
-        console.error('Error submitting form:', error);
-        toast({
-          title: t('contact.toasts.errorTitle'),
-          description: t('contact.toasts.errorDescription'),
-          variant: 'destructive',
-        });
-        return;
-      }
+      await createLead({
+        name: formData.name,
+        email: formData.email,
+        company: formData.company || null,
+        project: formData.project || null,
+        message: formData.message,
+      });
 
       setIsSubmitted(true);
       toast({

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,7 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { supabase } from '@/integrations/supabase';
-import type { Database } from '@/integrations/supabase/types';
 import { useAuth } from '@/hooks/useAuth';
 import { useToast } from '@/hooks/use-toast';
 import { Button } from '@/components/ui/button';
@@ -27,11 +25,21 @@ import Loading from '@/components/Loading';
 import { format } from 'date-fns';
 import { ptBR } from 'date-fns/locale';
 import { AlertTriangle, Loader2, LogOut, RefreshCcw } from 'lucide-react';
+import {
+  fetchProfileByUserId,
+  type ProfileRow,
+} from '@/lib/profiles';
+import type { LeadRow } from '@/lib/leads';
+import type { NewsletterSubscriberRow } from '@/lib/newsletter';
 
-type Profile = Database['public']['Tables']['profiles']['Row'];
-type Lead = Database['public']['Tables']['leads']['Row'];
-type NewsletterSubscriber =
-  Database['public']['Tables']['newsletter_subscribers']['Row'];
+type Profile = ProfileRow;
+type Lead = LeadRow;
+type NewsletterSubscriber = NewsletterSubscriberRow;
+
+interface AdminDashboardResponse {
+  leads: Lead[];
+  subscribers: NewsletterSubscriber[];
+}
 
 const formatDate = (value: string | null | undefined) => {
   if (!value) return '—';
@@ -45,7 +53,7 @@ const formatDate = (value: string | null | undefined) => {
 };
 
 const Dashboard = () => {
-  const { user, signOut } = useAuth();
+  const { user, session, signOut } = useAuth();
   const { toast } = useToast();
   const navigate = useNavigate();
 
@@ -73,15 +81,7 @@ const Dashboard = () => {
     }
 
     try {
-      const { data: profileData, error: profileError } = await supabase
-        .from('profiles')
-        .select('*')
-        .eq('user_id', user.id)
-        .maybeSingle();
-
-      if (profileError) {
-        throw profileError;
-      }
+      const profileData = await fetchProfileByUserId(user.id);
 
       const resolvedProfile: Profile =
         profileData ??
@@ -103,32 +103,45 @@ const Dashboard = () => {
       }
 
       if (resolvedProfile.role === 'admin') {
+        if (!session?.access_token) {
+          throw new Error('Sessão inválida. Faça login novamente.');
+        }
+
         if (isMounted.current) {
           setIsFetchingAdminData(true);
         }
 
-        const [leadsResponse, newsletterResponse] = await Promise.all([
-          supabase
-            .from('leads')
-            .select('*')
-            .order('created_at', { ascending: false }),
-          supabase
-            .from('newsletter_subscribers')
-            .select('*')
-            .order('subscribed_at', { ascending: false }),
-        ]);
+        const response = await fetch('/api/admin-dashboard', {
+          headers: {
+            Authorization: `Bearer ${session.access_token}`,
+          },
+        });
 
-        if (leadsResponse.error) {
-          throw leadsResponse.error;
+        if (!response.ok) {
+          let message = 'Não foi possível carregar dados administrativos.';
+          const rawBody = await response.text();
+
+          if (rawBody) {
+            try {
+              const parsed = JSON.parse(rawBody) as { error?: string };
+              if (parsed?.error) {
+                message = parsed.error;
+              } else {
+                message = rawBody;
+              }
+            } catch {
+              message = rawBody;
+            }
+          }
+
+          throw new Error(message);
         }
 
-        if (newsletterResponse.error) {
-          throw newsletterResponse.error;
-        }
+        const payload = (await response.json()) as AdminDashboardResponse;
 
         if (isMounted.current) {
-          setLeads(leadsResponse.data ?? []);
-          setSubscribers(newsletterResponse.data ?? []);
+          setLeads(payload.leads);
+          setSubscribers(payload.subscribers);
         }
       } else if (isMounted.current) {
         setLeads([]);
@@ -154,7 +167,7 @@ const Dashboard = () => {
         setIsFetchingAdminData(false);
       }
     }
-  }, [toast, user]);
+  }, [session?.access_token, toast, user]);
 
   useEffect(() => {
     void loadDashboard();

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -20,7 +20,6 @@ import {
   BreadcrumbPage,
   BreadcrumbSeparator,
 } from '@/components/ui/breadcrumb';
-import { supabase } from '@/integrations/supabase';
 import { useTranslation, Trans } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import useRepositorySync from '@/hooks/useRepositorySync';
@@ -31,16 +30,10 @@ import {
 } from '@/lib/solutions';
 import type { GitHubRepository } from '@/lib/solutions';
 import type { SolutionContent } from '@/types/solutions';
-
-interface Repository {
-  id: string;
-  name: string;
-  description: string;
-  github_url: string;
-  demo_url: string | null;
-  tags: string[] | null;
-  created_at: string;
-}
+import {
+  fetchActiveRepositories,
+  type RepositoryRow,
+} from '@/lib/repositories';
 
 const GITHUB_REPOS_URL =
   'https://api.github.com/orgs/Monynha-Softwares/repos?per_page=100';
@@ -53,21 +46,9 @@ const Projects = () => {
     data: repositories = [],
     isLoading: repositoriesLoading,
     isError: repositoriesError,
-  } = useQuery<Repository[]>({
+  } = useQuery<RepositoryRow[]>({
     queryKey: ['repositories'],
-    queryFn: async () => {
-      const { data, error } = await supabase
-        .from('repositories')
-        .select('*')
-        .eq('active', true)
-        .order('created_at', { ascending: false });
-
-      if (error) {
-        throw new Error(error.message);
-      }
-
-      return (data ?? []) as Repository[];
-    },
+    queryFn: fetchActiveRepositories,
   });
 
   const {


### PR DESCRIPTION
## Summary
- centralize Supabase client creation with server/service helpers and environment fallbacks
- add typed data access modules and update pages/components to use them, including an admin API route relying on the service role
- add a Supabase policy validation script and npm script entry to exercise RLS scenarios

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9d4ca3d8c8322929a6bb5e8fa7f27