### PR TITLE
Add reusable newsletter form and newsletter RLS updates

### DIFF
--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -1,0 +1,140 @@
+import { FormEvent, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { supabase } from '@/integrations/supabase';
+import { cn } from '@/lib/utils';
+
+type SubmissionStatus = 'idle' | 'success' | 'error';
+
+type NewsletterFormMessages = {
+  success: string;
+  invalid: string;
+  duplicate: string;
+  error: string;
+};
+
+const DEFAULT_MESSAGES: NewsletterFormMessages = {
+  success: 'You are now subscribed to the newsletter!',
+  invalid: 'Please enter a valid email address.',
+  duplicate: 'This email is already subscribed to the newsletter.',
+  error: 'We could not process your subscription. Please try again later.',
+};
+
+interface NewsletterFormProps {
+  placeholder?: string;
+  buttonLabel?: string;
+  loadingLabel?: string;
+  messages?: Partial<NewsletterFormMessages>;
+  wrapperClassName?: string;
+  formClassName?: string;
+  inputClassName?: string;
+  buttonClassName?: string;
+  messageClassName?: string;
+}
+
+const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const NewsletterForm = ({
+  placeholder,
+  buttonLabel = 'Subscribe',
+  loadingLabel = 'Subscribing...',
+  messages,
+  wrapperClassName,
+  formClassName,
+  inputClassName,
+  buttonClassName,
+  messageClassName,
+}: NewsletterFormProps) => {
+  const [email, setEmail] = useState('');
+  const [status, setStatus] = useState<SubmissionStatus>('idle');
+  const [feedback, setFeedback] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const mergedMessages = { ...DEFAULT_MESSAGES, ...messages } satisfies NewsletterFormMessages;
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    const trimmedEmail = email.trim();
+
+    if (!trimmedEmail || !emailRegex.test(trimmedEmail)) {
+      setStatus('error');
+      setFeedback(mergedMessages.invalid);
+      return;
+    }
+
+    setIsSubmitting(true);
+    setFeedback('');
+    setStatus('idle');
+
+    try {
+      const { error } = await supabase
+        .from('newsletter_subscribers')
+        .insert([{ email: trimmedEmail }]);
+
+      if (error) {
+        if (error.code === '23505') {
+          setStatus('error');
+          setFeedback(mergedMessages.duplicate);
+          return;
+        }
+
+        console.error('Newsletter subscription error:', error);
+        setStatus('error');
+        setFeedback(mergedMessages.error);
+        return;
+      }
+
+      setEmail('');
+      setStatus('success');
+      setFeedback(mergedMessages.success);
+    } catch (err) {
+      console.error('Newsletter subscription error:', err);
+      setStatus('error');
+      setFeedback(mergedMessages.error);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const showFeedback = status !== 'idle' && feedback;
+
+  return (
+    <div className={cn('w-full', wrapperClassName)}>
+      <form
+        onSubmit={handleSubmit}
+        className={cn('flex flex-col sm:flex-row gap-4', formClassName)}
+      >
+        <Input
+          type="email"
+          value={email}
+          onChange={(event) => setEmail(event.target.value)}
+          placeholder={placeholder}
+          className={cn('flex-1 h-12 rounded-xl', inputClassName)}
+          autoComplete="email"
+          disabled={isSubmitting}
+          required
+        />
+        <Button
+          type="submit"
+          className={cn('rounded-xl px-6 py-3 font-semibold', buttonClassName)}
+          disabled={isSubmitting}
+        >
+          {isSubmitting ? loadingLabel : buttonLabel}
+        </Button>
+      </form>
+
+      {showFeedback && (
+        <Alert
+          variant={status === 'success' ? 'default' : 'destructive'}
+          className={cn('mt-4', messageClassName)}
+        >
+          <AlertDescription>{feedback}</AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+};
+
+export default NewsletterForm;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -135,7 +135,12 @@
       "title": "Stay in the Loop",
       "description": "Subscribe to our newsletter for the latest insights on AI, software development, and business automation.",
       "placeholder": "Enter your email",
-      "subscribe": "Subscribe"
+      "subscribe": "Subscribe",
+      "subscribing": "Subscribing...",
+      "successMessage": "You're on the list! We'll keep you posted with our latest insights.",
+      "invalidEmail": "Please enter a valid email address.",
+      "duplicateEmail": "This email is already subscribed to our newsletter.",
+      "errorMessage": "We couldn't add you this time. Please try again later."
     }
   },
   "contact": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -133,7 +133,12 @@
       "title": "Mantente Informado",
       "description": "Suscríbete a nuestro boletín para recibir novedades sobre IA, desarrollo de software y automatización.",
       "placeholder": "Ingresa tu correo",
-      "subscribe": "Suscribirse"
+      "subscribe": "Suscribirse",
+      "subscribing": "Suscribiendo...",
+      "successMessage": "¡Ya estás en la lista! Te enviaremos nuestras novedades pronto.",
+      "invalidEmail": "Por favor ingresa un correo electrónico válido.",
+      "duplicateEmail": "Este correo ya está suscrito a nuestro boletín.",
+      "errorMessage": "No pudimos completar tu suscripción. Inténtalo más tarde."
     }
   },
   "contact": {

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -133,7 +133,12 @@
       "title": "Restez informé",
       "description": "Abonnez-vous à notre newsletter pour recevoir les dernières infos sur l'IA, le développement logiciel et l'automatisation.",
       "placeholder": "Entrez votre email",
-      "subscribe": "S'abonner"
+      "subscribe": "S'abonner",
+      "subscribing": "Abonnement...",
+      "successMessage": "Vous êtes inscrit ! Nous vous enverrons très bientôt nos actualités.",
+      "invalidEmail": "Veuillez saisir une adresse e-mail valide.",
+      "duplicateEmail": "Cet e-mail est déjà inscrit à notre newsletter.",
+      "errorMessage": "Impossible de finaliser votre inscription. Veuillez réessayer plus tard."
     }
   },
   "contact": {

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -133,7 +133,12 @@
       "title": "Fique Atualizado",
       "description": "Assine nossa newsletter para receber novidades sobre IA, desenvolvimento de software e automação.",
       "placeholder": "Digite seu email",
-      "subscribe": "Inscrever"
+      "subscribe": "Inscrever",
+      "subscribing": "Inscrevendo...",
+      "successMessage": "Você entrou para a lista! Em breve enviaremos nossas novidades.",
+      "invalidEmail": "Por favor, insira um email válido.",
+      "duplicateEmail": "Este email já está inscrito na nossa newsletter.",
+      "errorMessage": "Não conseguimos concluir sua inscrição. Tente novamente mais tarde."
     }
   },
   "contact": {

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -3,10 +3,11 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
+import NewsletterForm from '@/components/NewsletterForm';
 import NewsletterSection from '@/components/NewsletterSection';
 import { ArrowRight, Clock, User } from 'lucide-react';
 import { supabase } from '@/integrations/supabase';
-import { useTranslation, Trans } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import {
@@ -286,16 +287,22 @@ const Blog = () => {
           <p className="text-xl text-blue-100 mb-8">
             {t('blog.newsletter.description')}
           </p>
-          <div className="flex flex-col sm:flex-row gap-4 justify-center max-w-md mx-auto">
-            <input
-              type="email"
-              placeholder={t('blog.newsletter.placeholder')}
-              className="flex-1 px-4 py-3 rounded-xl border-0 text-neutral-900 placeholder-neutral-500 focus:ring-2 focus:ring-white focus:outline-none"
-            />
-            <Button className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl transition-all ease-in-out duration-300">
-              {t('blog.newsletter.subscribe')}
-            </Button>
-          </div>
+          <NewsletterForm
+            placeholder={t('blog.newsletter.placeholder')}
+            buttonLabel={t('blog.newsletter.subscribe')}
+            loadingLabel={t('blog.newsletter.subscribing')}
+            messages={{
+              success: t('blog.newsletter.successMessage'),
+              invalid: t('blog.newsletter.invalidEmail'),
+              duplicate: t('blog.newsletter.duplicateEmail'),
+              error: t('blog.newsletter.errorMessage'),
+            }}
+            wrapperClassName="max-w-md mx-auto"
+            formClassName="flex flex-col sm:flex-row gap-4 justify-center"
+            inputClassName="flex-1 h-12 rounded-xl border-0 bg-white px-4 py-3 text-neutral-900 placeholder-neutral-500 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-0 focus-visible:outline-none"
+            buttonClassName="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl transition-all ease-in-out duration-300 h-auto"
+            messageClassName="bg-white/10 text-white border-white/20 text-center"
+          />
         </div>
       </section>
       <NewsletterSection />

--- a/supabase/migrations/20250801120000-update-newsletter-rls.sql
+++ b/supabase/migrations/20250801120000-update-newsletter-rls.sql
@@ -1,0 +1,19 @@
+-- Ensure newsletter_subscribers policies allow public inserts and admin-only reads
+ALTER TABLE public.newsletter_subscribers ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "Anyone can subscribe to newsletter" ON public.newsletter_subscribers;
+CREATE POLICY "Anyone can subscribe to newsletter"
+ON public.newsletter_subscribers
+FOR INSERT
+TO public
+WITH CHECK (true);
+
+DROP POLICY IF EXISTS "Only admins can view newsletter subscribers" ON public.newsletter_subscribers;
+CREATE POLICY "Only admins can view newsletter subscribers"
+ON public.newsletter_subscribers
+FOR SELECT
+TO authenticated
+USING (public.is_admin(auth.uid()));
+
+GRANT INSERT ON public.newsletter_subscribers TO anon, authenticated;
+GRANT SELECT ON public.newsletter_subscribers TO authenticated, service_role;


### PR DESCRIPTION
## Summary
- add a reusable `NewsletterForm` component that validates emails, inserts into Supabase, and surfaces success or error feedback
- wire the blog newsletter call-to-action to use the new component with localized copy
- extend locale strings for the new feedback messages and ensure newsletter RLS allows public inserts with admin-only reads

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c9f097ca108322b5588a8396bed0d2