### PR TITLE
Fetch project types from Supabase and tighten lead RLS

### DIFF
--- a/supabase/migrations/20250723120000-ensure-leads-rls.sql
+++ b/supabase/migrations/20250723120000-ensure-leads-rls.sql
@@ -1,0 +1,22 @@
+-- Ensure lead form policies allow anonymous submissions while restricting reads to admins
+DROP POLICY IF EXISTS "Anyone can submit leads" ON public.leads;
+DROP POLICY IF EXISTS "Only admins can view leads" ON public.leads;
+
+CREATE POLICY "Enable lead submissions for anonymous users"
+ON public.leads
+FOR INSERT
+TO anon, authenticated
+WITH CHECK (true);
+
+CREATE POLICY "Only admins can view leads"
+ON public.leads
+FOR SELECT
+TO authenticated
+USING (
+  EXISTS (
+    SELECT 1
+    FROM public.profiles
+    WHERE user_id = auth.uid()
+      AND role = 'admin'
+  )
+);


### PR DESCRIPTION
## Summary
- load contact form project type options from Supabase `site_settings` with a fallback list
- validate required contact fields on blur/submit and reset the form after inserting a lead
- refresh the `leads` RLS policies so anonymous users can submit while only admins can read

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9fc9f57548322a5418946a2af9bcb