### PR TITLE
feat: internationalize content and meta data

### DIFF
--- a/src/data/solutions.ts
+++ b/src/data/solutions.ts
@@ -1,5 +1,3 @@
-import type { SolutionContent } from '@/types/solutions';
-
 export const gradientOptions = [
   'from-brand-purple to-brand-blue',
   'from-brand-pink to-brand-orange',
@@ -16,44 +14,36 @@ export const normalizeSolutionSlug = (value: string): string =>
     .toLowerCase()
     .replace(/^-+|-+$/g, '');
 
-export const fallbackSolutions: SolutionContent[] = [
+export interface FallbackSolutionDefinition {
+  key: string;
+  slug: string;
+  imageUrl?: string | null;
+  gradient: string;
+}
+
+export const fallbackSolutionDefinitions: FallbackSolutionDefinition[] = [
   {
-    title: 'Boteco Pro',
+    key: 'boteco',
     slug: 'boteco-pro',
-    description:
-      'Complete management solution for restaurants and bars with AI-powered analytics, inventory management, and customer insights.',
     imageUrl:
       'https://images.unsplash.com/photo-1514933651103-005eec06c04b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80',
-    features: [
-      'Real-time analytics to monitor sales, inventory, and customer behavior.',
-      'Smart staff scheduling and performance tracking tools.',
-      'Streamlined order processing with mobile POS support.',
-      'Secure multi-method payments protected against fraud.',
-    ],
     gradient: gradientOptions[0],
   },
   {
-    title: 'AssisTina AI',
+    key: 'assistina',
     slug: 'assistina',
-    description:
-      'Intelligent AI assistant that learns your business processes and automates routine tasks, increasing efficiency and productivity.',
     imageUrl:
       'https://images.unsplash.com/photo-1677442136019-21780ecad995?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D&auto=format&fit=crop&w=1000&q=80',
-    features: [
-      'Adaptive machine learning workflows tailored to your operations.',
-      'Natural language conversations across voice and text channels.',
-      'Automated scheduling, reminders, and follow-up tasks.',
-      'Custom integrations with your existing business tools.',
-    ],
     gradient: gradientOptions[1],
   },
 ];
 
-export const fallbackSolutionsMap = fallbackSolutions.reduce<
-  Record<string, SolutionContent>
->((accumulator, solution) => {
-  const normalizedSlug = normalizeSolutionSlug(solution.slug);
-  accumulator[solution.slug] = solution;
-  accumulator[normalizedSlug] = solution;
+export const fallbackSolutionDefinitionMap = fallbackSolutionDefinitions.reduce<
+  Record<string, FallbackSolutionDefinition>
+>((accumulator, definition) => {
+  const normalizedSlug = normalizeSolutionSlug(definition.slug);
+  accumulator[definition.slug] = definition;
+  accumulator[normalizedSlug] = definition;
+  accumulator[definition.key] = definition;
   return accumulator;
 }, {});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -71,6 +71,16 @@
       "integration": "AI Integration"
     }
   },
+  "meta": {
+    "index": "Monynha Softwares: Technology with pride, diversity, and resistance",
+    "about": "About Monynha Softwares Agency",
+    "projects": "Open Source Projects - Monynha Softwares Agency",
+    "solutions": "Our Software Solutions - Monynha Softwares Agency",
+    "contact": "Contact - Monynha Softwares Agency",
+    "blog": "Insights & Updates - Monynha Softwares Agency",
+    "blogPost": "{{title}} - Monynha Softwares Agency",
+    "solutionDetail": "{{title}} - Monynha Softwares Agency"
+  },
   "index": {
     "hero": {
       "headline": "Building the <0/><1>Future with Technology</1>",
@@ -111,6 +121,43 @@
     },
     "learnMore": "Learn More"
   },
+  "solutionsContent": {
+    "fallback": {
+      "boteco": {
+        "title": "Boteco Pro",
+        "description": "Complete management solution for restaurants and bars with AI-powered analytics, inventory control, and customer insights.",
+        "features": [
+          "Real-time analytics to monitor sales, inventory, and customer behavior.",
+          "Smart staff scheduling and performance tracking tools.",
+          "Streamlined order processing with mobile POS support.",
+          "Secure multi-method payments protected against fraud."
+        ]
+      },
+      "assistina": {
+        "title": "AssisTina AI",
+        "description": "Intelligent AI assistant that learns your business processes and automates routine tasks to boost efficiency.",
+        "features": [
+          "Adaptive machine learning workflows tailored to your operations.",
+          "Natural language conversations across voice and text channels.",
+          "Automated scheduling, reminders, and follow-up tasks.",
+          "Custom integrations with your existing business tools."
+        ]
+      }
+    },
+    "github": {
+      "fallbackDescription": "Open-source solution maintained by Monynha Softwares.",
+      "metadata": {
+        "language": "Built with {{language}}.",
+        "homepage": "Live project: {{url}}",
+        "stars_one": "{{count}} ⭐ star on GitHub",
+        "stars_other": "{{count}} ⭐ stars on GitHub",
+        "issues_one": "{{count}} open issue",
+        "issues_other": "{{count}} open issues",
+        "defaultBranch": "Default branch: {{branch}}",
+        "updatedAt": "Last updated on {{date}}"
+      }
+    }
+  },
   "solutionsPage": {
     "title": "Our Software Solutions",
     "description": "Discover our flagship products designed to transform how businesses operate. Each solution is crafted with AI at its core to deliver maximum efficiency and growth.",
@@ -120,7 +167,10 @@
     "notFound": "Solution not found",
     "customTitle": "Need a Custom Solution?",
     "customDescription": "We also create bespoke software solutions tailored to your specific business needs. Let's discuss how we can build something unique for you.",
-    "discuss": "Discuss Custom Project"
+    "discuss": "Discuss Custom Project",
+    "loading": "Loading...",
+    "error": "We couldn't load the solutions right now.",
+    "errorSingle": "We couldn't load this solution."
   },
   "about": {
     "title": "About Monynha Softwares Agency",
@@ -163,6 +213,8 @@
   "blog": {
     "title": "Insights & Updates",
     "description": "Stay updated with the latest trends in AI, software development, and business automation. Expert insights from our team of developers and AI specialists.",
+    "defaultAuthor": "Monynha Softwares Team",
+    "defaultCategory": "AI Insights",
     "featured": "Featured",
     "read": "Read Full Article",
     "readMore": "Read More",
@@ -297,7 +349,47 @@
     "liveDemo": "Live Demo",
     "like": "Like our projects?",
     "likeDescription": "Get in touch to craft a custom solution for your business.",
-    "contactUs": "Contact Us"
+    "contactUs": "Contact Us",
+    "loadingSolutions": "Loading solutions...",
+    "errorSolutions": "We couldn't load the solutions. Please try again.",
+    "error": "We couldn't load the projects right now.",
+    "errorAdditional": "We couldn't load additional projects.",
+    "loading": "Loading...",
+    "errorGithub": "We couldn't load GitHub projects."
+  },
+  "auth": {
+    "link": {
+      "backHome": "Back to home"
+    },
+    "brand": "Monynha Softwares",
+    "description": "Sign in or create your account",
+    "tabs": {
+      "signIn": "Sign In",
+      "signUp": "Sign Up"
+    },
+    "form": {
+      "email": "Email",
+      "password": "Password",
+      "name": "Full Name",
+      "emailPlaceholder": "your@email.com",
+      "passwordPlaceholder": "••••••••",
+      "namePlaceholder": "Your name",
+      "passwordHint": "Minimum of 6 characters",
+      "signIn": "Sign In",
+      "signingIn": "Signing in...",
+      "signUp": "Create account",
+      "signingUp": "Creating account..."
+    },
+    "toasts": {
+      "signInSuccessTitle": "Signed in successfully!",
+      "signInSuccessDescription": "Welcome back!",
+      "signInFallback": "Unable to sign in.",
+      "signInErrorTitle": "Error signing in",
+      "signUpSuccessTitle": "Account created successfully!",
+      "signUpSuccessDescription": "Check your email to confirm your account.",
+      "signUpFallback": "Unable to create the account.",
+      "signUpErrorTitle": "Error creating account"
+    }
   },
   "notFound": {
     "oops": "Oops! Page not found",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -71,6 +71,16 @@
       "integration": "Integración de IA"
     }
   },
+  "meta": {
+    "index": "Monynha Softwares: Tecnología con orgullo, diversidad y resistencia",
+    "about": "Acerca de Monynha Softwares Agency",
+    "projects": "Proyectos Open Source - Monynha Softwares Agency",
+    "solutions": "Nuestras Soluciones de Software - Monynha Softwares Agency",
+    "contact": "Contacto - Monynha Softwares Agency",
+    "blog": "Ideas y Actualizaciones - Monynha Softwares Agency",
+    "blogPost": "{{title}} - Monynha Softwares Agency",
+    "solutionDetail": "{{title}} - Monynha Softwares Agency"
+  },
   "index": {
     "hero": {
       "headline": "Construyendo el <0/><1>futuro con tecnología</1>",
@@ -111,6 +121,43 @@
     },
     "learnMore": "Saber Más"
   },
+  "solutionsContent": {
+    "fallback": {
+      "boteco": {
+        "title": "Boteco Pro",
+        "description": "Solución integral de gestión para bares y restaurantes con analíticas en tiempo real, control de inventario e insights de clientes.",
+        "features": [
+          "Analíticas en tiempo real para monitorear ventas, inventario y comportamiento de clientes.",
+          "Herramientas inteligentes para turnos y seguimiento del desempeño del equipo.",
+          "Procesamiento de pedidos optimizado con soporte POS móvil.",
+          "Pagos multicanal seguros y protegidos contra fraudes."
+        ]
+      },
+      "assistina": {
+        "title": "AssisTina AI",
+        "description": "Asistente de IA inteligente que aprende tus procesos y automatiza tareas rutinarias para aumentar la eficiencia.",
+        "features": [
+          "Flujos de machine learning adaptativos a tu operación.",
+          "Conversaciones en lenguaje natural por voz y texto.",
+          "Programaciones, recordatorios y tareas de seguimiento automatizadas.",
+          "Integraciones personalizadas con tus herramientas de negocio."
+        ]
+      }
+    },
+    "github": {
+      "fallbackDescription": "Solución open source mantenida por Monynha Softwares.",
+      "metadata": {
+        "language": "Construida con {{language}}.",
+        "homepage": "Proyecto en producción: {{url}}",
+        "stars_one": "{{count}} ⭐ estrella en GitHub",
+        "stars_other": "{{count}} ⭐ estrellas en GitHub",
+        "issues_one": "{{count}} issue abierta",
+        "issues_other": "{{count}} issues abiertas",
+        "defaultBranch": "Branch predeterminada: {{branch}}",
+        "updatedAt": "Última actualización: {{date}}"
+      }
+    }
+  },
   "solutionsPage": {
     "title": "Nuestras Soluciones de Software",
     "description": "Conoce nuestros productos estrella diseñados para transformar la operación de las empresas. Cada solución se crea con IA en el núcleo para máxima eficiencia.",
@@ -120,7 +167,10 @@
     "notFound": "Solución no encontrada",
     "customTitle": "¿Necesitas una Solución Personalizada?",
     "customDescription": "También creamos soluciones a medida para tus necesidades específicas. Conversemos sobre cómo construir algo único para ti.",
-    "discuss": "Discutir Proyecto"
+    "discuss": "Discutir Proyecto",
+    "loading": "Cargando...",
+    "error": "No pudimos cargar las soluciones en este momento.",
+    "errorSingle": "No pudimos cargar esta solución."
   },
   "about": {
     "title": "Sobre Monynha Softwares Agency",
@@ -163,6 +213,8 @@
   "blog": {
     "title": "Noticias e Ideas",
     "description": "Mantente actualizado con las últimas tendencias en IA, desarrollo de software y automatización empresarial. Contenido experto de nuestro equipo.",
+    "defaultAuthor": "Equipo Monynha Softwares",
+    "defaultCategory": "Ideas de IA",
     "featured": "Destacado",
     "read": "Leer Artículo Completo",
     "readMore": "Leer Más",
@@ -297,7 +349,47 @@
     "liveDemo": "Demo en Vivo",
     "like": "¿Te gustan nuestros proyectos?",
     "likeDescription": "Ponte en contacto para crear una solución personalizada para tu negocio.",
-    "contactUs": "Contáctanos"
+    "contactUs": "Contáctanos",
+    "loadingSolutions": "Cargando soluciones...",
+    "errorSolutions": "No pudimos cargar las soluciones. Inténtalo de nuevo.",
+    "error": "No pudimos cargar los proyectos en este momento.",
+    "errorAdditional": "No pudimos cargar más proyectos.",
+    "loading": "Cargando...",
+    "errorGithub": "No pudimos cargar los proyectos de GitHub."
+  },
+  "auth": {
+    "link": {
+      "backHome": "Volver al inicio"
+    },
+    "brand": "Monynha Softwares",
+    "description": "Inicia sesión o crea tu cuenta",
+    "tabs": {
+      "signIn": "Iniciar sesión",
+      "signUp": "Registrarse"
+    },
+    "form": {
+      "email": "Correo electrónico",
+      "password": "Contraseña",
+      "name": "Nombre completo",
+      "emailPlaceholder": "tu@email.com",
+      "passwordPlaceholder": "••••••••",
+      "namePlaceholder": "Tu nombre",
+      "passwordHint": "Mínimo 6 caracteres",
+      "signIn": "Iniciar sesión",
+      "signingIn": "Iniciando sesión...",
+      "signUp": "Crear cuenta",
+      "signingUp": "Creando cuenta..."
+    },
+    "toasts": {
+      "signInSuccessTitle": "¡Inicio de sesión exitoso!",
+      "signInSuccessDescription": "¡Bienvenido de nuevo!",
+      "signInFallback": "No fue posible iniciar sesión.",
+      "signInErrorTitle": "Error al iniciar sesión",
+      "signUpSuccessTitle": "¡Cuenta creada con éxito!",
+      "signUpSuccessDescription": "Revisa tu correo para confirmar la cuenta.",
+      "signUpFallback": "No fue posible crear la cuenta.",
+      "signUpErrorTitle": "Error al crear la cuenta"
+    }
   },
   "notFound": {
     "oops": "¡Vaya! Página no encontrada",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -71,6 +71,16 @@
       "integration": "Intégration IA"
     }
   },
+  "meta": {
+    "index": "Monynha Softwares : technologie avec fierté, diversité et résistance",
+    "about": "À propos de Monynha Softwares Agency",
+    "projects": "Projets Open Source - Monynha Softwares Agency",
+    "solutions": "Nos solutions logicielles - Monynha Softwares Agency",
+    "contact": "Contact - Monynha Softwares Agency",
+    "blog": "Actualités et insights - Monynha Softwares Agency",
+    "blogPost": "{{title}} - Monynha Softwares Agency",
+    "solutionDetail": "{{title}} - Monynha Softwares Agency"
+  },
   "index": {
     "hero": {
       "headline": "Construire l'<0/><1>Avenir avec la Technologie</1>",
@@ -111,6 +121,43 @@
     },
     "learnMore": "En savoir plus"
   },
+  "solutionsContent": {
+    "fallback": {
+      "boteco": {
+        "title": "Boteco Pro",
+        "description": "Solution de gestion complète pour bars et restaurants avec analyses en temps réel, gestion des stocks et insights clients.",
+        "features": [
+          "Analyses en temps réel pour suivre ventes, stocks et comportement client.",
+          "Planification intelligente des équipes et suivi des performances.",
+          "Traitement des commandes simplifié avec prise en charge POS mobile.",
+          "Paiements multicanaux sécurisés et protégés contre la fraude."
+        ]
+      },
+      "assistina": {
+        "title": "AssisTina AI",
+        "description": "Assistante IA intelligente qui apprend vos processus et automatise les tâches routinières pour gagner en efficacité.",
+        "features": [
+          "Workflows de machine learning adaptatifs à vos opérations.",
+          "Conversations en langage naturel via voix et texte.",
+          "Planifications, rappels et suivis automatisés.",
+          "Intégrations personnalisées avec vos outils métiers."
+        ]
+      }
+    },
+    "github": {
+      "fallbackDescription": "Solution open source maintenue par Monynha Softwares.",
+      "metadata": {
+        "language": "Développée avec {{language}}.",
+        "homepage": "Projet en ligne : {{url}}",
+        "stars_one": "{{count}} ⭐ étoile sur GitHub",
+        "stars_other": "{{count}} ⭐ étoiles sur GitHub",
+        "issues_one": "{{count}} ticket ouvert",
+        "issues_other": "{{count}} tickets ouverts",
+        "defaultBranch": "Branche par défaut : {{branch}}",
+        "updatedAt": "Dernière mise à jour : {{date}}"
+      }
+    }
+  },
   "solutionsPage": {
     "title": "Nos Solutions logicielles",
     "description": "Découvrez nos produits phares conçus pour transformer la façon dont les entreprises fonctionnent. Chaque solution est développée avec l'IA au cœur pour une efficacité maximale.",
@@ -120,7 +167,10 @@
     "notFound": "Solution introuvable",
     "customTitle": "Besoin d'une solution personnalisée ?",
     "customDescription": "Nous créons également des solutions sur mesure adaptées à vos besoins spécifiques. Discutons de la manière de construire quelque chose d'unique pour vous.",
-    "discuss": "Discuter du projet"
+    "discuss": "Discuter du projet",
+    "loading": "Chargement...",
+    "error": "Impossible de charger les solutions pour le moment.",
+    "errorSingle": "Impossible de charger cette solution."
   },
   "about": {
     "title": "À propos de Monynha Softwares Agency",
@@ -163,6 +213,8 @@
   "blog": {
     "title": "Actualités et Idées",
     "description": "Restez informé des dernières tendances en IA, développement logiciel et automatisation d'entreprise. Des contenus d'experts issus de notre équipe.",
+    "defaultAuthor": "Équipe Monynha Softwares",
+    "defaultCategory": "Insights IA",
     "featured": "À la une",
     "read": "Lire l'article complet",
     "readMore": "En savoir plus",
@@ -297,7 +349,47 @@
     "liveDemo": "Démo en ligne",
     "like": "Vous aimez nos projets ?",
     "likeDescription": "Contactez-nous pour créer une solution personnalisée pour votre entreprise.",
-    "contactUs": "Nous contacter"
+    "contactUs": "Nous contacter",
+    "loadingSolutions": "Chargement des solutions...",
+    "errorSolutions": "Impossible de charger les solutions. Réessayez.",
+    "error": "Impossible de charger les projets pour le moment.",
+    "errorAdditional": "Impossible de charger des projets supplémentaires.",
+    "loading": "Chargement...",
+    "errorGithub": "Impossible de charger les projets GitHub."
+  },
+  "auth": {
+    "link": {
+      "backHome": "Retour à l'accueil"
+    },
+    "brand": "Monynha Softwares",
+    "description": "Connectez-vous ou créez votre compte",
+    "tabs": {
+      "signIn": "Connexion",
+      "signUp": "Inscription"
+    },
+    "form": {
+      "email": "E-mail",
+      "password": "Mot de passe",
+      "name": "Nom complet",
+      "emailPlaceholder": "votre@email.com",
+      "passwordPlaceholder": "••••••••",
+      "namePlaceholder": "Votre nom",
+      "passwordHint": "6 caractères minimum",
+      "signIn": "Se connecter",
+      "signingIn": "Connexion...",
+      "signUp": "Créer un compte",
+      "signingUp": "Création du compte..."
+    },
+    "toasts": {
+      "signInSuccessTitle": "Connexion réussie !",
+      "signInSuccessDescription": "Heureux de vous revoir !",
+      "signInFallback": "Impossible de se connecter.",
+      "signInErrorTitle": "Erreur de connexion",
+      "signUpSuccessTitle": "Compte créé avec succès !",
+      "signUpSuccessDescription": "Vérifiez votre e-mail pour confirmer votre compte.",
+      "signUpFallback": "Impossible de créer le compte.",
+      "signUpErrorTitle": "Erreur lors de la création du compte"
+    }
   },
   "notFound": {
     "oops": "Oups ! Page introuvable",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -71,6 +71,16 @@
       "integration": "Integração de IA"
     }
   },
+  "meta": {
+    "index": "Monynha Softwares: Tecnologia com orgulho, diversidade e resistência",
+    "about": "Sobre a Monynha Softwares Agency",
+    "projects": "Projetos Open Source - Monynha Softwares Agency",
+    "solutions": "Nossas Soluções de Software - Monynha Softwares Agency",
+    "contact": "Contato - Monynha Softwares Agency",
+    "blog": "Insights & Novidades - Monynha Softwares Agency",
+    "blogPost": "{{title}} - Monynha Softwares Agency",
+    "solutionDetail": "{{title}} - Monynha Softwares Agency"
+  },
   "index": {
     "hero": {
       "headline": "Construindo o <0/><1>Futuro com Tecnologia</1>",
@@ -111,6 +121,43 @@
     },
     "learnMore": "Saiba Mais"
   },
+  "solutionsContent": {
+    "fallback": {
+      "boteco": {
+        "title": "Boteco Pro",
+        "description": "Solução completa de gestão para bares e restaurantes com analytics em tempo real, controle de estoque e insights de clientes.",
+        "features": [
+          "Analytics em tempo real para monitorar vendas, estoque e comportamento de clientes.",
+          "Escalas inteligentes e acompanhamento de performance da equipe.",
+          "Processamento de pedidos simplificado com suporte a POS móvel.",
+          "Pagamentos multicanal seguros e protegidos contra fraude."
+        ]
+      },
+      "assistina": {
+        "title": "AssisTina AI",
+        "description": "Assistente de IA inteligente que aprende seus processos e automatiza tarefas rotineiras para aumentar a eficiência.",
+        "features": [
+          "Fluxos de machine learning adaptativos personalizados para sua operação.",
+          "Conversas em linguagem natural por voz e texto.",
+          "Agendamentos automáticos, lembretes e tarefas de follow-up.",
+          "Integrações personalizadas com as ferramentas do seu negócio."
+        ]
+      }
+    },
+    "github": {
+      "fallbackDescription": "Solução open source mantida pela Monynha Softwares.",
+      "metadata": {
+        "language": "Construída com {{language}}.",
+        "homepage": "Projeto ao vivo: {{url}}",
+        "stars_one": "{{count}} ⭐ estrela no GitHub",
+        "stars_other": "{{count}} ⭐ estrelas no GitHub",
+        "issues_one": "{{count}} issue aberta",
+        "issues_other": "{{count}} issues abertas",
+        "defaultBranch": "Branch padrão: {{branch}}",
+        "updatedAt": "Atualizado pela última vez em {{date}}"
+      }
+    }
+  },
   "solutionsPage": {
     "title": "Nossas Soluções de Software",
     "description": "Conheça nossos produtos desenvolvidos para transformar a operação de empresas. Cada solução é criada com IA no núcleo para máxima eficiência.",
@@ -120,7 +167,10 @@
     "notFound": "Solução não encontrada",
     "customTitle": "Precisa de uma Solução Personalizada?",
     "customDescription": "Também criamos soluções sob medida para suas necessidades específicas de negócio. Vamos conversar sobre como construir algo único para você.",
-    "discuss": "Discutir Projeto"
+    "discuss": "Discutir Projeto",
+    "loading": "Carregando...",
+    "error": "Não foi possível carregar as soluções agora.",
+    "errorSingle": "Não foi possível carregar esta solução."
   },
   "about": {
     "title": "Sobre a Monynha Softwares Agency",
@@ -163,6 +213,8 @@
   "blog": {
     "title": "Insights e Novidades",
     "description": "Fique por dentro das últimas tendências em IA, desenvolvimento de software e automação empresarial. Conteúdos de especialistas do nosso time.",
+    "defaultAuthor": "Equipe Monynha Softwares",
+    "defaultCategory": "Insights de IA",
     "featured": "Destaque",
     "read": "Ler Artigo Completo",
     "readMore": "Ler Mais",
@@ -295,7 +347,47 @@
     "liveDemo": "Demo ao Vivo",
     "like": "Gostou dos projetos?",
     "likeDescription": "Entre em contato para criar uma solução personalizada para seu negócio.",
-    "contactUs": "Fale Conosco"
+    "contactUs": "Fale Conosco",
+    "loadingSolutions": "Carregando soluções...",
+    "errorSolutions": "Não foi possível carregar as soluções. Tente novamente.",
+    "error": "Não foi possível carregar os projetos agora.",
+    "errorAdditional": "Não foi possível carregar projetos adicionais.",
+    "loading": "Carregando...",
+    "errorGithub": "Não foi possível carregar projetos do GitHub."
+  },
+  "auth": {
+    "link": {
+      "backHome": "Voltar para o início"
+    },
+    "brand": "Monynha Softwares",
+    "description": "Faça login ou crie sua conta",
+    "tabs": {
+      "signIn": "Entrar",
+      "signUp": "Cadastrar-se"
+    },
+    "form": {
+      "email": "E-mail",
+      "password": "Senha",
+      "name": "Nome completo",
+      "emailPlaceholder": "seu@email.com",
+      "passwordPlaceholder": "••••••••",
+      "namePlaceholder": "Seu nome",
+      "passwordHint": "Mínimo de 6 caracteres",
+      "signIn": "Entrar",
+      "signingIn": "Entrando...",
+      "signUp": "Criar conta",
+      "signingUp": "Criando conta..."
+    },
+    "toasts": {
+      "signInSuccessTitle": "Login realizado com sucesso!",
+      "signInSuccessDescription": "Bem-vindo de volta!",
+      "signInFallback": "Não foi possível fazer login.",
+      "signInErrorTitle": "Erro ao fazer login",
+      "signUpSuccessTitle": "Conta criada com sucesso!",
+      "signUpSuccessDescription": "Verifique seu e-mail para confirmar a conta.",
+      "signUpFallback": "Não foi possível criar a conta.",
+      "signUpErrorTitle": "Erro ao criar conta"
+    }
   },
   "notFound": {
     "oops": "Ops! Página não encontrada",

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -140,9 +140,9 @@ const About = () => {
   return (
     <Layout>
       <Meta
-        title="About Monynha Softwares Agency"
+        title={t('meta.about')}
         description={t('about.description')}
-        ogTitle="About Monynha Softwares Agency"
+        ogTitle={t('meta.about')}
         ogDescription={t('about.description')}
         ogImage="/placeholder.svg"
       />

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -14,10 +14,12 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Label } from '@/components/ui/label';
 import { useToast } from '@/hooks/use-toast';
 import { ArrowLeft, Eye, EyeOff, Loader2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
 
 type AuthView = 'signin' | 'signup';
 
 const Auth = () => {
+  const { t } = useTranslation();
   const [authView, setAuthView] = useState<AuthView>('signin');
   const [loadingView, setLoadingView] = useState<AuthView | null>(null);
   const [showPassword, setShowPassword] = useState(false);
@@ -62,16 +64,18 @@ const Auth = () => {
       }
 
       toast({
-        title: 'Login realizado com sucesso!',
-        description: 'Bem-vindo de volta!',
+        title: t('auth.toasts.signInSuccessTitle'),
+        description: t('auth.toasts.signInSuccessDescription'),
       });
 
       navigate(redirectPath, { replace: true });
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Não foi possível fazer login.';
+        error instanceof Error
+          ? error.message
+          : t('auth.toasts.signInFallback');
       toast({
-        title: 'Erro ao fazer login',
+        title: t('auth.toasts.signInErrorTitle'),
         description: message,
         variant: 'destructive',
       });
@@ -106,8 +110,8 @@ const Auth = () => {
       }
 
       toast({
-        title: 'Conta criada com sucesso!',
-        description: 'Verifique seu email para confirmar a conta.',
+        title: t('auth.toasts.signUpSuccessTitle'),
+        description: t('auth.toasts.signUpSuccessDescription'),
       });
 
       setSignInForm({ email: signUpForm.email.trim(), password: '' });
@@ -116,9 +120,11 @@ const Auth = () => {
       setShowPassword(false);
     } catch (error) {
       const message =
-        error instanceof Error ? error.message : 'Não foi possível criar a conta.';
+        error instanceof Error
+          ? error.message
+          : t('auth.toasts.signUpFallback');
       toast({
-        title: 'Erro ao criar conta',
+        title: t('auth.toasts.signUpErrorTitle'),
         description: message,
         variant: 'destructive',
       });
@@ -136,11 +142,11 @@ const Auth = () => {
             className="flex items-center text-sm text-muted-foreground hover:text-primary transition-colors"
           >
             <ArrowLeft className="h-4 w-4 mr-2" />
-            Voltar para home
+            {t('auth.link.backHome')}
           </Link>
           <div className="text-center">
-            <CardTitle className="text-2xl font-bold">Monynha Softwares</CardTitle>
-            <CardDescription>Faça login ou crie sua conta</CardDescription>
+            <CardTitle className="text-2xl font-bold">{t('auth.brand')}</CardTitle>
+            <CardDescription>{t('auth.description')}</CardDescription>
           </div>
         </CardHeader>
 
@@ -154,14 +160,14 @@ const Auth = () => {
             className="w-full"
           >
             <TabsList className="grid w-full grid-cols-2">
-              <TabsTrigger value="signin">Login</TabsTrigger>
-              <TabsTrigger value="signup">Cadastro</TabsTrigger>
+              <TabsTrigger value="signin">{t('auth.tabs.signIn')}</TabsTrigger>
+              <TabsTrigger value="signup">{t('auth.tabs.signUp')}</TabsTrigger>
             </TabsList>
 
             <TabsContent value="signin" className="space-y-4">
               <form onSubmit={handleSignIn} className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="signin-email">Email</Label>
+                  <Label htmlFor="signin-email">{t('auth.form.email')}</Label>
                   <Input
                     id="signin-email"
                     type="email"
@@ -172,14 +178,14 @@ const Auth = () => {
                         email: event.target.value,
                       }))
                     }
-                    placeholder="seu@email.com"
+                    placeholder={t('auth.form.emailPlaceholder')}
                     autoComplete="email"
                     required
                   />
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="signin-password">Senha</Label>
+                  <Label htmlFor="signin-password">{t('auth.form.password')}</Label>
                   <div className="relative">
                     <Input
                       id="signin-password"
@@ -191,7 +197,7 @@ const Auth = () => {
                           password: event.target.value,
                         }))
                       }
-                      placeholder="••••••••"
+                      placeholder={t('auth.form.passwordPlaceholder')}
                       autoComplete="current-password"
                       required
                       minLength={6}
@@ -220,10 +226,10 @@ const Auth = () => {
                   {loadingView === 'signin' ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Entrando...
+                      {t('auth.form.signingIn')}
                     </>
                   ) : (
-                    'Entrar'
+                    t('auth.form.signIn')
                   )}
                 </Button>
               </form>
@@ -232,7 +238,7 @@ const Auth = () => {
             <TabsContent value="signup" className="space-y-4">
               <form onSubmit={handleSignUp} className="space-y-4">
                 <div className="space-y-2">
-                  <Label htmlFor="signup-name">Nome</Label>
+                  <Label htmlFor="signup-name">{t('auth.form.name')}</Label>
                   <Input
                     id="signup-name"
                     type="text"
@@ -243,14 +249,14 @@ const Auth = () => {
                         name: event.target.value,
                       }))
                     }
-                    placeholder="Seu nome"
+                    placeholder={t('auth.form.namePlaceholder')}
                     autoComplete="name"
                     required
                   />
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="signup-email">Email</Label>
+                  <Label htmlFor="signup-email">{t('auth.form.email')}</Label>
                   <Input
                     id="signup-email"
                     type="email"
@@ -261,14 +267,14 @@ const Auth = () => {
                         email: event.target.value,
                       }))
                     }
-                    placeholder="seu@email.com"
+                    placeholder={t('auth.form.emailPlaceholder')}
                     autoComplete="email"
                     required
                   />
                 </div>
 
                 <div className="space-y-2">
-                  <Label htmlFor="signup-password">Senha</Label>
+                  <Label htmlFor="signup-password">{t('auth.form.password')}</Label>
                   <div className="relative">
                     <Input
                       id="signup-password"
@@ -280,7 +286,7 @@ const Auth = () => {
                           password: event.target.value,
                         }))
                       }
-                      placeholder="••••••••"
+                      placeholder={t('auth.form.passwordPlaceholder')}
                       autoComplete="new-password"
                       required
                       minLength={6}
@@ -299,7 +305,7 @@ const Auth = () => {
                       )}
                     </Button>
                   </div>
-                  <p className="text-xs text-muted-foreground">Mínimo de 6 caracteres</p>
+                  <p className="text-xs text-muted-foreground">{t('auth.form.passwordHint')}</p>
                 </div>
 
                 <Button
@@ -310,10 +316,10 @@ const Auth = () => {
                   {loadingView === 'signup' ? (
                     <>
                       <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Criando conta...
+                      {t('auth.form.signingUp')}
                     </>
                   ) : (
-                    'Criar conta'
+                    t('auth.form.signUp')
                   )}
                 </Button>
               </form>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -149,19 +149,23 @@ const Blog = () => {
   const totalPages = totalPosts > 0 ? Math.ceil(totalPosts / POSTS_PER_PAGE) : 1;
 
   const formattedPosts = useMemo(
-    () =>
-      (data?.posts ?? []).map((post, index) => ({
+    () => {
+      const defaultAuthor = t('blog.defaultAuthor');
+      const defaultCategory = t('blog.defaultCategory');
+
+      return (data?.posts ?? []).map((post, index) => ({
         id: post.id,
         slug: post.slug,
         title: post.title,
         excerpt: post.excerpt ?? t('blog.fallbackExcerpt'),
         image: post.image_url ?? FALLBACK_IMAGE,
-        author: 'Monynha Softwares Team',
+        author: defaultAuthor,
         date: dateFormatter.format(new Date(post.updated_at)),
         readTime: t('blog.readTimeDefault'),
-        category: 'AI Insights',
+        category: defaultCategory,
         featured: page === 1 && index === 0,
-      })),
+      }));
+    },
     [data?.posts, dateFormatter, page, t]
   );
 
@@ -194,14 +198,17 @@ const Blog = () => {
     [page, totalPages]
   );
 
+  const metaTitle = t('meta.blog');
+  const metaDescription = t('blog.description');
+
   if (isLoading && !data) {
     return (
       <Layout>
         <Meta
-          title="Insights & Updates - Monynha Softwares Agency"
-          description={t('blog.description')}
-          ogTitle="Insights & Updates - Monynha Softwares Agency"
-          ogDescription={t('blog.description')}
+          title={metaTitle}
+          description={metaDescription}
+          ogTitle={metaTitle}
+          ogDescription={metaDescription}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
@@ -215,10 +222,10 @@ const Blog = () => {
     return (
       <Layout>
         <Meta
-          title="Insights & Updates - Monynha Softwares Agency"
-          description={t('blog.description')}
-          ogTitle="Insights & Updates - Monynha Softwares Agency"
-          ogDescription={t('blog.description')}
+          title={metaTitle}
+          description={metaDescription}
+          ogTitle={metaTitle}
+          ogDescription={metaDescription}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
@@ -231,10 +238,10 @@ const Blog = () => {
   return (
     <Layout>
       <Meta
-        title="Insights & Updates - Monynha Softwares Agency"
-        description={t('blog.description')}
-        ogTitle="Insights & Updates - Monynha Softwares Agency"
-        ogDescription={t('blog.description')}
+        title={metaTitle}
+        description={metaDescription}
+        ogTitle={metaTitle}
+        ogDescription={metaDescription}
         ogImage="/placeholder.svg"
       />
       <div className="max-w-7xl mx-auto px-4 pt-4">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -300,9 +300,9 @@ const Contact = () => {
     return (
       <Layout>
         <Meta
-          title="Contact - Monynha Softwares Agency"
+          title={t('meta.contact')}
           description={t('contact.description')}
-          ogTitle="Contact - Monynha Softwares Agency"
+          ogTitle={t('meta.contact')}
           ogDescription={t('contact.description')}
           ogImage="/placeholder.svg"
         />
@@ -347,9 +347,9 @@ const Contact = () => {
   return (
     <Layout>
       <Meta
-        title="Contact - Monynha Softwares Agency"
+        title={t('meta.contact')}
         description={t('contact.description')}
-        ogTitle="Contact - Monynha Softwares Agency"
+        ogTitle={t('meta.contact')}
         ogDescription={t('contact.description')}
         ogImage="/placeholder.svg"
       />

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -20,36 +20,21 @@ import { useTranslation, Trans } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase';
 import { useMemo } from 'react';
-
-const fallbackSolutions = [
-  {
-    name: 'Boteco Pro',
-    description:
-      'Complete restaurant and bar management system with AI-powered analytics and inventory management.',
-    features: [
-      'Order Management',
-      'Inventory Tracking',
-      'Analytics Dashboard',
-      'Staff Management',
-    ],
-    gradient: 'from-brand-purple to-brand-blue',
-  },
-  {
-    name: 'AssisTina AI',
-    description:
-      'Personalized AI assistant that learns your business needs and automates routine tasks.',
-    features: [
-      'Natural Language Processing',
-      'Task Automation',
-      'Learning Capabilities',
-      'Custom Integration',
-    ],
-    gradient: 'from-brand-pink to-brand-orange',
-  },
-];
+import { getFallbackSolutions } from '@/lib/solutions';
 
 const Index = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+
+  const localizedFallbackSolutions = useMemo(
+    () =>
+      getFallbackSolutions(i18n.language).map((solution) => ({
+        name: solution.title,
+        description: solution.description,
+        features: solution.features,
+        gradient: solution.gradient,
+      })),
+    [i18n.language]
+  );
 
   // Fetch dynamic homepage features from database
   const { data: features, isLoading: featuresLoading } = useQuery({
@@ -141,14 +126,14 @@ const Index = () => {
   );
 
   const displayFeatures = features || fallbackFeatures;
-  const displaySolutions = solutions || fallbackSolutions;
+  const displaySolutions = solutions || localizedFallbackSolutions;
 
   return (
     <Layout>
       <Meta
-        title="Monynha Softwares: Technology with pride, diversity, and resistance"
+        title={t('meta.index')}
         description={t('index.hero.description')}
-        ogTitle="Monynha Softwares: Technology with pride, diversity, and resistance"
+        ogTitle={t('meta.index')}
         ogDescription={t('index.hero.description')}
         ogImage="/placeholder.svg"
       />

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -24,11 +24,11 @@ import {
 import type { SolutionContent } from '@/types/solutions';
 
 const Solutions = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const memoizedFallbackSolutions = useMemo(
-    () => getFallbackSolutions(),
-    []
+    () => getFallbackSolutions(i18n.language),
+    [i18n.language]
   );
 
   const {
@@ -36,7 +36,7 @@ const Solutions = () => {
     isLoading,
     isError,
   } = useQuery<SolutionContent[]>({
-    queryKey: ['solutions'],
+    queryKey: ['solutions', i18n.language],
     queryFn: async () => {
       const { data, error } = await supabase
         .from('solutions')
@@ -49,7 +49,10 @@ const Solutions = () => {
       }
 
       return (data ?? []).map((solution, index) =>
-        mapSupabaseSolutionToContent(solution, { index })
+        mapSupabaseSolutionToContent(solution, {
+          index,
+          language: i18n.language,
+        })
       );
     },
 
@@ -65,14 +68,14 @@ const Solutions = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('meta.solutions')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('meta.solutions')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
-          Loading...
+          {t('solutionsPage.loading')}
         </div>
       </Layout>
     );
@@ -82,14 +85,14 @@ const Solutions = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('meta.solutions')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('meta.solutions')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
-          Error loading solutions
+          {t('solutionsPage.error')}
         </div>
       </Layout>
     );
@@ -98,9 +101,9 @@ const Solutions = () => {
   return (
     <Layout>
       <Meta
-        title="Our Software Solutions - Monynha Softwares Agency"
+        title={t('meta.solutions')}
         description={t('solutionsPage.description')}
-        ogTitle="Our Software Solutions - Monynha Softwares Agency"
+        ogTitle={t('meta.solutions')}
         ogDescription={t('solutionsPage.description')}
         ogImage="/placeholder.svg"
       />

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -266,12 +266,12 @@ const BlogPostPage = () => {
     : '';
 
   const metaTitle = post
-    ? `${post.title} - Monynha Softwares Agency`
-    : 'Insights & Updates - Monynha Softwares Agency';
+    ? t('meta.blogPost', { title: post.title })
+    : t('meta.blog');
 
   const metaDescription = post?.excerpt ?? t('blog.description');
   const metaImage = post?.image_url ?? '/placeholder.svg';
-  const defaultAuthor = 'Monynha Softwares Team';
+  const defaultAuthor = t('blog.defaultAuthor');
   const readTimeLabel = t('blog.readTimeDefault');
 
   if (isLoading) {

--- a/src/pages/solutions/[slug].tsx
+++ b/src/pages/solutions/[slug].tsx
@@ -31,11 +31,11 @@ const getRepositoryUrl = (repositorySlug: string) =>
 
 const SolutionDetail = () => {
   const { slug } = useParams<{ slug: string }>();
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
 
   const fallbackSolution = useMemo(
-    () => (slug ? getFallbackSolution(slug) : undefined),
-    [slug]
+    () => (slug ? getFallbackSolution(slug, i18n.language) : undefined),
+    [slug, i18n.language]
   );
 
   const {
@@ -43,7 +43,7 @@ const SolutionDetail = () => {
     isLoading,
     isError,
   } = useQuery<SolutionContent | null>({
-    queryKey: ['solution', slug],
+    queryKey: ['solution', slug, i18n.language],
     enabled: Boolean(slug),
     queryFn: async () => {
       if (!slug) {
@@ -62,7 +62,9 @@ const SolutionDetail = () => {
       }
 
       if (data) {
-        return mapSupabaseSolutionToContent(data);
+        return mapSupabaseSolutionToContent(data, {
+          language: i18n.language,
+        });
       }
 
       const response = await fetch(getRepositoryUrl(slug), {
@@ -85,7 +87,7 @@ const SolutionDetail = () => {
         return null;
       }
 
-      return mapGitHubRepoToContent(repository, 0);
+      return mapGitHubRepoToContent(repository, 0, i18n.language);
     },
     staleTime: 1000 * 60 * 10,
     retry: 1,
@@ -99,13 +101,15 @@ const SolutionDetail = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('meta.solutions')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('meta.solutions')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
-        <div className="container mx-auto px-4 py-16 text-center">Loading...</div>
+        <div className="container mx-auto px-4 py-16 text-center">
+          {t('solutionsPage.loading')}
+        </div>
       </Layout>
     );
   }
@@ -114,14 +118,14 @@ const SolutionDetail = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('meta.solutions')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('meta.solutions')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
         <div className="container mx-auto px-4 py-16 text-center">
-          Error loading solution
+          {t('solutionsPage.errorSingle')}
         </div>
       </Layout>
     );
@@ -131,9 +135,9 @@ const SolutionDetail = () => {
     return (
       <Layout>
         <Meta
-          title="Our Software Solutions - Monynha Softwares Agency"
+          title={t('meta.solutions')}
           description={t('solutionsPage.description')}
-          ogTitle="Our Software Solutions - Monynha Softwares Agency"
+          ogTitle={t('meta.solutions')}
           ogDescription={t('solutionsPage.description')}
           ogImage="/placeholder.svg"
         />
@@ -157,9 +161,9 @@ const SolutionDetail = () => {
   return (
     <Layout>
       <Meta
-        title={`${displaySolution.title} - Monynha Softwares Agency`}
+        title={t('meta.solutionDetail', { title: displaySolution.title })}
         description={displaySolution.description}
-        ogTitle={`${displaySolution.title} - Monynha Softwares Agency`}
+        ogTitle={t('meta.solutionDetail', { title: displaySolution.title })}
         ogDescription={displaySolution.description}
         ogImage={displaySolution.imageUrl ?? '/placeholder.svg'}
       />


### PR DESCRIPTION
## Summary
- add translation-aware fallback solution utilities and metadata handling
- expand locale resources with meta, solution fallback, project state, and auth strings across en/pt/es/fr
- update pages to load translations via the i18n helper, localize meta tags, and replace hard-coded text including the auth flow

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68ca52eea0608322a5d5ee830c04f706