### PR TITLE
feat: enhance About page with dynamic content

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -99,6 +99,9 @@
     "valuesDescription": "The principles that guide everything we do and every solution we create.",
     "impactTitle": "Our Impact",
     "impactDescription": "Numbers that reflect our commitment to excellence and client success.",
+    "statsLoading": "We're gathering updated numbers...",
+    "statsError": "We couldn't load our latest stats right now. Please check back soon.",
+    "statsEmpty": "Stay tuned for new milestones from our team.",
     "valuesList": {
       "innovation": "Innovation First",
       "innovationDesc": "We leverage cutting-edge AI and modern technologies to create solutions that push boundaries and deliver exceptional results.",
@@ -114,7 +117,10 @@
       "satisfaction": "Client Satisfaction",
       "experience": "Years Experience",
       "support": "Support Available"
-    }
+    },
+    "ctaTitle": "Let's build the next chapter of your business together",
+    "ctaDescription": "Share your goals with us and discover how tailored AI solutions can accelerate your growth.",
+    "ctaButton": "Talk to our team"
   },
   "blog": {
     "title": "Insights & Updates",
@@ -202,7 +208,8 @@
     "loading": "Loading our amazing team...",
     "error": "We're having trouble loading our team information. Please try again later.",
     "description": "Passionate experts dedicated to delivering innovative AI solutions that transform your business.",
-    "linkedin": "LinkedIn"
+    "linkedin": "LinkedIn",
+    "empty": "Our team lineup will be updated soon."
   },
   "projects": {
     "title": "Projects <0>Open Source</0>",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -99,6 +99,9 @@
     "valuesDescription": "Principios que guían todo lo que hacemos y cada solución que creamos.",
     "impactTitle": "Nuestro Impacto",
     "impactDescription": "Números que reflejan nuestro compromiso con la excelencia y el éxito de los clientes.",
+    "statsLoading": "Estamos actualizando nuestras métricas...",
+    "statsError": "No pudimos cargar las últimas estadísticas. Vuelve a intentarlo pronto.",
+    "statsEmpty": "Pronto compartiremos nuevos hitos de nuestro equipo.",
     "valuesList": {
       "innovation": "Innovación Primero",
       "innovationDesc": "Aprovechamos IA y tecnologías modernas para crear soluciones que superan límites y entregan resultados excepcionales.",
@@ -114,7 +117,10 @@
       "satisfaction": "Satisfacción del Cliente",
       "experience": "Años de Experiencia",
       "support": "Soporte Disponible"
-    }
+    },
+    "ctaTitle": "Construyamos juntos el próximo capítulo de tu negocio",
+    "ctaDescription": "Cuéntanos tus objetivos y descubre cómo soluciones de IA a medida pueden acelerar tu crecimiento.",
+    "ctaButton": "Habla con nuestro equipo"
   },
   "blog": {
     "title": "Noticias e Ideas",
@@ -200,7 +206,8 @@
     "loading": "Cargando a nuestro increíble equipo...",
     "error": "Estamos teniendo problemas para cargar la información del equipo. Por favor, inténtalo más tarde.",
     "description": "Expertos apasionados dedicados a ofrecer soluciones innovadoras de IA que transforman tu negocio.",
-    "linkedin": "LinkedIn"
+    "linkedin": "LinkedIn",
+    "empty": "Pronto presentaremos a todo nuestro equipo."
   },
   "projects": {
     "title": "Proyectos <0>Open Source</0>",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -99,6 +99,9 @@
     "valuesDescription": "Les principes qui guident tout ce que nous faisons et chaque solution que nous créons.",
     "impactTitle": "Notre impact",
     "impactDescription": "Des chiffres qui reflètent notre engagement envers l'excellence et la réussite de nos clients.",
+    "statsLoading": "Nous mettons à jour nos chiffres...",
+    "statsError": "Impossible de charger nos dernières statistiques pour le moment. Réessayez bientôt.",
+    "statsEmpty": "Nous partagerons bientôt de nouveaux jalons de notre équipe.",
     "valuesList": {
       "innovation": "Innovation avant tout",
       "innovationDesc": "Nous utilisons l'IA et les technologies modernes pour créer des solutions qui repoussent les limites et offrent des résultats remarquables.",
@@ -114,7 +117,10 @@
       "satisfaction": "Satisfaction client",
       "experience": "Années d'expérience",
       "support": "Support disponible"
-    }
+    },
+    "ctaTitle": "Construisons ensemble le prochain chapitre de votre entreprise",
+    "ctaDescription": "Parlez-nous de vos objectifs et découvrez comment des solutions IA sur mesure peuvent accélérer votre croissance.",
+    "ctaButton": "Parler à notre équipe"
   },
   "blog": {
     "title": "Idées et Actualités",
@@ -200,7 +206,8 @@
     "loading": "Chargement de notre équipe incroyable...",
     "error": "Nous rencontrons des difficultés pour charger les informations de l'équipe. Veuillez réessayer plus tard.",
     "description": "Des experts passionnés dédiés à fournir des solutions IA innovantes qui transforment votre entreprise.",
-    "linkedin": "LinkedIn"
+    "linkedin": "LinkedIn",
+    "empty": "Nous présenterons bientôt toute notre équipe."
   },
   "projects": {
     "title": "Projets <0>Open Source</0>",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -99,6 +99,9 @@
     "valuesDescription": "Princípios que guiam tudo o que fazemos e cada solução que criamos.",
     "impactTitle": "Nosso Impacto",
     "impactDescription": "Números que refletem nosso compromisso com excelência e sucesso dos clientes.",
+    "statsLoading": "Estamos atualizando nossos números...",
+    "statsError": "Não conseguimos carregar as estatísticas agora. Tente novamente em breve.",
+    "statsEmpty": "Em breve compartilharemos novos marcos da equipe.",
     "valuesList": {
       "innovation": "Inovação em Primeiro Lugar",
       "innovationDesc": "Usamos IA e tecnologias modernas para criar soluções que superam limites e entregam resultados excepcionais.",
@@ -114,7 +117,10 @@
       "satisfaction": "Satisfação dos Clientes",
       "experience": "Anos de Experiência",
       "support": "Suporte Disponível"
-    }
+    },
+    "ctaTitle": "Vamos construir o próximo capítulo do seu negócio juntos",
+    "ctaDescription": "Conte seus objetivos para descobrir como soluções de IA sob medida podem acelerar o seu crescimento.",
+    "ctaButton": "Fale com nosso time"
   },
   "blog": {
     "title": "Insights e Novidades",
@@ -200,7 +206,8 @@
     "loading": "Carregando nossa equipe incrível...",
     "error": "Estamos tendo problemas para carregar as informações da equipe. Por favor, tente novamente mais tarde.",
     "description": "Especialistas apaixonados dedicados a entregar soluções inovadoras de IA que transformam seu negócio.",
-    "linkedin": "LinkedIn"
+    "linkedin": "LinkedIn",
+    "empty": "Em breve apresentaremos nossa equipe completa."
   },
   "projects": {
     "title": "Projetos <0>Open Source</0>",

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,9 +1,71 @@
-import { Card, CardContent } from '@/components/ui/card';
+import { useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { Brain, Target, Users, Award } from 'lucide-react';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
-import { Brain, Target, Users, Award } from 'lucide-react';
+import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { supabase } from '@/integrations/supabase';
 import { useTranslation } from 'react-i18next';
-import { useMemo } from 'react';
+
+interface TeamMemberCard {
+  id: string;
+  name: string;
+  role: string;
+  image_url: string | null;
+}
+
+interface AboutStat {
+  number: string;
+  label: string;
+}
+
+const normalizeAboutStats = (value: unknown): AboutStat[] => {
+  if (!value) {
+    return [];
+  }
+
+  let parsedValue: unknown = value;
+
+  if (typeof parsedValue === 'string') {
+    try {
+      parsedValue = JSON.parse(parsedValue);
+    } catch {
+      return [];
+    }
+  }
+
+  if (Array.isArray(parsedValue)) {
+    return parsedValue
+      .map((item) => {
+        if (item && typeof item === 'object') {
+          const record = item as Record<string, unknown>;
+          const number = record.number;
+          const label = record.label;
+
+          if ((typeof number === 'string' || typeof number === 'number') && typeof label === 'string') {
+            return {
+              number: number.toString(),
+              label,
+            } satisfies AboutStat;
+          }
+        }
+        return null;
+      })
+      .filter((stat): stat is AboutStat => stat !== null);
+  }
+
+  if (typeof parsedValue === 'object' && parsedValue !== null) {
+    const record = parsedValue as Record<string, unknown>;
+    if (Array.isArray(record.stats)) {
+      return normalizeAboutStats(record.stats);
+    }
+  }
+
+  return [];
+};
 
 const About = () => {
   const { t } = useTranslation();
@@ -33,15 +95,47 @@ const About = () => {
     [t]
   );
 
-  const stats = useMemo(
-    () => [
-      { number: '50+', label: t('about.stats.projects') },
-      { number: '100%', label: t('about.stats.satisfaction') },
-      { number: '5+', label: t('about.stats.experience') },
-      { number: '24/7', label: t('about.stats.support') },
-    ],
+  const storyTimeline = useMemo(
+    () => [t('about.story.p1'), t('about.story.p2'), t('about.story.p3')],
     [t]
   );
+
+  const {
+    data: teamMembers,
+    isLoading: isTeamLoading,
+    error: teamError,
+  } = useQuery({
+    queryKey: ['team-members', 'about'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('team_members')
+        .select('id, name, role, image_url')
+        .eq('active', true)
+        .order('created_at', { ascending: true });
+
+      if (error) throw error;
+      return (data ?? []) as TeamMemberCard[];
+    },
+  });
+
+  const {
+    data: aboutStats,
+    isLoading: isStatsLoading,
+    error: statsError,
+  } = useQuery({
+    queryKey: ['site-settings', 'about-stats'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('site_settings')
+        .select('value')
+        .eq('key', 'about_stats')
+        .maybeSingle();
+
+      if (error) throw error;
+
+      return normalizeAboutStats(data?.value);
+    },
+  });
 
   return (
     <Layout>
@@ -66,15 +160,56 @@ const About = () => {
         </div>
       </section>
 
-      {/* Mission Section */}
-      <section className="py-24 bg-gradient-hero text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl lg:text-4xl font-bold mb-8">
-            {t('about.missionTitle')}
-          </h2>
-          <p className="text-xl text-blue-100 leading-relaxed">
-            {t('about.mission')}
-          </p>
+      {/* Mission & Values Section */}
+      <section className="py-24 bg-neutral-900 text-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-start">
+            <div className="space-y-8">
+              <div>
+                <span className="inline-flex items-center px-4 py-2 text-sm font-medium uppercase tracking-widest rounded-full bg-white/10 text-blue-100">
+                  {t('about.missionTitle')}
+                </span>
+              </div>
+              <h2 className="text-3xl lg:text-4xl font-bold leading-tight">
+                {t('about.description')}
+              </h2>
+              <p className="text-lg text-blue-100/90 leading-relaxed">
+                {t('about.mission')}
+              </p>
+            </div>
+            <div>
+              <div className="mb-10">
+                <h3 className="text-xl font-semibold uppercase tracking-widest text-blue-100 mb-2">
+                  {t('about.valuesTitle')}
+                </h3>
+                <p className="text-blue-100/80">
+                  {t('about.valuesDescription')}
+                </p>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+                {values.map((value, index) => (
+                  <Card
+                    key={index}
+                    className="border border-white/10 bg-white/10 backdrop-blur-md transition-all duration-300 hover:bg-white/20 hover:shadow-lg rounded-2xl"
+                  >
+                    <CardContent className="p-6 space-y-4">
+                      <div className="w-12 h-12 rounded-2xl bg-gradient-brand flex items-center justify-center">
+                        <value.icon className="h-6 w-6 text-white" />
+                      </div>
+                      <div>
+                        <h4 className="text-lg font-semibold text-white mb-2">
+                          {value.title}
+                        </h4>
+                        <p className="text-sm text-blue-100/90 leading-relaxed">
+                          {value.description}
+                        </p>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </div>
+          </div>
         </div>
       </section>
 
@@ -82,84 +217,175 @@ const About = () => {
       <section className="py-24 bg-white">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
-            <div>
-              <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-6">
-                {t('about.storyTitle')}
-              </h2>
-              <div className="space-y-6 text-lg text-neutral-600">
-                <p>{t('about.story.p1')}</p>
-                <p>{t('about.story.p2')}</p>
-                <p>{t('about.story.p3')}</p>
+            <div className="order-2 lg:order-1 space-y-8">
+              <div>
+                <span className="inline-flex items-center px-4 py-2 text-sm font-medium uppercase tracking-widest rounded-full bg-gradient-brand text-white">
+                  {t('about.storyTitle')}
+                </span>
               </div>
+              <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 leading-tight">
+                {t('about.title')}
+              </h2>
+              <ul className="space-y-6">
+                {storyTimeline.map((story, index) => (
+                  <li key={index} className="flex items-start gap-4">
+                    <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-brand text-white font-semibold">
+                      {(index + 1).toString().padStart(2, '0')}
+                    </span>
+                    <p className="text-lg text-neutral-600 leading-relaxed">
+                      {story}
+                    </p>
+                  </li>
+                ))}
+              </ul>
             </div>
-            <div>
-              <Card className="border-0 shadow-soft-lg rounded-2xl overflow-hidden">
-                <img
-                  src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80"
-                  alt="Team collaboration"
-                  loading="lazy"
-                  className="w-full h-80 object-cover"
-                />
-                <div className="h-2 bg-gradient-brand"></div>
+            <div className="order-1 lg:order-2">
+              <Card className="border-0 shadow-soft-lg rounded-3xl overflow-hidden">
+                <div className="relative h-80">
+                  <img
+                    src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80"
+                    alt="Team collaboration"
+                    loading="lazy"
+                    className="w-full h-full object-cover"
+                  />
+                  <div className="absolute inset-0 bg-gradient-to-t from-neutral-900/40 via-transparent" aria-hidden="true"></div>
+                </div>
               </Card>
             </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Values Section */}
-      <section className="py-24 bg-neutral-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
-              {t('about.valuesTitle')}
-            </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
-              {t('about.valuesDescription')}
-            </p>
-          </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
-            {values.map((value, index) => (
-              <Card
-                key={index}
-                className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl"
-              >
-                <CardContent className="p-8 text-center">
-                  <div className="w-16 h-16 bg-gradient-brand rounded-2xl flex items-center justify-center mx-auto mb-6">
-                    <value.icon className="h-8 w-8 text-white" />
-                  </div>
-                  <h3 className="text-xl font-semibold text-neutral-900 mb-4">
-                    {value.title}
-                  </h3>
-                  <p className="text-neutral-600">{value.description}</p>
-                </CardContent>
-              </Card>
-            ))}
           </div>
         </div>
       </section>
 
       {/* Stats Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-neutral-50">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
               {t('about.impactTitle')}
             </h2>
-            <p className="text-xl text-neutral-600">
+            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
               {t('about.impactDescription')}
             </p>
           </div>
-          <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
-            {stats.map((stat, index) => (
-              <div key={index} className="text-center">
-                <div className="text-4xl lg:text-5xl font-bold text-transparent bg-clip-text bg-gradient-brand mb-2">
-                  {stat.number}
-                </div>
-                <div className="text-neutral-600 font-medium">{stat.label}</div>
-              </div>
-            ))}
+          {isStatsLoading ? (
+            <div
+              className="grid grid-cols-2 lg:grid-cols-4 gap-8"
+              role="status"
+              aria-live="polite"
+            >
+              <span className="sr-only">{t('about.statsLoading')}</span>
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-32 rounded-2xl bg-white shadow-soft animate-pulse"
+                  aria-hidden="true"
+                ></div>
+              ))}
+            </div>
+          ) : statsError ? (
+            <p className="text-center text-neutral-500">{t('about.statsError')}</p>
+          ) : aboutStats && aboutStats.length > 0 ? (
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
+              {aboutStats.map((stat, index) => (
+                <Card
+                  key={`${stat.label}-${index}`}
+                  className="border-0 shadow-soft rounded-2xl bg-white text-center p-8"
+                >
+                  <div className="text-4xl lg:text-5xl font-bold text-transparent bg-clip-text bg-gradient-brand mb-2">
+                    {stat.number}
+                  </div>
+                  <div className="text-neutral-600 font-medium">{stat.label}</div>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <p className="text-center text-neutral-500">{t('about.statsEmpty')}</p>
+          )}
+        </div>
+      </section>
+
+      {/* Team Section */}
+      <section className="py-24 bg-white">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="text-center mb-16">
+            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+              {t('team.title')}
+            </h2>
+            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+              {t('team.description')}
+            </p>
           </div>
+          {isTeamLoading ? (
+            <div
+              className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8"
+              role="status"
+              aria-live="polite"
+            >
+              <span className="sr-only">{t('team.loading')}</span>
+              {Array.from({ length: 4 }).map((_, index) => (
+                <Card
+                  key={index}
+                  className="border-0 shadow-soft rounded-2xl p-8 animate-pulse h-full"
+                  aria-hidden="true"
+                >
+                  <div className="flex flex-col items-center gap-4">
+                    <div className="w-24 h-24 rounded-full bg-neutral-200" />
+                    <div className="w-32 h-6 rounded bg-neutral-200" />
+                    <div className="w-24 h-4 rounded bg-neutral-200" />
+                  </div>
+                </Card>
+              ))}
+            </div>
+          ) : teamError ? (
+            <p className="text-center text-neutral-500">{t('team.error')}</p>
+          ) : teamMembers && teamMembers.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+              {teamMembers.map((member) => (
+                <Card
+                  key={member.id}
+                  className="border-0 shadow-soft hover:shadow-soft-lg transition-all duration-200 rounded-2xl"
+                >
+                  <CardContent className="p-8 text-center space-y-4">
+                    <Avatar className="w-24 h-24 mx-auto">
+                      <AvatarImage
+                        src={member.image_url ?? undefined}
+                        alt={member.name}
+                      />
+                      <AvatarFallback className="bg-gradient-hero text-white text-xl font-semibold">
+                        {member.name
+                          .split(' ')
+                          .map((n) => n[0])
+                          .join('')}
+                      </AvatarFallback>
+                    </Avatar>
+                    <div className="space-y-1">
+                      <h3 className="text-xl font-semibold text-neutral-900">
+                        {member.name}
+                      </h3>
+                      <p className="text-brand-blue font-medium">{member.role}</p>
+                    </div>
+                  </CardContent>
+                </Card>
+              ))}
+            </div>
+          ) : (
+            <p className="text-center text-neutral-500">{t('team.empty')}</p>
+          )}
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <section className="py-24 bg-gradient-hero text-white">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-6">
+          <h2 className="text-3xl lg:text-4xl font-bold">
+            {t('about.ctaTitle')}
+          </h2>
+          <p className="text-xl text-blue-100">
+            {t('about.ctaDescription')}
+          </p>
+          <Button asChild size="lg" className="rounded-full px-10">
+            <Link to="/contact">{t('about.ctaButton')}</Link>
+          </Button>
         </div>
       </section>
     </Layout>


### PR DESCRIPTION
## Summary
- restructure the About layout with mission, story, stats, team, and CTA sections
- load company stats from `site_settings.about_stats` and render active team members from Supabase
- add localized copy for stats messaging, CTA, and empty team states in all supported languages

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9e8afd2ac83228f3bd2c14c0a58b6