### PR TITLE
Add reusable newsletter form and ensure RLS

### DIFF
--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -1,0 +1,160 @@
+import { useState } from 'react';
+import { supabase } from '@/integrations/supabase';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { cn } from '@/lib/utils';
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type Message = {
+  title: string;
+  description?: string;
+};
+
+type NewsletterFormMessages = {
+  success?: Message;
+  invalidEmail?: Message;
+  duplicateEmail?: Message;
+  error?: Message;
+};
+
+type NewsletterFormLabels = {
+  submit?: string;
+  submitting?: string;
+};
+
+interface NewsletterFormProps {
+  placeholder?: string;
+  className?: string;
+  inputClassName?: string;
+  buttonClassName?: string;
+  labels?: NewsletterFormLabels;
+  messages?: NewsletterFormMessages;
+  onSuccess?: (email: string) => void;
+}
+
+const DEFAULT_LABELS: Required<NewsletterFormLabels> = {
+  submit: 'Subscribe',
+  submitting: 'Subscribing...',
+};
+
+const DEFAULT_MESSAGES: Required<NewsletterFormMessages> = {
+  success: {
+    title: 'Subscription confirmed!',
+    description: 'You will start receiving our latest updates soon.',
+  },
+  invalidEmail: {
+    title: 'Invalid email',
+    description: 'Please enter a valid email address before subscribing.',
+  },
+  duplicateEmail: {
+    title: 'Already subscribed',
+    description: 'This email is already on our newsletter list.',
+  },
+  error: {
+    title: 'Something went wrong',
+    description: 'We could not complete your subscription. Please try again.',
+  },
+};
+
+const NewsletterForm = ({
+  placeholder = 'your@email.com',
+  className,
+  inputClassName,
+  buttonClassName,
+  labels,
+  messages,
+  onSuccess,
+}: NewsletterFormProps) => {
+  const [email, setEmail] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  const { submit, submitting } = { ...DEFAULT_LABELS, ...labels };
+  const {
+    success,
+    invalidEmail,
+    duplicateEmail,
+    error,
+  } = { ...DEFAULT_MESSAGES, ...messages };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail || !EMAIL_REGEX.test(trimmedEmail)) {
+      toast({
+        ...invalidEmail,
+        variant: 'destructive',
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const { error: insertError } = await supabase
+        .from('newsletter_subscribers')
+        .insert([{ email: trimmedEmail }]);
+
+      if (insertError) {
+        const normalizedMessage = insertError.message?.toLowerCase() ?? '';
+        const duplicateViolation =
+          insertError.code === '23505' ||
+          insertError.code === '409' ||
+          normalizedMessage.includes('duplicate');
+
+        if (duplicateViolation) {
+          toast({
+            ...duplicateEmail,
+            variant: 'destructive',
+          });
+        } else {
+          toast({
+            ...error,
+            variant: 'destructive',
+          });
+        }
+        return;
+      }
+
+      toast(success);
+      setEmail('');
+      onSuccess?.(trimmedEmail);
+    } catch (submitError) {
+      console.error('Newsletter subscription error:', submitError);
+      toast({
+        ...error,
+        variant: 'destructive',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className={cn('flex flex-col sm:flex-row gap-4', className)}>
+      <Input
+        type="email"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        placeholder={placeholder}
+        autoComplete="email"
+        disabled={isSubmitting}
+        className={cn('flex-1', inputClassName)}
+        required
+      />
+      <Button
+        type="submit"
+        disabled={isSubmitting}
+        className={buttonClassName}
+      >
+        {isSubmitting ? submitting : submit}
+      </Button>
+    </form>
+  );
+};
+
+export default NewsletterForm;

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -1,74 +1,13 @@
 import { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { supabase } from '@/integrations/supabase';
-import { useToast } from '@/hooks/use-toast';
+import NewsletterForm from '@/components/NewsletterForm';
 import { Mail, CheckCircle } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 const NewsletterSection = () => {
   const { t } = useTranslation();
-  const [email, setEmail] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
   const [isSubscribed, setIsSubscribed] = useState(false);
-  const { toast } = useToast();
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsSubmitting(true);
-
-    // Basic email validation
-    if (!email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
-      toast({
-        title: t('newsletterSection.invalidEmailTitle'),
-        description: t('newsletterSection.invalidEmailDescription'),
-        variant: 'destructive',
-      });
-      setIsSubmitting(false);
-      return;
-    }
-
-    try {
-      const { error } = await supabase
-        .from('newsletter_subscribers')
-        .insert([{ email: email.trim() }]);
-
-      if (error) {
-        if (error.code === '23505') {
-          // Unique constraint violation
-          toast({
-            title: t('newsletterSection.alreadySubscribedTitle'),
-            description: t('newsletterSection.alreadySubscribedDescription'),
-            variant: 'destructive',
-          });
-        } else {
-          toast({
-            title: t('newsletterSection.errorTitle'),
-            description: t('newsletterSection.errorDescription'),
-            variant: 'destructive',
-          });
-        }
-        setIsSubmitting(false);
-        return;
-      }
-
-      setIsSubscribed(true);
-      toast({
-        title: t('newsletterSection.successTitle'),
-        description: t('newsletterSection.successDescription'),
-      });
-    } catch (error) {
-      console.error('Newsletter subscription error:', error);
-      toast({
-        title: t('newsletterSection.errorTitle'),
-        description: t('newsletterSection.errorDescription'),
-        variant: 'destructive',
-      });
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
 
   if (isSubscribed) {
     return (
@@ -86,7 +25,6 @@ const NewsletterSection = () => {
           <Button
             onClick={() => {
               setIsSubscribed(false);
-              setEmail('');
             }}
             className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl"
           >
@@ -114,27 +52,35 @@ const NewsletterSection = () => {
               {t('newsletterSection.description')}
             </p>
 
-            <form onSubmit={handleSubmit} className="max-w-md mx-auto">
-              <div className="flex flex-col sm:flex-row gap-4">
-                <Input
-                  type="email"
-                  placeholder={t('newsletterSection.placeholder')}
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="flex-1 rounded-xl border-white/30 bg-white/20 text-white placeholder:text-white/70 focus:border-white focus:ring-white"
-                  required
-                />
-                <Button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-3 rounded-xl whitespace-nowrap"
-                >
-                  {isSubmitting
-                    ? t('newsletterSection.subscribing')
-                    : t('newsletterSection.subscribe')}
-                </Button>
-              </div>
-            </form>
+            <NewsletterForm
+              className="max-w-md mx-auto"
+              inputClassName="rounded-xl border-white/30 bg-white/20 text-white placeholder:text-white/70 focus:border-white focus:ring-white"
+              buttonClassName="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-3 rounded-xl whitespace-nowrap"
+              placeholder={t('newsletterSection.placeholder')}
+              labels={{
+                submit: t('newsletterSection.subscribe'),
+                submitting: t('newsletterSection.subscribing'),
+              }}
+              messages={{
+                success: {
+                  title: t('newsletterSection.successTitle'),
+                  description: t('newsletterSection.successDescription'),
+                },
+                invalidEmail: {
+                  title: t('newsletterSection.invalidEmailTitle'),
+                  description: t('newsletterSection.invalidEmailDescription'),
+                },
+                duplicateEmail: {
+                  title: t('newsletterSection.alreadySubscribedTitle'),
+                  description: t('newsletterSection.alreadySubscribedDescription'),
+                },
+                error: {
+                  title: t('newsletterSection.errorTitle'),
+                  description: t('newsletterSection.errorDescription'),
+                },
+              }}
+              onSuccess={() => setIsSubscribed(true)}
+            />
 
             <p className="text-sm text-blue-200 mt-4">
               {t('newsletterSection.privacy')}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
+import NewsletterForm from '@/components/NewsletterForm';
 import NewsletterSection from '@/components/NewsletterSection';
 import { ArrowRight, Clock, User } from 'lucide-react';
 import { supabase } from '@/integrations/supabase';
@@ -286,15 +287,35 @@ const Blog = () => {
           <p className="text-xl text-blue-100 mb-8">
             {t('blog.newsletter.description')}
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center max-w-md mx-auto">
-            <input
-              type="email"
+          <div className="max-w-md mx-auto">
+            <NewsletterForm
+              className="flex flex-col sm:flex-row gap-4 justify-center"
+              inputClassName="px-4 py-3 rounded-xl border-0 text-neutral-900 placeholder-neutral-500 focus:ring-2 focus:ring-white focus:outline-none"
+              buttonClassName="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl transition-all ease-in-out duration-300"
               placeholder={t('blog.newsletter.placeholder')}
-              className="flex-1 px-4 py-3 rounded-xl border-0 text-neutral-900 placeholder-neutral-500 focus:ring-2 focus:ring-white focus:outline-none"
+              labels={{
+                submit: t('blog.newsletter.subscribe'),
+                submitting: t('newsletterSection.subscribing'),
+              }}
+              messages={{
+                success: {
+                  title: t('newsletterSection.successTitle'),
+                  description: t('newsletterSection.successDescription'),
+                },
+                invalidEmail: {
+                  title: t('newsletterSection.invalidEmailTitle'),
+                  description: t('newsletterSection.invalidEmailDescription'),
+                },
+                duplicateEmail: {
+                  title: t('newsletterSection.alreadySubscribedTitle'),
+                  description: t('newsletterSection.alreadySubscribedDescription'),
+                },
+                error: {
+                  title: t('newsletterSection.errorTitle'),
+                  description: t('newsletterSection.errorDescription'),
+                },
+              }}
             />
-            <Button className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl transition-all ease-in-out duration-300">
-              {t('blog.newsletter.subscribe')}
-            </Button>
           </div>
         </div>
       </section>

--- a/supabase/migrations/20250801093000-ensure-newsletter-rls.sql
+++ b/supabase/migrations/20250801093000-ensure-newsletter-rls.sql
@@ -1,0 +1,15 @@
+-- Ensure RLS policies for newsletter subscribers allow public inserts
+ALTER TABLE public.newsletter_subscribers
+  ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anyone can subscribe to newsletter" ON public.newsletter_subscribers;
+CREATE POLICY "Anyone can subscribe to newsletter"
+ON public.newsletter_subscribers
+FOR INSERT
+WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Only admins can view newsletter subscribers" ON public.newsletter_subscribers;
+CREATE POLICY "Only admins can view newsletter subscribers"
+ON public.newsletter_subscribers
+FOR SELECT
+USING (public.is_admin(auth.uid()));


### PR DESCRIPTION
## Summary
- add a reusable `NewsletterForm` component that handles Supabase inserts, validation, and toast feedback
- update the newsletter section and blog CTA to consume the shared form component
- reinforce Supabase RLS policies so anyone can subscribe while only admins can read the newsletter list

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c9f097ca108322b5588a8396bed0d2