### PR TITLE
Localize new UI content and add missing translations

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -109,7 +109,29 @@
       "description": "Let's discuss how our AI-powered solutions can streamline your operations and drive growth.",
       "getStarted": "Get Started Today"
     },
-    "learnMore": "Learn More"
+    "learnMore": "Learn More",
+    "fallbackSolutions": {
+      "boteco": {
+        "name": "Boteco Pro",
+        "description": "Complete restaurant and bar management system with AI-powered analytics and inventory management.",
+        "features": {
+          "orderManagement": "Order Management",
+          "inventoryTracking": "Inventory Tracking",
+          "analyticsDashboard": "Analytics Dashboard",
+          "staffManagement": "Staff Management"
+        }
+      },
+      "assistina": {
+        "name": "AssisTina AI",
+        "description": "Personalized AI assistant that learns your business needs and automates routine tasks.",
+        "features": {
+          "nlp": "Natural Language Processing",
+          "taskAutomation": "Task Automation",
+          "learning": "Learning Capabilities",
+          "integration": "Custom Integration"
+        }
+      }
+    }
   },
   "solutionsPage": {
     "title": "Our Software Solutions",
@@ -120,7 +142,12 @@
     "notFound": "Solution not found",
     "customTitle": "Need a Custom Solution?",
     "customDescription": "We also create bespoke software solutions tailored to your specific business needs. Let's discuss how we can build something unique for you.",
-    "discuss": "Discuss Custom Project"
+    "discuss": "Discuss Custom Project",
+    "metaTitle": "Our Software Solutions - Monynha Softwares Agency",
+    "loading": "Loading solutions...",
+    "error": "We couldn't load the solutions. Please try again later.",
+    "detailLoading": "Loading solution...",
+    "detailError": "We couldn't load this solution. Please try again later."
   },
   "about": {
     "title": "About Monynha Softwares Agency",
@@ -158,7 +185,8 @@
     },
     "ctaTitle": "Let's build the next chapter of your business together",
     "ctaDescription": "Share your goals with us and discover how tailored AI solutions can accelerate your growth.",
-    "ctaButton": "Talk to our team"
+    "ctaButton": "Talk to our team",
+    "metaTitle": "About Monynha Softwares Agency"
   },
   "blog": {
     "title": "Insights & Updates",
@@ -167,7 +195,13 @@
     "read": "Read Full Article",
     "readMore": "Read More",
     "categories": {
-      "all": "All"
+      "all": "All",
+      "aiInsights": "AI Insights",
+      "development": "Development",
+      "caseStudy": "Case Study",
+      "business": "Business",
+      "security": "Security",
+      "integration": "Integration"
     },
     "newsletter": {
       "title": "Stay in the Loop",
@@ -215,7 +249,10 @@
       "validationErrorDescription": "Please add your message before sending it.",
       "characters": "{{count}} / {{max}} characters",
       "authenticating": "Checking your session..."
-    }
+    },
+    "defaultCategory": "AI Insights",
+    "defaultAuthor": "Monynha Softwares Team",
+    "metaTitle": "Insights & Updates - Monynha Softwares Agency"
   },
   "contact": {
     "title": "Let's Build Something Amazing Together",
@@ -261,6 +298,15 @@
       "title": "Thank You!",
       "description": "We've received your message and will get back to you within 24 hours. Our team is excited to learn more about your project!",
       "another": "Send Another Message"
+    },
+    "metaTitle": "Contact - Monynha Softwares Agency",
+    "projectTypes": {
+      "customAssistant": "Custom AI Assistant",
+      "restaurant": "Restaurant Management System",
+      "automation": "Business Automation",
+      "legacy": "Legacy System Integration",
+      "consulting": "Consulting Services",
+      "other": "Other"
     }
   },
   "newsletterSection": {
@@ -297,10 +343,126 @@
     "liveDemo": "Live Demo",
     "like": "Like our projects?",
     "likeDescription": "Get in touch to craft a custom solution for your business.",
-    "contactUs": "Contact Us"
+    "contactUs": "Contact Us",
+    "metaTitle": "Open Source Projects - Monynha Softwares Agency",
+    "loadingProjects": "Loading projects...",
+    "errorProjects": "We couldn't load the projects right now.",
+    "errorProjectsPartial": "We couldn't load additional projects.",
+    "loadingSolutions": "Loading solutions...",
+    "errorSolutions": "We couldn't load the solutions list.",
+    "loadingGithub": "Loading GitHub projects...",
+    "errorGithub": "We couldn't load the GitHub projects."
   },
   "notFound": {
     "oops": "Oops! Page not found",
-    "returnHome": "Return to Home"
+    "returnHome": "Return to Home",
+    "metaTitle": "404 - Page Not Found",
+    "metaDescription": "The page you are looking for does not exist."
+  },
+  "auth": {
+    "backHome": "Back to home",
+    "subtitle": "Sign in or create your account",
+    "tabs": {
+      "signin": "Sign in",
+      "signup": "Create account"
+    },
+    "labels": {
+      "name": "Name",
+      "email": "Email",
+      "password": "Password"
+    },
+    "placeholders": {
+      "name": "Your name",
+      "email": "you@example.com"
+    },
+    "actions": {
+      "signIn": "Sign in",
+      "signingIn": "Signing in...",
+      "signUp": "Create account",
+      "signingUp": "Creating account..."
+    },
+    "passwordHint": "Minimum of 6 characters",
+    "toast": {
+      "signInSuccess": {
+        "title": "Signed in successfully!",
+        "description": "Welcome back!"
+      },
+      "signInError": {
+        "title": "Error signing in",
+        "description": "We couldn't sign you in. Please try again."
+      },
+      "signUpSuccess": {
+        "title": "Account created successfully!",
+        "description": "Check your email to confirm your account."
+      },
+      "signUpError": {
+        "title": "Error creating account",
+        "description": "We couldn't create your account. Please try again."
+      }
+    }
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "welcome": "Welcome, {{name}}",
+    "welcomeFallback": "Check your account information.",
+    "refresh": "Refresh",
+    "signOut": "Sign out",
+    "signingOut": "Signing out...",
+    "alertTitle": "Something went wrong",
+    "profile": {
+      "fallbackTitle": "User profile",
+      "emailUnavailable": "Email not available",
+      "name": "Name",
+      "email": "Email",
+      "role": "Role",
+      "updatedAt": "Last updated",
+      "roleAdmin": "Administrator",
+      "roleUser": "User"
+    },
+    "leads": {
+      "title": "Leads",
+      "description": "Contacts received from the public pages.",
+      "loading": "Loading lead data...",
+      "empty": "No leads recorded yet.",
+      "columns": {
+        "name": "Name",
+        "email": "Email",
+        "company": "Company",
+        "project": "Project",
+        "message": "Message",
+        "createdAt": "Submitted on"
+      }
+    },
+    "newsletter": {
+      "title": "Newsletter",
+      "description": "Subscribers registered in the email list.",
+      "loading": "Loading subscribers...",
+      "empty": "No subscribers found.",
+      "columns": {
+        "email": "Email",
+        "status": "Status",
+        "subscribedAt": "Subscribed on"
+      },
+      "status": {
+        "active": "Active",
+        "inactive": "Inactive"
+      }
+    },
+    "toast": {
+      "loadError": {
+        "title": "Error loading data"
+      },
+      "signOutSuccess": {
+        "title": "Session ended",
+        "description": "You have signed out successfully."
+      },
+      "signOutError": {
+        "title": "Error signing out",
+        "description": "We couldn't sign you out. Please try again."
+      }
+    },
+    "errors": {
+      "loadDashboard": "We couldn't load the dashboard."
+    }
   }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -109,7 +109,29 @@
       "description": "Hablemos de cómo nuestras soluciones con IA pueden optimizar tus operaciones y generar crecimiento.",
       "getStarted": "Empezar Hoy"
     },
-    "learnMore": "Saber Más"
+    "learnMore": "Saber Más",
+    "fallbackSolutions": {
+      "boteco": {
+        "name": "Boteco Pro",
+        "description": "Sistema completo de gestión para restaurantes y bares con analíticas impulsadas por IA y control de inventario.",
+        "features": {
+          "orderManagement": "Gestión de pedidos",
+          "inventoryTracking": "Seguimiento de inventario",
+          "analyticsDashboard": "Panel analítico",
+          "staffManagement": "Gestión de personal"
+        }
+      },
+      "assistina": {
+        "name": "AssisTina AI",
+        "description": "Asistente de IA personalizado que aprende las necesidades de tu negocio y automatiza tareas rutinarias.",
+        "features": {
+          "nlp": "Procesamiento de lenguaje natural",
+          "taskAutomation": "Automatización de tareas",
+          "learning": "Capacidades de aprendizaje",
+          "integration": "Integración personalizada"
+        }
+      }
+    }
   },
   "solutionsPage": {
     "title": "Nuestras Soluciones de Software",
@@ -120,7 +142,12 @@
     "notFound": "Solución no encontrada",
     "customTitle": "¿Necesitas una Solución Personalizada?",
     "customDescription": "También creamos soluciones a medida para tus necesidades específicas. Conversemos sobre cómo construir algo único para ti.",
-    "discuss": "Discutir Proyecto"
+    "discuss": "Discutir Proyecto",
+    "metaTitle": "Nuestras Soluciones de Software - Monynha Softwares Agency",
+    "loading": "Cargando soluciones...",
+    "error": "No pudimos cargar las soluciones. Por favor, inténtalo más tarde.",
+    "detailLoading": "Cargando solución...",
+    "detailError": "No pudimos cargar esta solución. Por favor, inténtalo más tarde."
   },
   "about": {
     "title": "Sobre Monynha Softwares Agency",
@@ -158,7 +185,8 @@
     },
     "ctaTitle": "Construyamos juntos el próximo capítulo de tu negocio",
     "ctaDescription": "Cuéntanos tus objetivos y descubre cómo soluciones de IA a medida pueden acelerar tu crecimiento.",
-    "ctaButton": "Habla con nuestro equipo"
+    "ctaButton": "Habla con nuestro equipo",
+    "metaTitle": "Sobre Monynha Softwares Agency"
   },
   "blog": {
     "title": "Noticias e Ideas",
@@ -167,7 +195,13 @@
     "read": "Leer Artículo Completo",
     "readMore": "Leer Más",
     "categories": {
-      "all": "Todos"
+      "all": "Todos",
+      "aiInsights": "Insights de IA",
+      "development": "Desarrollo",
+      "caseStudy": "Caso de estudio",
+      "business": "Negocios",
+      "security": "Seguridad",
+      "integration": "Integración"
     },
     "newsletter": {
       "title": "Mantente Informado",
@@ -215,7 +249,10 @@
       "validationErrorDescription": "Agrega tu mensaje antes de enviarlo.",
       "characters": "{{count}} / {{max}} caracteres",
       "authenticating": "Verificando tu sesión..."
-    }
+    },
+    "defaultCategory": "Insights de IA",
+    "defaultAuthor": "Equipo de Monynha Softwares",
+    "metaTitle": "Insights y Novedades - Monynha Softwares Agency"
   },
   "contact": {
     "title": "Construyamos Algo Increíble Juntos",
@@ -261,6 +298,15 @@
       "title": "¡Gracias!",
       "description": "Hemos recibido tu mensaje y te contactaremos en 24 horas. ¡Nuestro equipo está emocionado por saber más de tu proyecto!",
       "another": "Enviar Otro Mensaje"
+    },
+    "metaTitle": "Contacto - Monynha Softwares Agency",
+    "projectTypes": {
+      "customAssistant": "Asistente de IA personalizado",
+      "restaurant": "Sistema de gestión para restaurantes",
+      "automation": "Automatización empresarial",
+      "legacy": "Integración de sistemas heredados",
+      "consulting": "Servicios de consultoría",
+      "other": "Otro"
     }
   },
   "newsletterSection": {
@@ -297,10 +343,126 @@
     "liveDemo": "Demo en Vivo",
     "like": "¿Te gustan nuestros proyectos?",
     "likeDescription": "Ponte en contacto para crear una solución personalizada para tu negocio.",
-    "contactUs": "Contáctanos"
+    "contactUs": "Contáctanos",
+    "metaTitle": "Proyectos Open Source - Monynha Softwares Agency",
+    "loadingProjects": "Cargando proyectos...",
+    "errorProjects": "No pudimos cargar los proyectos en este momento.",
+    "errorProjectsPartial": "No pudimos cargar proyectos adicionales.",
+    "loadingSolutions": "Cargando soluciones...",
+    "errorSolutions": "No pudimos cargar la lista de soluciones.",
+    "loadingGithub": "Cargando proyectos de GitHub...",
+    "errorGithub": "No pudimos cargar los proyectos de GitHub."
   },
   "notFound": {
     "oops": "¡Vaya! Página no encontrada",
-    "returnHome": "Volver al Inicio"
+    "returnHome": "Volver al Inicio",
+    "metaTitle": "404 - Página no encontrada",
+    "metaDescription": "La página que buscas no existe."
+  },
+  "auth": {
+    "backHome": "Volver al inicio",
+    "subtitle": "Inicia sesión o crea tu cuenta",
+    "tabs": {
+      "signin": "Iniciar sesión",
+      "signup": "Registrarse"
+    },
+    "labels": {
+      "name": "Nombre",
+      "email": "Correo electrónico",
+      "password": "Contraseña"
+    },
+    "placeholders": {
+      "name": "Tu nombre",
+      "email": "tu@ejemplo.com"
+    },
+    "actions": {
+      "signIn": "Iniciar sesión",
+      "signingIn": "Iniciando sesión...",
+      "signUp": "Crear cuenta",
+      "signingUp": "Creando cuenta..."
+    },
+    "passwordHint": "Mínimo de 6 caracteres",
+    "toast": {
+      "signInSuccess": {
+        "title": "¡Inicio de sesión realizado!",
+        "description": "¡Bienvenido de nuevo!"
+      },
+      "signInError": {
+        "title": "Error al iniciar sesión",
+        "description": "No pudimos iniciar tu sesión. Inténtalo de nuevo."
+      },
+      "signUpSuccess": {
+        "title": "¡Cuenta creada con éxito!",
+        "description": "Revisa tu correo para confirmar la cuenta."
+      },
+      "signUpError": {
+        "title": "Error al crear la cuenta",
+        "description": "No pudimos crear tu cuenta. Inténtalo de nuevo."
+      }
+    }
+  },
+  "dashboard": {
+    "title": "Panel",
+    "welcome": "Bienvenido, {{name}}",
+    "welcomeFallback": "Consulta la información de tu cuenta.",
+    "refresh": "Actualizar",
+    "signOut": "Cerrar sesión",
+    "signingOut": "Cerrando sesión...",
+    "alertTitle": "Ocurrió un problema",
+    "profile": {
+      "fallbackTitle": "Perfil del usuario",
+      "emailUnavailable": "Correo no disponible",
+      "name": "Nombre",
+      "email": "Correo electrónico",
+      "role": "Rol",
+      "updatedAt": "Última actualización",
+      "roleAdmin": "Administrador",
+      "roleUser": "Usuario"
+    },
+    "leads": {
+      "title": "Leads",
+      "description": "Contactos recibidos desde las páginas públicas.",
+      "loading": "Cargando datos de leads...",
+      "empty": "Aún no se registraron leads.",
+      "columns": {
+        "name": "Nombre",
+        "email": "Correo electrónico",
+        "company": "Empresa",
+        "project": "Proyecto",
+        "message": "Mensaje",
+        "createdAt": "Enviado el"
+      }
+    },
+    "newsletter": {
+      "title": "Newsletter",
+      "description": "Suscriptores registrados en la lista de correos.",
+      "loading": "Cargando suscriptores...",
+      "empty": "No se encontraron suscriptores.",
+      "columns": {
+        "email": "Correo electrónico",
+        "status": "Estado",
+        "subscribedAt": "Suscrito el"
+      },
+      "status": {
+        "active": "Activo",
+        "inactive": "Inactivo"
+      }
+    },
+    "toast": {
+      "loadError": {
+        "title": "Error al cargar los datos"
+      },
+      "signOutSuccess": {
+        "title": "Sesión finalizada",
+        "description": "Has cerrado sesión correctamente."
+      },
+      "signOutError": {
+        "title": "Error al cerrar sesión",
+        "description": "No pudimos cerrar tu sesión. Intenta nuevamente."
+      }
+    },
+    "errors": {
+      "loadDashboard": "No pudimos cargar el panel."
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -109,7 +109,29 @@
       "description": "Discutons de la manière dont nos solutions IA peuvent rationaliser vos opérations et favoriser la croissance.",
       "getStarted": "Commencer aujourd'hui"
     },
-    "learnMore": "En savoir plus"
+    "learnMore": "En savoir plus",
+    "fallbackSolutions": {
+      "boteco": {
+        "name": "Boteco Pro",
+        "description": "Système complet de gestion pour restaurants et bars avec analyses alimentées par l'IA et gestion des stocks.",
+        "features": {
+          "orderManagement": "Gestion des commandes",
+          "inventoryTracking": "Suivi des stocks",
+          "analyticsDashboard": "Tableau de bord analytique",
+          "staffManagement": "Gestion du personnel"
+        }
+      },
+      "assistina": {
+        "name": "AssisTina AI",
+        "description": "Assistant IA personnalisé qui comprend les besoins de votre entreprise et automatise les tâches routinières.",
+        "features": {
+          "nlp": "Traitement du langage naturel",
+          "taskAutomation": "Automatisation des tâches",
+          "learning": "Capacités d'apprentissage",
+          "integration": "Intégration personnalisée"
+        }
+      }
+    }
   },
   "solutionsPage": {
     "title": "Nos Solutions logicielles",
@@ -120,7 +142,12 @@
     "notFound": "Solution introuvable",
     "customTitle": "Besoin d'une solution personnalisée ?",
     "customDescription": "Nous créons également des solutions sur mesure adaptées à vos besoins spécifiques. Discutons de la manière de construire quelque chose d'unique pour vous.",
-    "discuss": "Discuter du projet"
+    "discuss": "Discuter du projet",
+    "metaTitle": "Nos solutions logicielles - Monynha Softwares Agency",
+    "loading": "Chargement des solutions...",
+    "error": "Nous n'avons pas pu charger les solutions. Veuillez réessayer plus tard.",
+    "detailLoading": "Chargement de la solution...",
+    "detailError": "Nous n'avons pas pu charger cette solution. Veuillez réessayer plus tard."
   },
   "about": {
     "title": "À propos de Monynha Softwares Agency",
@@ -158,7 +185,8 @@
     },
     "ctaTitle": "Construisons ensemble le prochain chapitre de votre entreprise",
     "ctaDescription": "Parlez-nous de vos objectifs et découvrez comment des solutions IA sur mesure peuvent accélérer votre croissance.",
-    "ctaButton": "Parler à notre équipe"
+    "ctaButton": "Parler à notre équipe",
+    "metaTitle": "À propos de Monynha Softwares Agency"
   },
   "blog": {
     "title": "Actualités et Idées",
@@ -167,7 +195,13 @@
     "read": "Lire l'article complet",
     "readMore": "En savoir plus",
     "categories": {
-      "all": "Tous"
+      "all": "Tous",
+      "aiInsights": "Analyses IA",
+      "development": "Développement",
+      "caseStudy": "Étude de cas",
+      "business": "Affaires",
+      "security": "Sécurité",
+      "integration": "Intégration"
     },
     "newsletter": {
       "title": "Restez informé",
@@ -215,7 +249,10 @@
       "validationErrorDescription": "Ajoutez votre message avant de l'envoyer.",
       "characters": "{{count}} / {{max}} caractères",
       "authenticating": "Vérification de votre session..."
-    }
+    },
+    "defaultCategory": "Analyses IA",
+    "defaultAuthor": "Équipe Monynha Softwares",
+    "metaTitle": "Analyses & Actualités - Monynha Softwares Agency"
   },
   "contact": {
     "title": "Construisons quelque chose d'incroyable ensemble",
@@ -261,6 +298,15 @@
       "title": "Merci !",
       "description": "Nous avons bien reçu votre message et vous répondrons sous 24 heures. Notre équipe est impatiente d'en savoir plus sur votre projet !",
       "another": "Envoyer un autre message"
+    },
+    "metaTitle": "Contact - Monynha Softwares Agency",
+    "projectTypes": {
+      "customAssistant": "Assistant IA personnalisé",
+      "restaurant": "Système de gestion pour restaurants",
+      "automation": "Automatisation d'entreprise",
+      "legacy": "Intégration de systèmes hérités",
+      "consulting": "Services de conseil",
+      "other": "Autre"
     }
   },
   "newsletterSection": {
@@ -297,10 +343,126 @@
     "liveDemo": "Démo en ligne",
     "like": "Vous aimez nos projets ?",
     "likeDescription": "Contactez-nous pour créer une solution personnalisée pour votre entreprise.",
-    "contactUs": "Nous contacter"
+    "contactUs": "Nous contacter",
+    "metaTitle": "Projets Open Source - Monynha Softwares Agency",
+    "loadingProjects": "Chargement des projets...",
+    "errorProjects": "Nous n'avons pas pu charger les projets pour le moment.",
+    "errorProjectsPartial": "Nous n'avons pas pu charger d'autres projets.",
+    "loadingSolutions": "Chargement des solutions...",
+    "errorSolutions": "Nous n'avons pas pu charger la liste des solutions.",
+    "loadingGithub": "Chargement des projets GitHub...",
+    "errorGithub": "Nous n'avons pas pu charger les projets GitHub."
   },
   "notFound": {
     "oops": "Oups ! Page introuvable",
-    "returnHome": "Retour à l'accueil"
+    "returnHome": "Retour à l'accueil",
+    "metaTitle": "404 - Page introuvable",
+    "metaDescription": "La page que vous recherchez n'existe pas."
+  },
+  "auth": {
+    "backHome": "Retour à l'accueil",
+    "subtitle": "Connectez-vous ou créez votre compte",
+    "tabs": {
+      "signin": "Connexion",
+      "signup": "Inscription"
+    },
+    "labels": {
+      "name": "Nom",
+      "email": "E-mail",
+      "password": "Mot de passe"
+    },
+    "placeholders": {
+      "name": "Votre nom",
+      "email": "vous@exemple.com"
+    },
+    "actions": {
+      "signIn": "Se connecter",
+      "signingIn": "Connexion en cours...",
+      "signUp": "Créer un compte",
+      "signingUp": "Création du compte..."
+    },
+    "passwordHint": "Minimum de 6 caractères",
+    "toast": {
+      "signInSuccess": {
+        "title": "Connexion réussie !",
+        "description": "Ravi de vous revoir !"
+      },
+      "signInError": {
+        "title": "Erreur de connexion",
+        "description": "Impossible de vous connecter. Veuillez réessayer."
+      },
+      "signUpSuccess": {
+        "title": "Compte créé avec succès !",
+        "description": "Vérifiez votre e-mail pour confirmer votre compte."
+      },
+      "signUpError": {
+        "title": "Erreur lors de la création du compte",
+        "description": "Impossible de créer votre compte. Veuillez réessayer."
+      }
+    }
+  },
+  "dashboard": {
+    "title": "Tableau de bord",
+    "welcome": "Bienvenue, {{name}}",
+    "welcomeFallback": "Consultez les informations de votre compte.",
+    "refresh": "Actualiser",
+    "signOut": "Se déconnecter",
+    "signingOut": "Déconnexion...",
+    "alertTitle": "Un problème est survenu",
+    "profile": {
+      "fallbackTitle": "Profil de l'utilisateur",
+      "emailUnavailable": "E-mail indisponible",
+      "name": "Nom",
+      "email": "E-mail",
+      "role": "Rôle",
+      "updatedAt": "Dernière mise à jour",
+      "roleAdmin": "Administrateur",
+      "roleUser": "Utilisateur"
+    },
+    "leads": {
+      "title": "Leads",
+      "description": "Contacts reçus depuis les pages publiques.",
+      "loading": "Chargement des leads...",
+      "empty": "Aucun lead enregistré pour le moment.",
+      "columns": {
+        "name": "Nom",
+        "email": "E-mail",
+        "company": "Entreprise",
+        "project": "Projet",
+        "message": "Message",
+        "createdAt": "Envoyé le"
+      }
+    },
+    "newsletter": {
+      "title": "Newsletter",
+      "description": "Abonnés enregistrés dans la liste e-mail.",
+      "loading": "Chargement des abonnés...",
+      "empty": "Aucun abonné trouvé.",
+      "columns": {
+        "email": "E-mail",
+        "status": "Statut",
+        "subscribedAt": "Inscrit le"
+      },
+      "status": {
+        "active": "Actif",
+        "inactive": "Inactif"
+      }
+    },
+    "toast": {
+      "loadError": {
+        "title": "Erreur lors du chargement des données"
+      },
+      "signOutSuccess": {
+        "title": "Session terminée",
+        "description": "Vous vous êtes déconnecté avec succès."
+      },
+      "signOutError": {
+        "title": "Erreur lors de la déconnexion",
+        "description": "Nous n'avons pas pu vous déconnecter. Veuillez réessayer."
+      }
+    },
+    "errors": {
+      "loadDashboard": "Impossible de charger le tableau de bord."
+    }
   }
 }

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -109,7 +109,29 @@
       "description": "Vamos discutir como nossas soluções com IA podem otimizar suas operações e gerar crescimento.",
       "getStarted": "Começar Hoje"
     },
-    "learnMore": "Saiba Mais"
+    "learnMore": "Saiba Mais",
+    "fallbackSolutions": {
+      "boteco": {
+        "name": "Boteco Pro",
+        "description": "Sistema completo de gestão para restaurantes e bares com análises por IA e controle de estoque.",
+        "features": {
+          "orderManagement": "Gestão de Pedidos",
+          "inventoryTracking": "Controle de Estoque",
+          "analyticsDashboard": "Painel Analítico",
+          "staffManagement": "Gestão de Equipe"
+        }
+      },
+      "assistina": {
+        "name": "AssisTina AI",
+        "description": "Assistente de IA personalizado que aprende as necessidades do seu negócio e automatiza tarefas rotineiras.",
+        "features": {
+          "nlp": "Processamento de Linguagem Natural",
+          "taskAutomation": "Automação de Tarefas",
+          "learning": "Capacidade de Aprendizado",
+          "integration": "Integração Personalizada"
+        }
+      }
+    }
   },
   "solutionsPage": {
     "title": "Nossas Soluções de Software",
@@ -120,7 +142,12 @@
     "notFound": "Solução não encontrada",
     "customTitle": "Precisa de uma Solução Personalizada?",
     "customDescription": "Também criamos soluções sob medida para suas necessidades específicas de negócio. Vamos conversar sobre como construir algo único para você.",
-    "discuss": "Discutir Projeto"
+    "discuss": "Discutir Projeto",
+    "metaTitle": "Nossas Soluções de Software - Monynha Softwares Agency",
+    "loading": "Carregando soluções...",
+    "error": "Não foi possível carregar as soluções. Tente novamente mais tarde.",
+    "detailLoading": "Carregando solução...",
+    "detailError": "Não foi possível carregar esta solução. Tente novamente mais tarde."
   },
   "about": {
     "title": "Sobre a Monynha Softwares Agency",
@@ -158,7 +185,8 @@
     },
     "ctaTitle": "Vamos construir o próximo capítulo do seu negócio juntos",
     "ctaDescription": "Conte seus objetivos para descobrir como soluções de IA sob medida podem acelerar o seu crescimento.",
-    "ctaButton": "Fale com nosso time"
+    "ctaButton": "Fale com nosso time",
+    "metaTitle": "Sobre a Monynha Softwares Agency"
   },
   "blog": {
     "title": "Insights e Novidades",
@@ -166,7 +194,15 @@
     "featured": "Destaque",
     "read": "Ler Artigo Completo",
     "readMore": "Ler Mais",
-    "categories": { "all": "Todos" },
+    "categories": {
+      "all": "Todos",
+      "aiInsights": "Insights de IA",
+      "development": "Desenvolvimento",
+      "caseStudy": "Estudo de Caso",
+      "business": "Negócios",
+      "security": "Segurança",
+      "integration": "Integração"
+    },
     "newsletter": {
       "title": "Fique Atualizado",
       "description": "Assine nossa newsletter para receber novidades sobre IA, desenvolvimento de software e automação.",
@@ -213,7 +249,10 @@
       "validationErrorDescription": "Adicione sua mensagem antes de enviar.",
       "characters": "{{count}} / {{max}} caracteres",
       "authenticating": "Verificando sua sessão..."
-    }
+    },
+    "defaultCategory": "Insights de IA",
+    "defaultAuthor": "Equipe Monynha Softwares",
+    "metaTitle": "Insights & Atualizações - Monynha Softwares Agency"
   },
   "contact": {
     "title": "Vamos Construir Algo Incrível Juntos",
@@ -259,6 +298,15 @@
       "title": "Obrigado!",
       "description": "Recebemos sua mensagem e retornaremos em até 24 horas. Estamos ansiosos para saber mais sobre seu projeto!",
       "another": "Enviar Outra Mensagem"
+    },
+    "metaTitle": "Contato - Monynha Softwares Agency",
+    "projectTypes": {
+      "customAssistant": "Assistente de IA Personalizado",
+      "restaurant": "Sistema de Gestão para Restaurantes",
+      "automation": "Automação de Negócios",
+      "legacy": "Integração de Sistemas Legados",
+      "consulting": "Serviços de Consultoria",
+      "other": "Outro"
     }
   },
   "newsletterSection": {
@@ -295,10 +343,126 @@
     "liveDemo": "Demo ao Vivo",
     "like": "Gostou dos projetos?",
     "likeDescription": "Entre em contato para criar uma solução personalizada para seu negócio.",
-    "contactUs": "Fale Conosco"
+    "contactUs": "Fale Conosco",
+    "metaTitle": "Projetos Open Source - Monynha Softwares Agency",
+    "loadingProjects": "Carregando projetos...",
+    "errorProjects": "Não foi possível carregar os projetos no momento.",
+    "errorProjectsPartial": "Não foi possível carregar projetos adicionais.",
+    "loadingSolutions": "Carregando soluções...",
+    "errorSolutions": "Não foi possível carregar a lista de soluções.",
+    "loadingGithub": "Carregando projetos do GitHub...",
+    "errorGithub": "Não foi possível carregar os projetos do GitHub."
   },
   "notFound": {
     "oops": "Ops! Página não encontrada",
-    "returnHome": "Voltar ao Início"
+    "returnHome": "Voltar ao Início",
+    "metaTitle": "404 - Página não encontrada",
+    "metaDescription": "A página que você procura não existe."
+  },
+  "auth": {
+    "backHome": "Voltar para a home",
+    "subtitle": "Faça login ou crie sua conta",
+    "tabs": {
+      "signin": "Login",
+      "signup": "Cadastro"
+    },
+    "labels": {
+      "name": "Nome",
+      "email": "Email",
+      "password": "Senha"
+    },
+    "placeholders": {
+      "name": "Seu nome",
+      "email": "voce@exemplo.com"
+    },
+    "actions": {
+      "signIn": "Entrar",
+      "signingIn": "Entrando...",
+      "signUp": "Criar conta",
+      "signingUp": "Criando conta..."
+    },
+    "passwordHint": "Mínimo de 6 caracteres",
+    "toast": {
+      "signInSuccess": {
+        "title": "Login realizado com sucesso!",
+        "description": "Bem-vindo de volta!"
+      },
+      "signInError": {
+        "title": "Erro ao fazer login",
+        "description": "Não foi possível fazer login. Tente novamente."
+      },
+      "signUpSuccess": {
+        "title": "Conta criada com sucesso!",
+        "description": "Verifique seu email para confirmar a conta."
+      },
+      "signUpError": {
+        "title": "Erro ao criar conta",
+        "description": "Não foi possível criar a conta. Tente novamente."
+      }
+    }
+  },
+  "dashboard": {
+    "title": "Dashboard",
+    "welcome": "Bem-vindo, {{name}}",
+    "welcomeFallback": "Confira as informações da sua conta.",
+    "refresh": "Atualizar",
+    "signOut": "Sair",
+    "signingOut": "Saindo...",
+    "alertTitle": "Ocorreu um problema",
+    "profile": {
+      "fallbackTitle": "Perfil do usuário",
+      "emailUnavailable": "Email não disponível",
+      "name": "Nome",
+      "email": "Email",
+      "role": "Função",
+      "updatedAt": "Última atualização",
+      "roleAdmin": "Administrador",
+      "roleUser": "Usuário"
+    },
+    "leads": {
+      "title": "Leads",
+      "description": "Contatos recebidos pelas páginas públicas.",
+      "loading": "Carregando dados de leads...",
+      "empty": "Nenhum lead registrado até o momento.",
+      "columns": {
+        "name": "Nome",
+        "email": "Email",
+        "company": "Empresa",
+        "project": "Projeto",
+        "message": "Mensagem",
+        "createdAt": "Enviado em"
+      }
+    },
+    "newsletter": {
+      "title": "Newsletter",
+      "description": "Assinantes cadastrados na base de emails.",
+      "loading": "Carregando assinantes...",
+      "empty": "Nenhum inscrito encontrado.",
+      "columns": {
+        "email": "Email",
+        "status": "Status",
+        "subscribedAt": "Inscrito em"
+      },
+      "status": {
+        "active": "Ativo",
+        "inactive": "Inativo"
+      }
+    },
+    "toast": {
+      "loadError": {
+        "title": "Erro ao carregar dados"
+      },
+      "signOutSuccess": {
+        "title": "Sessão encerrada",
+        "description": "Você saiu da aplicação com sucesso."
+      },
+      "signOutError": {
+        "title": "Erro ao sair",
+        "description": "Não foi possível encerrar a sessão. Tente novamente."
+      }
+    },
+    "errors": {
+      "loadDashboard": "Não foi possível carregar o dashboard."
+    }
   }
 }

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -14,6 +14,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { ArrowLeft, Eye, EyeOff, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 type AuthView = 'signin' | 'signup';
 
@@ -27,6 +28,7 @@ const Auth = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { toast } = useToast();
+  const { t } = useTranslation();
 
   const redirectPath = useMemo(() => {
     const state = location.state as { from?: { pathname?: string } } | null;
@@ -62,17 +64,18 @@ const Auth = () => {
       }
 
       toast({
-        title: 'Login realizado com sucesso!',
-        description: 'Bem-vindo de volta!',
+        title: t('auth.toast.signInSuccess.title'),
+        description: t('auth.toast.signInSuccess.description'),
       });
 
       navigate(redirectPath, { replace: true });
     } catch (error) {
+      const fallbackMessage = t('auth.toast.signInError.description');
       const message =
-        error instanceof Error ? error.message : 'Não foi possível fazer login.';
+        error instanceof Error ? error.message : fallbackMessage;
       toast({
-        title: 'Erro ao fazer login',
-        description: message,
+        title: t('auth.toast.signInError.title'),
+        description: message || fallbackMessage,
         variant: 'destructive',
       });
     } finally {
@@ -106,8 +109,8 @@ const Auth = () => {
       }
 
       toast({
-        title: 'Conta criada com sucesso!',
-        description: 'Verifique seu email para confirmar a conta.',
+        title: t('auth.toast.signUpSuccess.title'),
+        description: t('auth.toast.signUpSuccess.description'),
       });
 
       setSignInForm({ email: signUpForm.email.trim(), password: '' });
@@ -115,11 +118,12 @@ const Auth = () => {
       setAuthView('signin');
       setShowPassword(false);
     } catch (error) {
+      const fallbackMessage = t('auth.toast.signUpError.description');
       const message =
-        error instanceof Error ? error.message : 'Não foi possível criar a conta.';
+        error instanceof Error ? error.message : fallbackMessage;
       toast({
-        title: 'Erro ao criar conta',
-        description: message,
+        title: t('auth.toast.signUpError.title'),
+        description: message || fallbackMessage,
         variant: 'destructive',
       });
     } finally {
@@ -136,11 +140,13 @@ const Auth = () => {
             className="flex items-center text-sm text-muted-foreground hover:text-primary transition-colors"
           >
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Voltar para home
+            {t('auth.backHome')}
           </Link>
           <div className="text-center">
             <CardTitle className="text-2xl font-bold">Monynha Softwares</CardTitle>
-            <CardDescription>Faça login ou crie sua conta</CardDescription>
+            <CardDescription className="text-balance">
+              {t('auth.subtitle')}
+            </CardDescription>
           </div>
         </CardHeader>
 
@@ -154,14 +160,24 @@ const Auth = () => {
             className="w-full"
           >
             <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="signin">Login</TabsTrigger>
-              <TabsTrigger value="signup">Cadastro</TabsTrigger>
+              <TabsTrigger
+                value="signin"
+                className="whitespace-normal break-words leading-tight"
+              >
+                {t('auth.tabs.signin')}
+              </TabsTrigger>
+              <TabsTrigger
+                value="signup"
+                className="whitespace-normal break-words leading-tight"
+              >
+                {t('auth.tabs.signup')}
+              </TabsTrigger>
             </TabsList>
 
             <TabsContent value="signin" className="space-y-4">
               <form onSubmit={handleSignIn} className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="signin-email">Email</Label>
+                  <Label htmlFor="signin-email">{t('auth.labels.email')}</Label>
                   <Input
                     id="signin-email"
                     type="email"
@@ -172,14 +188,14 @@ const Auth = () => {
                         email: event.target.value,
                       }))
                     }
-                    placeholder="seu@email.com"
+                    placeholder={t('auth.placeholders.email')}
                     autoComplete="email"
                     required
                   />
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="signin-password">Senha</Label>
+                  <Label htmlFor="signin-password">{t('auth.labels.password')}</Label>
                   <div className="relative">
                     <Input
                       id="signin-password"
@@ -220,10 +236,10 @@ const Auth = () => {
                   {loadingView === 'signin' ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Entrando...
+                      {t('auth.actions.signingIn')}
                     </>
                   ) : (
-                    'Entrar'
+                    t('auth.actions.signIn')
                   )}
                 </Button>
               </form>
@@ -232,7 +248,7 @@ const Auth = () => {
             <TabsContent value="signup" className="space-y-4">
               <form onSubmit={handleSignUp} className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="signup-name">Nome</Label>
+                  <Label htmlFor="signup-name">{t('auth.labels.name')}</Label>
                   <Input
                     id="signup-name"
                     type="text"
@@ -243,14 +259,14 @@ const Auth = () => {
                         name: event.target.value,
                       }))
                     }
-                    placeholder="Seu nome"
+                    placeholder={t('auth.placeholders.name')}
                     autoComplete="name"
                     required
                   />
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="signup-email">Email</Label>
+                  <Label htmlFor="signup-email">{t('auth.labels.email')}</Label>
                   <Input
                     id="signup-email"
                     type="email"
@@ -261,14 +277,14 @@ const Auth = () => {
                         email: event.target.value,
                       }))
                     }
-                    placeholder="seu@email.com"
+                    placeholder={t('auth.placeholders.email')}
                     autoComplete="email"
                     required
                   />
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="signup-password">Senha</Label>
+                  <Label htmlFor="signup-password">{t('auth.labels.password')}</Label>
                   <div className="relative">
                     <Input
                       id="signup-password"
@@ -299,7 +315,9 @@ const Auth = () => {
                       )}
                     </Button>
                   </div>
-                  <p className="text-xs text-muted-foreground">Mínimo de 6 caracteres</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t('auth.passwordHint')}
+                  </p>
                 </div>
 
                 <Button
@@ -310,10 +328,10 @@ const Auth = () => {
                   {loadingView === 'signup' ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Criando conta...
+                      {t('auth.actions.signingUp')}
                     </>
                   ) : (
-                    'Criar conta'
+                    t('auth.actions.signUp')
                   )}
                 </Button>
               </form>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -39,6 +39,16 @@ const FALLBACK_IMAGE =
 
 const POSTS_PER_PAGE = 7;
 
+const BLOG_CATEGORY_KEYS = [
+  'blog.categories.all',
+  'blog.categories.aiInsights',
+  'blog.categories.development',
+  'blog.categories.caseStudy',
+  'blog.categories.business',
+  'blog.categories.security',
+  'blog.categories.integration',
+];
+
 type BlogPostRow = Pick<
   Database['public']['Tables']['blog_posts']['Row'],
   'id' | 'slug' | 'title' | 'excerpt' | 'image_url' | 'updated_at'
@@ -103,15 +113,7 @@ const Blog = () => {
   }, [normalizedLocale]);
 
   const categories = useMemo(
-    () => [
-      t('blog.categories.all'),
-      'AI Insights',
-      'Development',
-      'Case Study',
-      'Business',
-      'Security',
-      'Integration',
-    ],
+    () => BLOG_CATEGORY_KEYS.map((key) => t(key)),
     [t]
   );
 
@@ -156,10 +158,10 @@ const Blog = () => {
         title: post.title,
         excerpt: post.excerpt ?? t('blog.fallbackExcerpt'),
         image: post.image_url ?? FALLBACK_IMAGE,
-        author: 'Monynha Softwares Team',
+        author: t('blog.defaultAuthor'),
         date: dateFormatter.format(new Date(post.updated_at)),
         readTime: t('blog.readTimeDefault'),
-        category: 'AI Insights',
+        category: t('blog.defaultCategory'),
         featured: page === 1 && index === 0,
       })),
     [data?.posts, dateFormatter, page, t]
@@ -198,9 +200,9 @@ const Blog = () => {
     return (
       <Layout>
         <Meta
-          title="Insights & Updates - Monynha Softwares Agency"
+          title={t('blog.metaTitle')}
           description={t('blog.description')}
-          ogTitle="Insights & Updates - Monynha Softwares Agency"
+          ogTitle={t('blog.metaTitle')}
           ogDescription={t('blog.description')}
           ogImage="/placeholder.svg"
         />
@@ -215,9 +217,9 @@ const Blog = () => {
     return (
       <Layout>
         <Meta
-          title="Insights & Updates - Monynha Softwares Agency"
+          title={t('blog.metaTitle')}
           description={t('blog.description')}
-          ogTitle="Insights & Updates - Monynha Softwares Agency"
+          ogTitle={t('blog.metaTitle')}
           ogDescription={t('blog.description')}
           ogImage="/placeholder.svg"
         />
@@ -231,9 +233,9 @@ const Blog = () => {
   return (
     <Layout>
       <Meta
-        title="Insights & Updates - Monynha Softwares Agency"
+        title={t('blog.metaTitle')}
         description={t('blog.description')}
-        ogTitle="Insights & Updates - Monynha Softwares Agency"
+        ogTitle={t('blog.metaTitle')}
         ogDescription={t('blog.description')}
         ogImage="/placeholder.svg"
       />

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -20,13 +20,13 @@ import {
 } from '@/components/ui/breadcrumb';
 import { useQuery } from '@tanstack/react-query';
 
-const DEFAULT_PROJECT_TYPES = [
-  'Custom AI Assistant',
-  'Restaurant Management System',
-  'Business Automation',
-  'Legacy System Integration',
-  'Consulting Services',
-  'Other',
+const PROJECT_TYPE_KEYS = [
+  'contact.projectTypes.customAssistant',
+  'contact.projectTypes.restaurant',
+  'contact.projectTypes.automation',
+  'contact.projectTypes.legacy',
+  'contact.projectTypes.consulting',
+  'contact.projectTypes.other',
 ];
 
 const validatableFields = ['name', 'email', 'message'] as const;
@@ -132,13 +132,18 @@ const Contact = () => {
     }
   }, [projectTypesError]);
 
+  const defaultProjectTypes = useMemo(
+    () => PROJECT_TYPE_KEYS.map((key) => t(key)),
+    [t]
+  );
+
   const projectTypes = useMemo(() => {
     if (projectTypeResponse && projectTypeResponse.length > 0) {
       return projectTypeResponse;
     }
 
-    return DEFAULT_PROJECT_TYPES;
-  }, [projectTypeResponse]);
+    return defaultProjectTypes;
+  }, [defaultProjectTypes, projectTypeResponse]);
 
   const validateField = (field: ValidatableField, value: string) => {
     const trimmedValue = value.trim();
@@ -300,9 +305,9 @@ const Contact = () => {
     return (
       <Layout>
         <Meta
-          title="Contact - Monynha Softwares Agency"
+          title={t('contact.metaTitle')}
           description={t('contact.description')}
-          ogTitle="Contact - Monynha Softwares Agency"
+          ogTitle={t('contact.metaTitle')}
           ogDescription={t('contact.description')}
           ogImage="/placeholder.svg"
         />
@@ -347,9 +352,9 @@ const Contact = () => {
   return (
     <Layout>
       <Meta
-        title="Contact - Monynha Softwares Agency"
+        title={t('contact.metaTitle')}
         description={t('contact.description')}
-        ogTitle="Contact - Monynha Softwares Agency"
+        ogTitle={t('contact.metaTitle')}
         ogDescription={t('contact.description')}
         ogImage="/placeholder.svg"
       />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,30 +21,21 @@ import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase';
 import { useMemo } from 'react';
 
-const fallbackSolutions = [
+const fallbackSolutionsConfig = [
   {
-    name: 'Boteco Pro',
-    description:
-      'Complete restaurant and bar management system with AI-powered analytics and inventory management.',
-    features: [
-      'Order Management',
-      'Inventory Tracking',
-      'Analytics Dashboard',
-      'Staff Management',
-    ],
+    id: 'boteco',
     gradient: 'from-brand-purple to-brand-blue',
+    featureKeys: [
+      'orderManagement',
+      'inventoryTracking',
+      'analyticsDashboard',
+      'staffManagement',
+    ],
   },
   {
-    name: 'AssisTina AI',
-    description:
-      'Personalized AI assistant that learns your business needs and automates routine tasks.',
-    features: [
-      'Natural Language Processing',
-      'Task Automation',
-      'Learning Capabilities',
-      'Custom Integration',
-    ],
+    id: 'assistina',
     gradient: 'from-brand-pink to-brand-orange',
+    featureKeys: ['nlp', 'taskAutomation', 'learning', 'integration'],
   },
 ];
 
@@ -141,6 +132,21 @@ const Index = () => {
   );
 
   const displayFeatures = features || fallbackFeatures;
+  const fallbackSolutions = useMemo(
+    () =>
+      fallbackSolutionsConfig.map((solution) => ({
+        name: t(`index.fallbackSolutions.${solution.id}.name`),
+        description: t(
+          `index.fallbackSolutions.${solution.id}.description`
+        ),
+        features: solution.featureKeys.map((featureKey) =>
+          t(`index.fallbackSolutions.${solution.id}.features.${featureKey}`)
+        ),
+        gradient: solution.gradient,
+      })),
+    [t]
+  );
+
   const displaySolutions = solutions || fallbackSolutions;
 
   return (

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -19,10 +19,10 @@ const NotFound = () => {
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <Meta
-        title="404 - Page Not Found"
-        description="The page you are looking for does not exist."
-        ogTitle="404 - Page Not Found"
-        ogDescription="The page you are looking for does not exist."
+        title={t('notFound.metaTitle')}
+        description={t('notFound.metaDescription')}
+        ogTitle={t('notFound.metaTitle')}
+        ogDescription={t('notFound.metaDescription')}
         ogImage="/placeholder.svg"
       />
       <div className="text-center">

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -65,14 +65,14 @@ const Solutions = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('solutionsPage.metaTitle')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('solutionsPage.metaTitle')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
-          Loading...
+          {t('solutionsPage.loading')}
         </div>
       </Layout>
     );
@@ -82,14 +82,14 @@ const Solutions = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('solutionsPage.metaTitle')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('solutionsPage.metaTitle')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
-          Error loading solutions
+          {t('solutionsPage.error')}
         </div>
       </Layout>
     );
@@ -98,9 +98,9 @@ const Solutions = () => {
   return (
     <Layout>
       <Meta
-        title="Our Software Solutions - Monynha Softwares Agency"
+        title={t('solutionsPage.metaTitle')}
         description={t('solutionsPage.description')}
-        ogTitle="Our Software Solutions - Monynha Softwares Agency"
+        ogTitle={t('solutionsPage.metaTitle')}
         ogDescription={t('solutionsPage.description')}
         ogImage="/placeholder.svg"
       />

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -265,13 +265,14 @@ const BlogPostPage = () => {
     ? dateFormatter.format(new Date(post.updated_at))
     : '';
 
+  const fallbackMetaTitle = t('blog.metaTitle');
   const metaTitle = post
     ? `${post.title} - Monynha Softwares Agency`
-    : 'Insights & Updates - Monynha Softwares Agency';
+    : fallbackMetaTitle;
 
   const metaDescription = post?.excerpt ?? t('blog.description');
   const metaImage = post?.image_url ?? '/placeholder.svg';
-  const defaultAuthor = 'Monynha Softwares Team';
+  const defaultAuthor = t('blog.defaultAuthor');
   const readTimeLabel = t('blog.readTimeDefault');
 
   if (isLoading) {

--- a/src/pages/solutions/[slug].tsx
+++ b/src/pages/solutions/[slug].tsx
@@ -99,13 +99,15 @@ const SolutionDetail = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('solutionsPage.metaTitle')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('solutionsPage.metaTitle')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
-        <div className="container mx-auto px-4 py-16 text-center">Loading...</div>
+        <div className="container mx-auto px-4 py-16 text-center">
+          {t('solutionsPage.detailLoading')}
+        </div>
       </Layout>
     );
   }
@@ -114,14 +116,14 @@ const SolutionDetail = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('solutionsPage.metaTitle')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('solutionsPage.metaTitle')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
-          Error loading solution
+          {t('solutionsPage.detailError')}
         </div>
       </Layout>
     );
@@ -131,9 +133,9 @@ const SolutionDetail = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('solutionsPage.metaTitle')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('solutionsPage.metaTitle')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />


### PR DESCRIPTION
## Summary
- add comprehensive translation keys for fallback homepage content, contact project types, blog categories, solutions/project status messages, and new auth/dashboard flows across all supported locales
- update pages to consume the i18n helper so meta tags, fallback data, and status messaging are localized, including translation-backed homepage solutions and contact defaults
- enhance projects and dashboard pages with locale-aware formatting and translated toasts while adapting the auth screen for longer multilingual labels

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca52eea0608322a5d5ee830c04f706