### PR TITLE
feat: refresh theming, accessibility and sitemap

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,4 @@
-User-agent: Googlebot
-Allow: /
-
-User-agent: Bingbot
-Allow: /
-
-User-agent: Twitterbot
-Allow: /
-
-User-agent: facebookexternalhit
-Allow: /
-
 User-agent: *
 Allow: /
+
+Sitemap: https://monynha.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://monynha.com/</loc></url>
   <url><loc>https://monynha.com/about</loc></url>
   <url><loc>https://monynha.com/auth</loc></url>
   <url><loc>https://monynha.com/blog</loc></url>
   <url><loc>https://monynha.com/contact</loc></url>
-  <url><loc>https://monynha.com/</loc></url>
   <url><loc>https://monynha.com/projects</loc></url>
   <url><loc>https://monynha.com/solutions</loc></url>
 </urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -5,21 +5,54 @@ const pagesDir = path.join(process.cwd(), 'src', 'pages');
 const publicDir = path.join(process.cwd(), 'public');
 const baseUrl = process.env.SITE_URL || 'https://monynha.com';
 
-function getRoutes(dir: string): string[] {
-  return readdirSync(dir)
-    .filter((file) => {
-      if (file === '__tests__') return false;
-      if (!file.endsWith('.tsx') && !file.endsWith('.ts')) return false;
-      return true;
-    })
-    .map((file) => path.basename(file, path.extname(file)))
-    .filter((name) => name !== 'NotFound')
-    .map((name) =>
-      name.toLowerCase() === 'index' ? '/' : `/${name.toLowerCase()}`
-    );
+const IGNORE_DIRECTORIES = new Set(['__tests__']);
+const IGNORE_FILES = new Set(['NotFound', 'Dashboard']);
+
+function collectRoutes(dir: string, segments: string[] = []): string[] {
+  const entries = readdirSync(dir, { withFileTypes: true });
+  const routes = new Set<string>();
+
+  for (const entry of entries) {
+    if (IGNORE_DIRECTORIES.has(entry.name)) continue;
+
+    const fullPath = path.join(dir, entry.name);
+
+    if (entry.isDirectory()) {
+      if (entry.name.startsWith('[')) continue;
+
+      const nextSegments = [...segments, entry.name.toLowerCase()];
+      collectRoutes(fullPath, nextSegments)
+        .filter(Boolean)
+        .forEach((route) => routes.add(route));
+      continue;
+    }
+
+    if (!entry.name.endsWith('.tsx') && !entry.name.endsWith('.ts')) {
+      continue;
+    }
+
+    const name = path.basename(entry.name, path.extname(entry.name));
+    if (IGNORE_FILES.has(name) || name.startsWith('[') || name.startsWith('_')) {
+      continue;
+    }
+
+    const routeSegments =
+      name.toLowerCase() === 'index'
+        ? segments
+        : [...segments, name.toLowerCase()];
+
+    const normalized = path.posix.join('/', ...routeSegments);
+    const routePath = normalized === '' ? '/' : normalized;
+
+    routes.add(routePath);
+  }
+
+  return Array.from(routes);
 }
 
-const routes = getRoutes(pagesDir);
+const routes = collectRoutes(pagesDir)
+  .map((route) => (route.endsWith('/') && route !== '/' ? route.slice(0, -1) : route))
+  .sort((a, b) => (a === '/' ? -1 : a.localeCompare(b)));
 
 const xml =
   '<?xml version="1.0" encoding="UTF-8"?>\n' +

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,39 +6,39 @@ import { Separator } from '@/components/ui/separator';
 const Footer = () => {
   const { t } = useTranslation();
   return (
-    <footer className="bg-neutral-50 border-t border-neutral-100">
+    <footer className="border-t border-neutral-100 bg-neutral-50 transition-colors dark:border-neutral-800 dark:bg-neutral-950">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8">
           {/* Logo and Description */}
           <div className="sm:col-span-2">
-            <Link to="/" className="flex items-center space-x-3 mb-4">
-              <div className="w-10 h-10 bg-gradient-brand rounded-xl flex items-center justify-center">
-                <span className="text-white text-lg font-bold">M</span>
+            <Link to="/" className="mb-4 flex items-center space-x-3">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-brand">
+                <span className="text-lg font-bold text-white">M</span>
               </div>
               <div className="flex flex-col">
-                <span className="font-brand font-semibold text-xl text-neutral-900">
+                <span className="font-brand text-xl font-semibold text-neutral-900 dark:text-neutral-100">
                   Mon<span className="text-brand-blue">y</span>nha.com
                 </span>
-                <span className="text-sm text-neutral-400 font-medium">
+                <span className="text-sm font-medium text-neutral-400 dark:text-neutral-500">
                   {t('footer.tagline')}
                 </span>
               </div>
             </Link>
-            <p className="text-neutral-600 max-w-md">
+            <p className="max-w-md text-neutral-600 dark:text-neutral-300">
               {t('footer.description')}
             </p>
           </div>
 
           {/* Quick Links */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="mb-4 font-semibold text-neutral-900 dark:text-neutral-100">
               {t('footer.quickLinks')}
             </h3>
             <ul className="space-y-2">
               <li>
                 <Link
                   to="/solutions"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
                 >
                   {t('navigation.solutions')}
                 </Link>
@@ -46,7 +46,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/about"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
                 >
                   {t('navigation.about')}
                 </Link>
@@ -54,7 +54,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/blog"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
                 >
                   {t('navigation.blog')}
                 </Link>
@@ -62,7 +62,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/contact"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
                 >
                   {t('navigation.contact')}
                 </Link>
@@ -72,27 +72,27 @@ const Footer = () => {
 
           {/* Solutions */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="mb-4 font-semibold text-neutral-900 dark:text-neutral-100">
               {t('footer.solutions')}
             </h3>
             <ul className="space-y-2">
               <li>
-                <span className="text-neutral-600">
+                <span className="text-neutral-600 dark:text-neutral-300">
                   {t('footer.solutionList.boteco')}
                 </span>
               </li>
               <li>
-                <span className="text-neutral-600">
+                <span className="text-neutral-600 dark:text-neutral-300">
                   {t('footer.solutionList.assistina')}
                 </span>
               </li>
               <li>
-                <span className="text-neutral-600">
+                <span className="text-neutral-600 dark:text-neutral-300">
                   {t('footer.solutionList.custom')}
                 </span>
               </li>
               <li>
-                <span className="text-neutral-600">
+                <span className="text-neutral-600 dark:text-neutral-300">
                   {t('footer.solutionList.integration')}
                 </span>
               </li>
@@ -101,7 +101,7 @@ const Footer = () => {
 
           {/* Monynha Ecosystem */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="mb-4 font-semibold text-neutral-900 dark:text-neutral-100">
               {t('footer.ecosystem')}
             </h3>
             <ul className="space-y-2">
@@ -110,7 +110,7 @@ const Footer = () => {
                   href="https://monynha.tech"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
                   aria-label="Visit monynha.tech"
                   title="monynha.tech"
                 >
@@ -122,7 +122,7 @@ const Footer = () => {
                   href="https://monynha.fun"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
                   aria-label="Visit monynha.fun"
                   title="monynha.fun"
                 >
@@ -134,7 +134,7 @@ const Footer = () => {
                   href="https://monynha.online"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
                   aria-label="Visit monynha.online"
                   title="monynha.online"
                 >
@@ -146,7 +146,7 @@ const Footer = () => {
                   href="https://monynha.me"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
                   aria-label="Visit monynha.me"
                   title="monynha.me"
                 >
@@ -158,15 +158,15 @@ const Footer = () => {
 
           {/* Contact */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="mb-4 font-semibold text-neutral-900 dark:text-neutral-100">
               {t('footer.contact')}
             </h3>
             <ul className="space-y-2">
-              <li className="text-sm text-muted-foreground">
+              <li className="text-sm text-muted-foreground dark:text-neutral-300">
                 {t('footer.email')}: {
                   <a
                     href="mailto:hello@monynha.com"
-                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                    className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
                     aria-label="Send email to hello@monynha.com"
                     title="hello@monynha.com"
                   >
@@ -174,17 +174,17 @@ const Footer = () => {
                   </a>
                 }
               </li>
-              <li className="text-sm text-muted-foreground">
+              <li className="text-sm text-muted-foreground dark:text-neutral-300">
                 {t('footer.location')}: Faro, Portugal
               </li>
             </ul>
           </div>
         </div>
 
-        <Separator className="my-8" />
+        <Separator className="my-8 bg-neutral-200 dark:bg-neutral-800" />
 
         <div className="flex flex-col md:flex-row justify-between items-center">
-          <p className="text-neutral-500 text-sm flex items-center space-x-1">
+          <p className="flex items-center space-x-1 text-sm text-neutral-500 dark:text-neutral-400">
             <span>
               {t('footer.copyright', { year: new Date().getFullYear() })}
             </span>
@@ -197,13 +197,13 @@ const Footer = () => {
           <div className="flex space-x-6 mt-4 md:mt-0">
             <Link
               to="#"
-              className="text-neutral-500 hover:text-brand-blue transition-colors ease-in-out duration-300 text-sm"
+              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-400"
             >
               {t('footer.privacy')}
             </Link>
             <Link
               to="#"
-              className="text-neutral-500 hover:text-brand-blue transition-colors ease-in-out duration-300 text-sm"
+              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-400"
             >
               {t('footer.terms')}
             </Link>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors duration-300">
       <SiteHeader />
       <main className="flex-1 pt-20">{children}</main>
       <Footer />

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -88,7 +88,7 @@ const NewsletterSection = () => {
               setIsSubscribed(false);
               setEmail('');
             }}
-            className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl"
+            className="rounded-xl bg-white px-6 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
           >
             {t('newsletterSection.subscribeAnother')}
           </Button>
@@ -100,7 +100,7 @@ const NewsletterSection = () => {
   return (
     <section className="py-24 bg-gradient-hero text-white">
       <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Card className="border-0 shadow-soft-lg rounded-2xl bg-white/10 backdrop-blur-sm">
+        <Card className="rounded-2xl border-0 bg-white/10 shadow-soft-lg backdrop-blur-sm">
           <CardContent className="p-8 lg:p-12 text-center">
             <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
               <Mail className="h-8 w-8 text-white" />
@@ -127,7 +127,7 @@ const NewsletterSection = () => {
                 <Button
                   type="submit"
                   disabled={isSubmitting}
-                  className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-3 rounded-xl whitespace-nowrap"
+                  className="whitespace-nowrap rounded-xl bg-white px-8 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
                 >
                   {isSubmitting
                     ? t('newsletterSection.subscribing')
@@ -136,7 +136,7 @@ const NewsletterSection = () => {
               </div>
             </form>
 
-            <p className="text-sm text-blue-200 mt-4">
+            <p className="mt-4 text-sm text-blue-200">
               {t('newsletterSection.privacy')}
             </p>
           </CardContent>

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -101,7 +101,7 @@ const SiteHeader = () => {
   const isProjectsActive = location.pathname.startsWith('/projects');
 
   const menuCardLinkClasses =
-    'group block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white transition-transform duration-300 hover:-translate-y-0.5 focus-visible:-translate-y-0.5';
+    'group block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-transform duration-300 hover:-translate-y-0.5 focus-visible:-translate-y-0.5';
 
   const renderGradientCard = (
     gradient: string,
@@ -114,9 +114,9 @@ const SiteHeader = () => {
         'rounded-2xl'
       )}
     >
-      <div className="rounded-[1.05rem] bg-white/95 p-4">
+      <div className="rounded-[1.05rem] bg-white/95 p-4 transition-colors dark:bg-neutral-950/90">
         <div className="flex items-center justify-between gap-3">
-          <span className="text-sm font-semibold text-neutral-900">
+          <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
             {content.title}
           </span>
           <ArrowRight
@@ -124,7 +124,7 @@ const SiteHeader = () => {
             aria-hidden="true"
           />
         </div>
-        <p className="mt-2 text-xs leading-relaxed text-neutral-600">
+        <p className="mt-2 text-xs leading-relaxed text-neutral-600 dark:text-neutral-300">
           {content.description}
         </p>
       </div>
@@ -132,23 +132,23 @@ const SiteHeader = () => {
   );
 
   const desktopNavLinkClasses =
-    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white';
+    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-neutral-200';
 
   const desktopNavLinkActiveClasses =
-    'text-brand-blue bg-white/80 shadow-soft-lg';
+    'text-brand-blue bg-white/80 shadow-soft-lg dark:bg-neutral-900/70';
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50 border-b border-white/40 bg-white/70 shadow-[0_10px_35px_rgba(91,44,111,0.08)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/60">
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-white/40 bg-white/70 shadow-[0_10px_35px_rgba(91,44,111,0.08)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/60 transition-colors dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_12px_40px_rgba(3,7,18,0.6)] dark:supports-[backdrop-filter]:bg-neutral-950/70">
       <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <NavLink
           to="/"
-          className="flex items-center space-x-3 rounded-xl px-2 py-1 transition-opacity duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white hover:opacity-80"
+          className="flex items-center space-x-3 rounded-xl px-2 py-1 transition-opacity duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:opacity-80"
         >
           <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-brand text-white shadow-soft-lg">
             <span className="text-lg font-bold">M</span>
           </div>
           <div className="flex items-center space-x-1">
-            <span className="font-brand text-xl font-semibold text-neutral-900">
+            <span className="font-brand text-xl font-semibold text-neutral-900 dark:text-white">
               Mon
               <span className="text-brand-blue">y</span>
               nha
@@ -190,14 +190,14 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isSolutionsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue'
+                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
                   )}
                 >
                   {t('navigation.solutions')}
                 </NavigationMenuTrigger>
                 <NavigationMenuContent className="rounded-2xl shadow-soft-lg">
                   <div className="rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink p-[1px]">
-                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm">
+                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm transition-colors dark:bg-neutral-950/90">
                       <div className="grid gap-4 md:grid-cols-2">
                         {solutionItems.map((item) => {
                           const content = solutionsContent[item.key];
@@ -242,14 +242,14 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isProjectsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue'
+                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
                   )}
                 >
                   {t('navigation.projects')}
                 </NavigationMenuTrigger>
                 <NavigationMenuContent className="rounded-2xl shadow-soft-lg">
                   <div className="rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink p-[1px]">
-                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm">
+                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm transition-colors dark:bg-neutral-950/90">
                       <div className="grid gap-4 md:grid-cols-2">
                         {projectItems.map((item) => {
                           const content = projectsContent[item.key];
@@ -362,14 +362,14 @@ const SiteHeader = () => {
         <div className="hidden items-center gap-3 lg:flex">
           {user ? (
             <div className="flex items-center gap-3">
-              <span className="text-sm text-neutral-600">
+              <span className="text-sm text-neutral-600 dark:text-neutral-300">
                 Olá, {user.email}
               </span>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={signOut}
-                className="flex items-center gap-2 border-brand-blue/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue"
+                className="flex items-center gap-2 border-brand-blue/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40 dark:text-neutral-200"
               >
                 <LogOut className="h-4 w-4" />
                 <span>Sair</span>
@@ -381,7 +381,7 @@ const SiteHeader = () => {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="flex items-center gap-2 border-brand-purple/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue"
+                  className="flex items-center gap-2 border-brand-purple/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
                 >
                   <User className="h-4 w-4" />
                   <span>Login</span>
@@ -401,29 +401,29 @@ const SiteHeader = () => {
             <SheetTrigger asChild>
               <button
                 aria-label={t('navigation.toggleNavigation')}
-                className="flex items-center justify-center rounded-xl border border-white/0 bg-white/70 p-2 text-neutral-700 shadow-soft transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white hover:text-brand-blue"
+                className="flex items-center justify-center rounded-xl border border-white/0 bg-white/70 p-2 text-neutral-700 shadow-soft transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:text-brand-blue dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:text-neutral-100"
               >
                 {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </button>
             </SheetTrigger>
             <SheetContent
               side="right"
-              className="w-full border-l border-white/40 bg-white/95 px-6 py-8 backdrop-blur-sm sm:max-w-sm"
+              className="w-full border-l border-white/40 bg-white/95 px-6 py-8 backdrop-blur-sm transition-colors sm:max-w-sm dark:border-neutral-800 dark:bg-neutral-950/90"
             >
               <div className="flex items-center justify-between">
-                <span className="text-lg font-semibold text-neutral-900">
+                <span className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
                   {t('navigation.toggleNavigation')}
                 </span>
                 <LanguageSwitcher />
               </div>
 
-              <nav className="mt-8 flex flex-col gap-4 text-base font-medium text-neutral-800">
+              <nav className="mt-8 flex flex-col gap-4 text-base font-medium text-neutral-800 dark:text-neutral-200">
                 <SheetClose asChild>
                   <NavLink
                     to="/"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                         isActive && 'text-brand-blue'
                       )
                     }
@@ -434,7 +434,7 @@ const SiteHeader = () => {
 
                 <Accordion type="single" collapsible className="w-full border-none">
                   <AccordionItem value="solutions" className="border-none">
-                    <AccordionTrigger className="rounded-lg bg-neutral-50 px-3 py-2 text-left text-base font-semibold text-neutral-900">
+                    <AccordionTrigger className="rounded-lg bg-neutral-50 px-3 py-2 text-left text-base font-semibold text-neutral-900 transition-colors dark:bg-neutral-900 dark:text-neutral-100">
                       {t('navigation.solutions')}
                     </AccordionTrigger>
                     <AccordionContent className="px-1">
@@ -458,7 +458,7 @@ const SiteHeader = () => {
                         <SheetClose asChild>
                           <Link
                             to="/solutions"
-                            className="inline-flex items-center justify-center rounded-lg border border-brand-blue/20 px-4 py-2 text-sm font-semibold text-brand-blue transition-colors hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                            className="inline-flex items-center justify-center rounded-lg border border-brand-blue/20 px-4 py-2 text-sm font-semibold text-brand-blue transition-colors hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40"
                           >
                             {t('navigation.solutionsMenu.viewAll')}
                           </Link>
@@ -476,7 +476,7 @@ const SiteHeader = () => {
                   </AccordionItem>
 
                   <AccordionItem value="projects" className="border-none">
-                    <AccordionTrigger className="mt-2 rounded-lg bg-neutral-50 px-3 py-2 text-left text-base font-semibold text-neutral-900">
+                    <AccordionTrigger className="mt-2 rounded-lg bg-neutral-50 px-3 py-2 text-left text-base font-semibold text-neutral-900 transition-colors dark:bg-neutral-900 dark:text-neutral-100">
                       {t('navigation.projects')}
                     </AccordionTrigger>
                     <AccordionContent className="px-1">
@@ -515,7 +515,7 @@ const SiteHeader = () => {
                         <SheetClose asChild>
                           <Link
                             to="/projects"
-                            className="inline-flex items-center justify-center rounded-lg border border-brand-blue/20 px-4 py-2 text-sm font-semibold text-brand-blue transition-colors hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white"
+                            className="inline-flex items-center justify-center rounded-lg border border-brand-blue/20 px-4 py-2 text-sm font-semibold text-brand-blue transition-colors hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40"
                           >
                             {t('navigation.projectsMenu.viewAll')}
                           </Link>
@@ -530,7 +530,7 @@ const SiteHeader = () => {
                     to="/about"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                         isActive && 'text-brand-blue'
                       )
                     }
@@ -543,7 +543,7 @@ const SiteHeader = () => {
                     to="/blog"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                         isActive && 'text-brand-blue'
                       )
                     }
@@ -556,7 +556,7 @@ const SiteHeader = () => {
                     to="/contact"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
+                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                         isActive && 'text-brand-blue'
                       )
                     }
@@ -566,10 +566,10 @@ const SiteHeader = () => {
                 </SheetClose>
               </nav>
 
-              <div className="mt-8 border-t border-neutral-200 pt-6">
+              <div className="mt-8 border-t border-neutral-200 pt-6 dark:border-neutral-800">
                 {user ? (
                   <div className="flex flex-col gap-3">
-                    <span className="text-sm text-neutral-600">
+                    <span className="text-sm text-neutral-600 dark:text-neutral-300">
                       Olá, {user.email}
                     </span>
                     <Button
@@ -578,7 +578,7 @@ const SiteHeader = () => {
                         signOut();
                         setMobileOpen(false);
                       }}
-                      className="flex w-full items-center justify-center gap-2 border-brand-blue/30 text-neutral-700 hover:border-brand-blue hover:text-brand-blue"
+                      className="flex w-full items-center justify-center gap-2 border-brand-blue/30 text-neutral-700 hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40 dark:text-neutral-200"
                     >
                       <LogOut className="h-4 w-4" />
                       <span>Sair</span>
@@ -589,7 +589,7 @@ const SiteHeader = () => {
                     <SheetClose asChild>
                       <Link
                         to="/auth"
-                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-brand-purple/30 px-4 py-2 text-sm font-semibold text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue"
+                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-brand-purple/30 px-4 py-2 text-sm font-semibold text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
                       >
                         <User className="h-4 w-4" />
                         <span>Login</span>

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
 import { supabase } from '@/integrations/supabase';
-import { Linkedin, Mail } from 'lucide-react';
+import { Linkedin } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 
 interface TeamMember {
@@ -38,13 +38,13 @@ const TeamSection = () => {
 
   if (isLoading) {
     return (
-      <section className="py-24 bg-neutral-50">
+      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
               {t('team.title')}
             </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="mx-auto max-w-3xl text-xl text-neutral-600 dark:text-neutral-300">
               {t('team.loading')}
             </p>
           </div>
@@ -52,13 +52,13 @@ const TeamSection = () => {
             {[...Array(4)].map((_, i) => (
               <Card
                 key={i}
-                className="w-full md:w-1/2 lg:w-1/4 border-0 shadow-soft rounded-2xl animate-pulse"
+                className="w-full animate-pulse rounded-2xl border-0 shadow-soft transition-colors md:w-1/2 lg:w-1/4 dark:bg-neutral-900/60"
               >
                 <CardContent className="p-8 text-center">
-                  <div className="w-24 h-24 bg-neutral-200 rounded-full mx-auto mb-6"></div>
-                  <div className="h-6 bg-neutral-200 rounded mb-2"></div>
-                  <div className="h-4 bg-neutral-200 rounded mb-4"></div>
-                  <div className="h-16 bg-neutral-200 rounded"></div>
+                  <div className="mx-auto mb-6 h-24 w-24 rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
+                  <div className="mb-2 h-6 rounded bg-neutral-200 dark:bg-neutral-700"></div>
+                  <div className="mb-4 h-4 rounded bg-neutral-200 dark:bg-neutral-700"></div>
+                  <div className="h-16 rounded bg-neutral-200 dark:bg-neutral-700"></div>
                 </CardContent>
               </Card>
             ))}
@@ -70,25 +70,27 @@ const TeamSection = () => {
 
   if (error) {
     return (
-      <section className="py-24 bg-neutral-50">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
+        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+          <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
             {t('team.title')}
           </h2>
-          <p className="text-xl text-neutral-600">{t('team.error')}</p>
+          <p className="text-xl text-neutral-600 dark:text-neutral-300">
+            {t('team.error')}
+          </p>
         </div>
       </section>
     );
   }
 
   return (
-    <section className="py-24 bg-neutral-50">
+    <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="text-center mb-16">
-          <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+        <div className="mb-16 text-center">
+          <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
             {t('team.title')}
           </h2>
-          <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+          <p className="mx-auto max-w-3xl text-xl text-neutral-600 dark:text-neutral-300">
             {t('team.description')}
           </p>
         </div>
@@ -97,10 +99,10 @@ const TeamSection = () => {
           {members?.map((member) => (
             <Card
               key={member.id}
-              className="w-full md:w-1/2 lg:w-1/4 border-0 shadow-soft hover:shadow-soft-lg transition-all duration-200 card-hover rounded-2xl"
+              className="card-hover w-full rounded-2xl border-0 shadow-soft transition-all duration-200 hover:shadow-soft-lg md:w-1/2 lg:w-1/4 dark:bg-neutral-900/80"
             >
               <CardContent className="p-8 text-center">
-                <Avatar className="w-24 h-24 mx-auto mb-6">
+                <Avatar className="mx-auto mb-6 h-24 w-24">
                   <AvatarImage
                     src={member.image_url || undefined}
                     alt={member.name}
@@ -113,16 +115,16 @@ const TeamSection = () => {
                   </AvatarFallback>
                 </Avatar>
 
-                <h3 className="text-xl font-semibold text-neutral-900 mb-2">
+                <h3 className="mb-2 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
                   {member.name}
                 </h3>
 
-                <p className="text-brand-blue font-medium mb-4">
+                <p className="mb-4 font-medium text-brand-blue">
                   {member.role}
                 </p>
 
                 {member.bio && (
-                  <p className="text-neutral-600 text-sm mb-6 leading-relaxed">
+                  <p className="mb-6 text-sm leading-relaxed text-neutral-600 dark:text-neutral-300">
                     {member.bio}
                   </p>
                 )}
@@ -132,10 +134,10 @@ const TeamSection = () => {
                     variant="outline"
                     size="sm"
                     aria-label={t('team.linkedin')}
-                    className="rounded-full border-brand-blue text-brand-blue hover:bg-brand-blue hover:text-white"
+                    className="rounded-full border-brand-blue text-brand-blue transition-colors hover:bg-brand-blue hover:text-white focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                     onClick={() => window.open(member.linkedin_url!, '_blank')}
                   >
-                    <Linkedin className="w-4 h-4" />
+                    <Linkedin className="h-4 w-4" />
                     <span className="sr-only">{t('team.linkedin')}</span>
                   </Button>
                 )}

--- a/src/components/ThemeProvider.tsx
+++ b/src/components/ThemeProvider.tsx
@@ -1,7 +1,8 @@
+import type { ReactNode } from 'react';
 import { ThemeProvider as NextThemesProvider } from 'next-themes';
 
 interface ThemeProviderProps {
-  children: React.ReactNode;
+  children: ReactNode;
 }
 
 const ThemeProvider = ({ children }: ThemeProviderProps) => (

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Quicksand:wght@500;600;700&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -6,34 +6,64 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 222 47% 9%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 47% 9%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 222 47% 9%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 262 83% 58%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 199 89% 55%;
+    --secondary-foreground: 210 40% 98%;
 
     --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted-foreground: 215 16% 46%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 330 72% 67%;
+    --accent-foreground: 210 40% 98%;
 
-    --destructive: 0 84.2% 60.2%;
+    --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 214 32% 91%;
+    --input: 214 32% 91%;
+    --ring: 262 83% 58%;
 
     --radius: 1.5rem;
+  }
+
+  .dark {
+    --background: 240 10% 6%;
+    --foreground: 210 40% 96%;
+
+    --card: 240 10% 12%;
+    --card-foreground: 210 40% 96%;
+
+    --popover: 240 10% 12%;
+    --popover-foreground: 210 40% 96%;
+
+    --primary: 262 83% 68%;
+    --primary-foreground: 240 33% 12%;
+
+    --secondary: 199 89% 62%;
+    --secondary-foreground: 240 10% 6%;
+
+    --muted: 240 8% 18%;
+    --muted-foreground: 215 20% 72%;
+
+    --accent: 330 72% 72%;
+    --accent-foreground: 240 10% 6%;
+
+    --destructive: 0 84% 60%;
+    --destructive-foreground: 210 40% 98%;
+
+    --border: 240 8% 22%;
+    --input: 240 8% 22%;
+    --ring: 262 83% 68%;
   }
 
   * {
@@ -41,7 +71,7 @@
   }
 
   body {
-    @apply bg-background text-neutral-900 font-sans antialiased;
+    @apply bg-background text-foreground font-sans antialiased;
   }
 
   h1,
@@ -50,7 +80,27 @@
   h4,
   h5,
   h6 {
-    @apply font-heading font-semibold text-neutral-900;
+    @apply font-heading font-semibold text-foreground;
+  }
+
+  .dark .text-neutral-900 {
+    color: #f3f4f6;
+  }
+
+  .dark .text-neutral-800 {
+    color: #e2e8f0;
+  }
+
+  .dark .text-neutral-700 {
+    color: #d1d5db;
+  }
+
+  .dark .text-neutral-600 {
+    color: #e5e7eb;
+  }
+
+  .dark .text-neutral-500 {
+    color: #9ca3af;
   }
 
   code,
@@ -61,11 +111,11 @@
 
 @layer components {
   .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2;
+    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 transition-all ease-in-out duration-300;
+    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-all ease-in-out duration-300 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800;
   }
 
   .card-hover {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import './index.css';
 import './i18n';
 import { Suspense } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
+import ThemeProvider from './components/ThemeProvider';
 
 createRoot(document.getElementById('root')!).render(
   <Suspense fallback={null}>
     <HelmetProvider>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </HelmetProvider>
   </Suspense>
 );

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -147,13 +147,13 @@ const About = () => {
         ogImage="/placeholder.svg"
       />
       {/* Hero Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
               {t('about.title')}
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('about.description')}
             </p>
           </div>
@@ -214,7 +214,7 @@ const About = () => {
       </section>
 
       {/* Story Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div className="order-2 lg:order-1 space-y-8">
@@ -223,7 +223,7 @@ const About = () => {
                   {t('about.storyTitle')}
                 </span>
               </div>
-              <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 leading-tight">
+              <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 leading-tight">
                 {t('about.title')}
               </h2>
               <ul className="space-y-6">
@@ -232,7 +232,7 @@ const About = () => {
                     <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-brand text-white font-semibold">
                       {(index + 1).toString().padStart(2, '0')}
                     </span>
-                    <p className="text-lg text-neutral-600 leading-relaxed">
+                    <p className="text-lg text-neutral-600 dark:text-neutral-300 leading-relaxed">
                       {story}
                     </p>
                   </li>
@@ -257,13 +257,13 @@ const About = () => {
       </section>
 
       {/* Stats Section */}
-      <section className="py-24 bg-neutral-50">
+      <section className="py-24 bg-neutral-50 dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('about.impactTitle')}
             </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('about.impactDescription')}
             </p>
           </div>
@@ -277,41 +277,41 @@ const About = () => {
               {Array.from({ length: 4 }).map((_, index) => (
                 <div
                   key={index}
-                  className="h-32 rounded-2xl bg-white shadow-soft animate-pulse"
+                  className="h-32 rounded-2xl bg-white transition-colors dark:bg-neutral-950 shadow-soft animate-pulse"
                   aria-hidden="true"
                 ></div>
               ))}
             </div>
           ) : statsError ? (
-            <p className="text-center text-neutral-500">{t('about.statsError')}</p>
+            <p className="text-center text-neutral-500 dark:text-neutral-400">{t('about.statsError')}</p>
           ) : aboutStats && aboutStats.length > 0 ? (
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
               {aboutStats.map((stat, index) => (
                 <Card
                   key={`${stat.label}-${index}`}
-                  className="border-0 shadow-soft rounded-2xl bg-white text-center p-8"
+                  className="border-0 shadow-soft rounded-2xl bg-white transition-colors dark:bg-neutral-950 text-center p-8"
                 >
                   <div className="text-4xl lg:text-5xl font-bold text-transparent bg-clip-text bg-gradient-brand mb-2">
                     {stat.number}
                   </div>
-                  <div className="text-neutral-600 font-medium">{stat.label}</div>
+                  <div className="text-neutral-600 dark:text-neutral-300 font-medium">{stat.label}</div>
                 </Card>
               ))}
             </div>
           ) : (
-            <p className="text-center text-neutral-500">{t('about.statsEmpty')}</p>
+            <p className="text-center text-neutral-500 dark:text-neutral-400">{t('about.statsEmpty')}</p>
           )}
         </div>
       </section>
 
       {/* Team Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('team.title')}
             </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('team.description')}
             </p>
           </div>
@@ -337,7 +337,7 @@ const About = () => {
               ))}
             </div>
           ) : teamError ? (
-            <p className="text-center text-neutral-500">{t('team.error')}</p>
+            <p className="text-center text-neutral-500 dark:text-neutral-400">{t('team.error')}</p>
           ) : teamMembers && teamMembers.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
               {teamMembers.map((member) => (
@@ -359,7 +359,7 @@ const About = () => {
                       </AvatarFallback>
                     </Avatar>
                     <div className="space-y-1">
-                      <h3 className="text-xl font-semibold text-neutral-900">
+                      <h3 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
                         {member.name}
                       </h3>
                       <p className="text-brand-blue font-medium">{member.role}</p>
@@ -369,7 +369,7 @@ const About = () => {
               ))}
             </div>
           ) : (
-            <p className="text-center text-neutral-500">{t('team.empty')}</p>
+            <p className="text-center text-neutral-500 dark:text-neutral-400">{t('team.empty')}</p>
           )}
         </div>
       </section>

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -254,20 +254,20 @@ const Blog = () => {
           </BreadcrumbList>
         </Breadcrumb>
       </div>
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
               {t('blog.title')}
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('blog.description')}
             </p>
           </div>
         </div>
       </section>
 
-      <section className="pb-12 bg-white">
+      <section className="pb-12 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="flex flex-wrap justify-center gap-4">
             {categories.map((category, index) => (
@@ -277,7 +277,7 @@ const Blog = () => {
                 className={`rounded-full px-6 py-2 ${
                   index === 0
                     ? 'bg-gradient-brand text-white'
-                    : 'border-neutral-200 text-neutral-600 hover:border-brand-blue hover:text-brand-blue'
+                    : 'border-neutral-200 dark:border-neutral-800 text-neutral-600 dark:text-neutral-300 hover:border-brand-blue hover:text-brand-blue'
                 }`}
                 type="button"
               >
@@ -289,7 +289,7 @@ const Blog = () => {
       </section>
 
       {featuredPost && (
-        <section className="pb-16 bg-white">
+        <section className="pb-16 bg-white transition-colors dark:bg-neutral-950">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <Card className="border-0 shadow-soft-lg rounded-2xl overflow-hidden">
               <div className="grid grid-cols-1 lg:grid-cols-2">
@@ -310,7 +310,7 @@ const Blog = () => {
                   </div>
                 </Link>
                 <div className="p-8 lg:p-12 flex flex-col justify-center">
-                  <div className="flex items-center space-x-4 text-sm text-neutral-500 mb-4">
+                  <div className="flex items-center space-x-4 text-sm text-neutral-500 dark:text-neutral-400 mb-4">
                     <span className="bg-brand-blue/10 text-brand-blue px-3 py-1 rounded-full font-medium">
                       {featuredPost.category}
                     </span>
@@ -325,10 +325,10 @@ const Blog = () => {
                       </div>
                     </div>
                   </div>
-                  <h2 className="text-2xl lg:text-3xl font-bold text-neutral-900 mb-4">
+                  <h2 className="text-2xl lg:text-3xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
                     {featuredPost.title}
                   </h2>
-                  <p className="text-lg text-neutral-600 mb-6">
+                  <p className="text-lg text-neutral-600 dark:text-neutral-300 mb-6">
                     {featuredPost.excerpt}
                   </p>
                   <Button asChild className="btn-primary w-fit">
@@ -347,10 +347,10 @@ const Blog = () => {
         </section>
       )}
 
-      <section className="py-16 bg-neutral-50">
+      <section className="py-16 bg-neutral-50 dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           {totalPosts === 0 ? (
-            <div className="rounded-2xl bg-white p-10 text-center text-neutral-600 shadow-soft">
+            <div className="rounded-2xl bg-white transition-colors dark:bg-neutral-950 p-10 text-center text-neutral-600 dark:text-neutral-300 shadow-soft">
               {t('blog.empty')}
             </div>
           ) : (
@@ -358,7 +358,7 @@ const Blog = () => {
               {regularPosts.map((post) => (
                 <Card
                   key={post.id}
-                  className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl overflow-hidden bg-white"
+                  className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl overflow-hidden bg-white transition-colors dark:bg-neutral-950"
                 >
                   <Link to={`/blog/${post.slug}`} className="relative block">
                     <img
@@ -374,7 +374,7 @@ const Blog = () => {
                     </div>
                   </Link>
                   <CardContent className="p-6">
-                    <div className="flex items-center space-x-4 text-sm text-neutral-500 mb-3">
+                    <div className="flex items-center space-x-4 text-sm text-neutral-500 dark:text-neutral-400 mb-3">
                       <div className="flex items-center space-x-1">
                         <User className="h-4 w-4" />
                         <span>{post.author}</span>
@@ -386,11 +386,11 @@ const Blog = () => {
                     </div>
                     <Link
                       to={`/blog/${post.slug}`}
-                      className="block text-xl font-semibold text-neutral-900 mb-3 line-clamp-2 hover:text-brand-blue"
+                      className="block text-xl font-semibold text-neutral-900 dark:text-neutral-100 mb-3 line-clamp-2 hover:text-brand-blue"
                     >
                       {post.title}
                     </Link>
-                    <p className="text-neutral-600 mb-4 line-clamp-3">
+                    <p className="text-neutral-600 dark:text-neutral-300 mb-4 line-clamp-3">
                       {post.excerpt}
                     </p>
                     <Button
@@ -415,10 +415,10 @@ const Blog = () => {
       </section>
 
       {totalPosts > POSTS_PER_PAGE && (
-        <section className="bg-neutral-50 pb-16">
+        <section className="bg-neutral-50 dark:bg-neutral-950 pb-16">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
             <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-              <p className="text-sm text-neutral-500">
+              <p className="text-sm text-neutral-500 dark:text-neutral-400">
                 {t('blog.pagination.showing', {
                   start: showingRangeStart,
                   end: showingRangeEnd,
@@ -500,9 +500,9 @@ const Blog = () => {
             <input
               type="email"
               placeholder={t('blog.newsletter.placeholder')}
-              className="flex-1 px-4 py-3 rounded-xl border-0 text-neutral-900 placeholder-neutral-500 focus:ring-2 focus:ring-white focus:outline-none"
+              className="flex-1 px-4 py-3 rounded-xl border-0 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:ring-2 focus:ring-white focus:outline-none"
             />
-            <Button className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl transition-all ease-in-out duration-300">
+            <Button className="bg-white transition-colors dark:bg-neutral-950 text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl transition-all ease-in-out duration-300">
               {t('blog.newsletter.subscribe')}
             </Button>
           </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -326,15 +326,15 @@ const Contact = () => {
             </BreadcrumbList>
           </Breadcrumb>
         </div>
-        <section className="py-24 bg-white min-h-screen flex items-center">
+        <section className="py-24 bg-white transition-colors dark:bg-neutral-950 min-h-screen flex items-center">
           <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <div className="w-16 h-16 bg-gradient-brand rounded-full flex items-center justify-center mx-auto mb-6">
               <CheckCircle className="h-8 w-8 text-white" />
             </div>
-            <h1 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h1 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('contact.thankYou.title')}
             </h1>
-            <p className="text-xl text-neutral-600 mb-8">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 mb-8">
               {t('contact.thankYou.description')}
             </p>
             <Button
@@ -374,13 +374,13 @@ const Contact = () => {
         </Breadcrumb>
       </div>
       {/* Hero Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
               {t('contact.title')}
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('contact.description')}
             </p>
           </div>
@@ -388,14 +388,14 @@ const Contact = () => {
       </section>
 
       {/* Contact Form and Info */}
-      <section className="pb-24 bg-white">
+      <section className="pb-24 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
             {/* Contact Form */}
             <div className="lg:col-span-2">
               <Card className="border-0 shadow-soft-lg rounded-2xl">
                 <CardContent className="p-8">
-                  <h2 className="text-2xl font-bold text-neutral-900 mb-6">
+                  <h2 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
                     {t('contact.form.headline')}
                   </h2>
                   <form onSubmit={handleSubmit} className="space-y-6">
@@ -403,7 +403,7 @@ const Contact = () => {
                       <div>
                         <label
                           htmlFor="name"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
                         >
                           {t('contact.form.fullName')}
                         </label>
@@ -415,7 +415,7 @@ const Contact = () => {
                           value={formData.name}
                           onChange={handleInputChange}
                           onBlur={handleFieldBlur}
-                          className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue"
+                          className="rounded-xl border-neutral-200 dark:border-neutral-800 focus:border-brand-blue focus:ring-brand-blue"
                           placeholder={t('contact.form.placeholderName')}
                         />
                         {errors.name && (
@@ -427,7 +427,7 @@ const Contact = () => {
                       <div>
                         <label
                           htmlFor="email"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
                         >
                           {t('contact.form.email')}
                         </label>
@@ -439,7 +439,7 @@ const Contact = () => {
                           value={formData.email}
                           onChange={handleInputChange}
                           onBlur={handleFieldBlur}
-                          className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue"
+                          className="rounded-xl border-neutral-200 dark:border-neutral-800 focus:border-brand-blue focus:ring-brand-blue"
                           placeholder={t('contact.form.placeholderEmail')}
                         />
                         {errors.email && (
@@ -454,7 +454,7 @@ const Contact = () => {
                       <div>
                         <label
                           htmlFor="company"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
                         >
                           {t('contact.form.company')}
                         </label>
@@ -464,14 +464,14 @@ const Contact = () => {
                           type="text"
                           value={formData.company}
                           onChange={handleInputChange}
-                          className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue"
+                          className="rounded-xl border-neutral-200 dark:border-neutral-800 focus:border-brand-blue focus:ring-brand-blue"
                           placeholder={t('contact.form.placeholderCompany')}
                         />
                       </div>
                       <div>
                         <label
                           htmlFor="project"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
                         >
                           {t('contact.form.projectType')}
                         </label>
@@ -481,7 +481,7 @@ const Contact = () => {
                           value={formData.project}
                           onChange={handleInputChange}
                           onBlur={handleFieldBlur}
-                          className="w-full px-3 py-2 border border-neutral-200 rounded-xl focus:border-brand-blue focus:ring-1 focus:ring-brand-blue focus:outline-none text-neutral-900"
+                          className="w-full px-3 py-2 border border-neutral-200 dark:border-neutral-800 rounded-xl focus:border-brand-blue focus:ring-1 focus:ring-brand-blue focus:outline-none text-neutral-900 dark:text-neutral-100"
                         >
                           <option value="">{t('contact.form.select')}</option>
                           {projectTypes.map((type, index) => (
@@ -496,7 +496,7 @@ const Contact = () => {
                     <div>
                       <label
                         htmlFor="message"
-                        className="block text-sm font-medium text-neutral-700 mb-2"
+                        className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-2"
                       >
                         {t('contact.form.details')}
                       </label>
@@ -508,7 +508,7 @@ const Contact = () => {
                         onChange={handleInputChange}
                         onBlur={handleFieldBlur}
                         rows={6}
-                        className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue resize-none"
+                        className="rounded-xl border-neutral-200 dark:border-neutral-800 focus:border-brand-blue focus:ring-brand-blue resize-none"
                         placeholder={t('contact.form.placeholderDetails')}
                       />
                       {errors.message && (
@@ -536,10 +536,10 @@ const Contact = () => {
             {/* Contact Information */}
             <div className="space-y-8">
               <div>
-                <h2 className="text-2xl font-bold text-neutral-900 mb-6">
+                <h2 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
                   {t('contact.info.getInTouch')}
                 </h2>
-                <p className="text-neutral-600 mb-8">
+                <p className="text-neutral-600 dark:text-neutral-300 mb-8">
                   {t('contact.info.description')}
                 </p>
               </div>
@@ -555,13 +555,13 @@ const Contact = () => {
                         <info.icon className="h-6 w-6 text-white" />
                       </div>
                       <div>
-                        <h3 className="font-semibold text-neutral-900 mb-1">
+                        <h3 className="font-semibold text-neutral-900 dark:text-neutral-100 mb-1">
                           {info.title}
                         </h3>
                         <p className="text-lg text-brand-blue font-medium mb-1">
                           {info.content}
                         </p>
-                        <p className="text-sm text-neutral-600">
+                        <p className="text-sm text-neutral-600 dark:text-neutral-300">
                           {info.description}
                         </p>
                       </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -189,7 +189,7 @@ const Index = () => {
               <Link to="/solutions">
                 <Button
                   size="lg"
-                  className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-xl text-lg transition-all ease-in-out duration-300"
+                  className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
                 >
                   {t('index.hero.viewSolutions')}
                 </Button>
@@ -200,13 +200,13 @@ const Index = () => {
       </section>
 
       {/* Features Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-white transition-colors dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('index.why.title')}
             </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('index.why.description')}
             </p>
           </div>
@@ -224,10 +224,10 @@ const Index = () => {
                     <div className="w-16 h-16 bg-gradient-hero rounded-2xl flex items-center justify-center mx-auto mb-6">
                       <feature.icon className="h-8 w-8 text-white" />
                     </div>
-                    <h3 className="text-xl font-semibold text-neutral-900 mb-4">
+                    <h3 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">
                       {feature.title}
                     </h3>
-                    <p className="text-neutral-600">{feature.description}</p>
+                    <p className="text-neutral-600 dark:text-neutral-300">{feature.description}</p>
                   </CardContent>
                 </Card>
               </a>
@@ -237,13 +237,13 @@ const Index = () => {
       </section>
 
       {/* Solutions Preview */}
-      <section className="py-24 bg-neutral-50">
+      <section className="py-24 bg-neutral-50 dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('index.solutions.title')}
             </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('index.solutions.description')}
             </p>
           </div>
@@ -257,10 +257,10 @@ const Index = () => {
                   className={`h-4 bg-gradient-to-r ${solution.gradient}`}
                 ></div>
                 <CardContent className="p-8">
-                  <h3 className="text-2xl font-bold text-neutral-900 mb-4">
+                  <h3 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
                     {solution.name}
                   </h3>
-                  <p className="text-neutral-600 mb-6">
+                  <p className="text-neutral-600 dark:text-neutral-300 mb-6">
                     {solution.description}
                   </p>
                   {solution.features &&
@@ -270,7 +270,7 @@ const Index = () => {
                         {solution.features.map((feature, featureIndex) => (
                           <li
                             key={featureIndex}
-                            className="flex items-center text-neutral-700"
+                            className="flex items-center text-neutral-700 dark:text-neutral-300"
                           >
                             <CheckCircle className="h-5 w-5 text-brand-blue mr-3" />
                             {feature}
@@ -309,7 +309,7 @@ const Index = () => {
           <Link to="/contact">
             <Button
               size="lg"
-              className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-xl text-lg transition-all ease-in-out duration-300"
+              className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
             >
               {t('index.cta.getStarted')}
               <ArrowRight className="ml-2 h-5 w-5" />

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -273,7 +273,7 @@ const Projects = () => {
       <section className={cn(sectionPaddingY, 'bg-white')}>
         <div className={sectionContainer}>
           <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl md:text-5xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
               <Trans
                 i18nKey="projects.title"
                 components={[
@@ -284,26 +284,26 @@ const Projects = () => {
                 ]}
               />
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('projects.description')}
             </p>
           </div>
         </div>
       </section>
 
-      <section className={cn(sectionPaddingY, 'bg-neutral-50')}>
+      <section className={cn(sectionPaddingY, 'bg-neutral-50 dark:bg-neutral-950')}>
         <div className={sectionContainer}>
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('solutionsPage.title')}
             </h2>
-            <p className="text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('solutionsPage.description')}
             </p>
           </div>
 
           {supabaseSolutionsLoading ? (
-            <div className="text-center text-neutral-500">
+            <div className="text-center text-neutral-500 dark:text-neutral-400 dark:text-neutral-500">
               {t('projects.loadingSolutions')}
             </div>
           ) : (
@@ -349,7 +349,7 @@ const Projects = () => {
       <section className={cn(sectionPaddingY, 'bg-white')}>
         <div className={sectionContainer}>
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               <Trans
                 i18nKey="projects.title"
                 components={[
@@ -360,13 +360,13 @@ const Projects = () => {
                 ]}
               />
             </h2>
-            <p className="text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('projects.description')}
             </p>
           </div>
 
           {isGitHubLoading ? (
-            <div className="text-center text-neutral-500">
+            <div className="text-center text-neutral-500 dark:text-neutral-400 dark:text-neutral-500">
               {t('projects.loadingGithub')}
             </div>
           ) : (
@@ -428,13 +428,13 @@ const Projects = () => {
         </div>
       </section>
 
-      <section className={cn(sectionPaddingY, 'bg-neutral-50')}>
+      <section className={cn(sectionPaddingY, 'bg-neutral-50 dark:bg-neutral-950')}>
         <div className={sectionContainer}>
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('navigation.projects')}
             </h2>
-            <p className="text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('projects.description')}
             </p>
           </div>
@@ -452,15 +452,15 @@ const Projects = () => {
                 >
                   <CardHeader className="pb-4">
                     <div className="flex items-start justify-between">
-                      <CardTitle className="text-xl font-semibold text-neutral-900">
+                      <CardTitle className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
                         {repo.name}
                       </CardTitle>
-                      <div className="flex items-center gap-1 text-sm text-neutral-500">
+                      <div className="flex items-center gap-1 text-sm text-neutral-500 dark:text-neutral-400 dark:text-neutral-500">
                         <Calendar className="h-4 w-4" />
                         {formatDate(repo.created_at)}
                       </div>
                     </div>
-                    <p className="text-neutral-600 leading-relaxed">
+                    <p className="text-neutral-600 dark:text-neutral-300 leading-relaxed">
                       {repo.description}
                     </p>
                   </CardHeader>
@@ -471,7 +471,7 @@ const Projects = () => {
                           <Badge
                             key={index}
                             variant="secondary"
-                            className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-medium text-neutral-700"
+                            className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-medium text-neutral-700 dark:text-neutral-300"
                           >
                             {tag}
                           </Badge>

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -125,13 +125,18 @@ const Solutions = () => {
         </Breadcrumb>
       </div>
       {/* Hero Section */}
-      <section className={cn(sectionPaddingY, 'bg-white')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-white transition-colors dark:bg-neutral-950'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
               {t('solutionsPage.title')}
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
               {t('solutionsPage.description')}
             </p>
           </div>
@@ -139,7 +144,12 @@ const Solutions = () => {
       </section>
 
       {/* Solutions Detail */}
-      <section className={cn(sectionPaddingY, 'bg-white')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-white transition-colors dark:bg-neutral-950'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
             {displaySolutions.map((solution) => (
@@ -189,7 +199,7 @@ const Solutions = () => {
           <Link to="/contact">
             <Button
               size="lg"
-              className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-2xl text-lg transition-all ease-in-out duration-300 shadow-md hover:shadow-soft-lg"
+              className="rounded-2xl bg-white px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 shadow-md hover:shadow-soft-lg dark:text-white dark:hover:bg-neutral-800"
             >
               {t('solutionsPage.discuss')}
               <ArrowRight className="ml-2 h-5 w-5" />

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -31,13 +31,13 @@ type LexicalNode = {
 };
 
 const headingStyles: Record<string, string> = {
-  h1: 'text-4xl font-bold text-neutral-900',
-  h2: 'text-3xl font-bold text-neutral-900',
-  h3: 'text-2xl font-semibold text-neutral-900',
-  h4: 'text-xl font-semibold text-neutral-900',
-  h5: 'text-lg font-semibold text-neutral-900',
-  h6: 'text-lg font-semibold text-neutral-900',
-  default: 'text-3xl font-bold text-neutral-900',
+  h1: 'text-4xl font-bold text-neutral-900 dark:text-neutral-100',
+  h2: 'text-3xl font-bold text-neutral-900 dark:text-neutral-100',
+  h3: 'text-2xl font-semibold text-neutral-900 dark:text-neutral-100',
+  h4: 'text-xl font-semibold text-neutral-900 dark:text-neutral-100',
+  h5: 'text-lg font-semibold text-neutral-900 dark:text-neutral-100',
+  h6: 'text-lg font-semibold text-neutral-900 dark:text-neutral-100',
+  default: 'text-3xl font-bold text-neutral-900 dark:text-neutral-100',
 };
 
 const renderNodes = (
@@ -107,7 +107,7 @@ const renderLexicalNode = (node: LexicalNode, key: string): ReactNode => {
       return <React.Fragment key={key}>{renderNodes(node.children, key)}</React.Fragment>;
     case 'paragraph':
       return (
-        <p key={key} className="leading-relaxed text-neutral-700">
+        <p key={key} className="leading-relaxed text-neutral-700 dark:text-neutral-300">
           {renderNodes(node.children, key)}
         </p>
       );
@@ -124,7 +124,7 @@ const renderLexicalNode = (node: LexicalNode, key: string): ReactNode => {
       return (
         <blockquote
           key={key}
-          className="border-l-4 border-brand-blue/40 pl-4 italic text-neutral-600"
+          className="border-l-4 border-brand-blue/40 pl-4 italic text-neutral-600 dark:text-neutral-300"
         >
           {renderNodes(node.children, key)}
         </blockquote>
@@ -133,8 +133,8 @@ const renderLexicalNode = (node: LexicalNode, key: string): ReactNode => {
       const ListTag = node.tag === 'ol' ? 'ol' : 'ul';
       const listClasses =
         ListTag === 'ol'
-          ? 'ml-6 list-decimal space-y-2 text-neutral-700'
-          : 'ml-6 list-disc space-y-2 text-neutral-700';
+          ? 'ml-6 list-decimal space-y-2 text-neutral-700 dark:text-neutral-300'
+          : 'ml-6 list-disc space-y-2 text-neutral-700 dark:text-neutral-300';
       return (
         <ListTag key={key} className={listClasses}>
           {renderNodes(node.children, key)}
@@ -143,7 +143,7 @@ const renderLexicalNode = (node: LexicalNode, key: string): ReactNode => {
     }
     case 'listitem':
       return (
-        <li key={key} className="leading-relaxed text-neutral-700">
+        <li key={key} className="leading-relaxed text-neutral-700 dark:text-neutral-300">
           {renderNodes(node.children, key)}
         </li>
       );
@@ -203,7 +203,7 @@ const renderBlogContent = (content: string): ReactNode[] => {
     .split(/\n{2,}/)
     .filter((paragraph) => paragraph.trim().length > 0)
     .map((paragraph, index) => (
-      <p key={`paragraph-${index}`} className="leading-relaxed text-neutral-700">
+      <p key={`paragraph-${index}`} className="leading-relaxed text-neutral-700 dark:text-neutral-300">
         {paragraph.trim()}
       </p>
     ));
@@ -320,7 +320,7 @@ const BlogPostPage = () => {
           ogImage={metaImage}
         />
         <div className="container mx-auto px-4 py-16 text-center space-y-4">
-          <p className="text-lg text-neutral-600">{t('blog.post.notFound')}</p>
+          <p className="text-lg text-neutral-600 dark:text-neutral-300">{t('blog.post.notFound')}</p>
           <ButtonLink />
         </div>
       </Layout>
@@ -357,7 +357,7 @@ const BlogPostPage = () => {
           </BreadcrumbList>
         </Breadcrumb>
       </div>
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-white transition-colors dark:bg-neutral-950">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <Link
             to="/blog"
@@ -370,14 +370,14 @@ const BlogPostPage = () => {
           <article className="space-y-10">
             <header className="space-y-6">
               <div className="space-y-4">
-                <h1 className="text-4xl font-bold text-neutral-900">
+                <h1 className="text-4xl font-bold text-neutral-900 dark:text-neutral-100">
                   {post.title}
                 </h1>
                 {post.excerpt && (
-                  <p className="text-xl text-neutral-600">{post.excerpt}</p>
+                  <p className="text-xl text-neutral-600 dark:text-neutral-300">{post.excerpt}</p>
                 )}
               </div>
-              <div className="flex flex-wrap items-center gap-4 text-sm text-neutral-500">
+              <div className="flex flex-wrap items-center gap-4 text-sm text-neutral-500 dark:text-neutral-400">
                 <div className="flex items-center gap-2">
                   <User className="h-4 w-4" />
                   <span>{t('blog.post.author', { author: defaultAuthor })}</span>
@@ -404,7 +404,7 @@ const BlogPostPage = () => {
               </div>
             )}
 
-            <div className="space-y-6 text-lg leading-relaxed text-neutral-700">
+            <div className="space-y-6 text-lg leading-relaxed text-neutral-700 dark:text-neutral-300">
               {renderedContent.length > 0 ? (
                 renderedContent
               ) : (

--- a/src/pages/solutions/[slug].tsx
+++ b/src/pages/solutions/[slug].tsx
@@ -141,10 +141,10 @@ const SolutionDetail = () => {
         />
         <div className="container mx-auto px-4 py-24 text-center">
           <div className="max-w-lg mx-auto space-y-6">
-            <h1 className="text-3xl font-semibold text-neutral-900">
+            <h1 className="text-3xl font-semibold text-neutral-900 dark:text-neutral-100">
               {t('solutionsPage.notFound')}
             </h1>
-            <p className="text-neutral-600">
+            <p className="text-neutral-600 dark:text-neutral-300">
               {t('solutionsPage.description')}
             </p>
             <Button asChild>
@@ -194,10 +194,10 @@ const SolutionDetail = () => {
               <div
                 className={`h-1 w-16 bg-gradient-to-r ${displaySolution.gradient} rounded-full mb-6`}
               />
-              <h1 className="text-4xl font-bold text-neutral-900 mb-6">
+              <h1 className="text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
                 {displaySolution.title}
               </h1>
-              <p className="text-lg text-neutral-600 leading-relaxed">
+              <p className="text-lg text-neutral-600 dark:text-neutral-300 leading-relaxed">
                 {displaySolution.description}
               </p>
 
@@ -205,7 +205,7 @@ const SolutionDetail = () => {
                 <Button
                   asChild
                   variant="outline"
-                  className="flex-1 sm:flex-none sm:w-auto border-neutral-200 hover:border-brand-blue hover:text-brand-blue transition-colors"
+                  className="flex-1 sm:flex-none sm:w-auto border-neutral-200 dark:border-neutral-800 hover:border-brand-blue hover:text-brand-blue transition-colors"
                 >
                   <Link to="/solutions" className="flex items-center justify-center gap-2">
                     <ArrowLeft className="h-4 w-4" />
@@ -242,23 +242,23 @@ const SolutionDetail = () => {
       </section>
 
       {displaySolution.features.length > 0 && (
-        <section className="py-16 bg-neutral-50">
+        <section className="py-16 bg-neutral-50 dark:bg-neutral-950">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold text-neutral-900 mb-8">
+            <h2 className="text-2xl font-semibold text-neutral-900 dark:text-neutral-100 mb-8">
               {t('solutionsPage.featuresTitle')}
             </h2>
             <div className="space-y-4">
               {displaySolution.features.map((feature, index) => (
                 <div
                   key={`${displaySolution.slug}-detail-feature-${index}`}
-                  className="bg-white rounded-2xl shadow-soft p-6 flex items-start gap-4"
+                  className="bg-white transition-colors dark:bg-neutral-950 rounded-2xl shadow-soft p-6 flex items-start gap-4"
                 >
                   <span
                     className={`inline-flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-r ${displaySolution.gradient}`}
                   >
                     <CheckCircle className="h-5 w-5 text-white" />
                   </span>
-                  <p className="text-neutral-700 leading-relaxed">{feature}</p>
+                  <p className="text-neutral-700 dark:text-neutral-300 leading-relaxed">{feature}</p>
                 </div>
               ))}
             </div>
@@ -277,7 +277,7 @@ const SolutionDetail = () => {
           <Button
             asChild
             size="lg"
-            className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-xl text-lg transition-all ease-in-out duration-300"
+            className="bg-white transition-colors dark:bg-neutral-950 text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-xl text-lg transition-all ease-in-out duration-300"
           >
             <Link to="/contact" className="flex items-center justify-center gap-2">
               {t('solutionsPage.discuss')}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -56,6 +56,7 @@ export default {
         },
         // Monynha Softwares Brand Colors
         brand: {
+          DEFAULT: '#7C3AED',
           purple: '#7C3AED',
           blue: '#0EA5E9',
           pink: '#EC4899',
@@ -74,12 +75,13 @@ export default {
           700: '#374151',
           800: '#1F2937',
           900: '#111827',
+          950: '#030712',
         },
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', 'sans-serif'],
-        heading: ['"Space Grotesk"', 'Inter', 'system-ui', 'sans-serif'],
-        brand: ['"Space Grotesk"', 'Inter', 'system-ui', 'sans-serif'],
+        heading: ['"Quicksand"', 'Inter', 'system-ui', 'sans-serif'],
+        brand: ['"Quicksand"', 'Inter', 'system-ui', 'sans-serif'],
         mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
       backgroundImage: {


### PR DESCRIPTION
## Summary
- align Tailwind design tokens and base styles with the Quicksand/Inter typography and new dark-mode variables
- wrap the app with the theme provider and harden header/footer + key pages for accessible dark mode, focus states and keyboard use
- refresh newsletter and marketing sections for lazy loading/focus states and regenerate SEO automation via the sitemap script and robots.txt

## Testing
- npm run lint
- npm run sitemap

------
https://chatgpt.com/codex/tasks/task_e_68ca85f604d883228d6fbf47c935e66d