### PR TITLE
Refresh design tokens and sitemap

### DIFF
--- a/packages/ui/src/components/SolutionCard.tsx
+++ b/packages/ui/src/components/SolutionCard.tsx
@@ -55,6 +55,7 @@ export const SolutionCard = ({
             src={imageUrl}
             alt={title}
             loading="lazy"
+            decoding="async"
             className="h-full w-full object-cover"
           />
           <div
@@ -74,15 +75,15 @@ export const SolutionCard = ({
           className={cn('h-1 w-16 rounded-full bg-gradient-to-r', gradient, 'mb-6')}
           aria-hidden="true"
         />
-        <h3 className="text-2xl font-heading font-semibold text-neutral-900">
+        <h3 className="text-2xl font-heading font-semibold text-foreground">
           {title}
         </h3>
-        <p className="mt-4 flex-1 text-neutral-600 leading-relaxed">
+        <p className="mt-4 flex-1 text-muted-foreground leading-relaxed">
           {description}
         </p>
 
         {displayFeatures.length > 0 && (
-          <ul className="mt-8 space-y-3 text-neutral-600">
+          <ul className="mt-8 space-y-3 text-muted-foreground">
             {displayFeatures.map((feature, index) => (
               <li key={`${slug}-feature-${index}`} className="flex items-start gap-3">
                 <span

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -9,7 +9,7 @@ export const sectionPaddingY = 'py-24 sm:py-28';
 export const sectionContainer = 'max-w-7xl mx-auto px-4 sm:px-6 lg:px-8';
 
 export const surfaceCardClass =
-  'rounded-2xl border border-white/60 bg-white/90 shadow-md backdrop-blur-sm';
+  'rounded-2xl border border-border/60 bg-card/90 shadow-md backdrop-blur-sm transition-colors duration-300 dark:border-border/40 dark:bg-card/80';
 
 export const featureIconWrapperClass =
-  'inline-flex h-8 w-8 items-center justify-center rounded-full text-white shadow-sm';
+  'inline-flex h-8 w-8 items-center justify-center rounded-full text-white shadow-sm ring-1 ring-white/40 dark:ring-white/10';

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,14 +1,4 @@
-User-agent: Googlebot
-Allow: /
-
-User-agent: Bingbot
-Allow: /
-
-User-agent: Twitterbot
-Allow: /
-
-User-agent: facebookexternalhit
-Allow: /
-
 User-agent: *
 Allow: /
+
+Sitemap: https://monynha.com/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://monynha.com/</loc></url>
   <url><loc>https://monynha.com/about</loc></url>
   <url><loc>https://monynha.com/auth</loc></url>
   <url><loc>https://monynha.com/blog</loc></url>
   <url><loc>https://monynha.com/contact</loc></url>
-  <url><loc>https://monynha.com/</loc></url>
+  <url><loc>https://monynha.com/dashboard</loc></url>
   <url><loc>https://monynha.com/projects</loc></url>
   <url><loc>https://monynha.com/solutions</loc></url>
+  <url><loc>https://monynha.com/solutions/assistina</loc></url>
+  <url><loc>https://monynha.com/solutions/boteco-pro</loc></url>
 </urlset>

--- a/scripts/generate-sitemap.ts
+++ b/scripts/generate-sitemap.ts
@@ -1,25 +1,76 @@
-import { readdirSync, writeFileSync } from 'fs';
+import { readdirSync, statSync, writeFileSync } from 'fs';
 import * as path from 'path';
+import { fallbackSolutions } from '../src/data/solutions';
 
 const pagesDir = path.join(process.cwd(), 'src', 'pages');
 const publicDir = path.join(process.cwd(), 'public');
 const baseUrl = process.env.SITE_URL || 'https://monynha.com';
 
-function getRoutes(dir: string): string[] {
-  return readdirSync(dir)
-    .filter((file) => {
-      if (file === '__tests__') return false;
-      if (!file.endsWith('.tsx') && !file.endsWith('.ts')) return false;
-      return true;
-    })
-    .map((file) => path.basename(file, path.extname(file)))
-    .filter((name) => name !== 'NotFound')
-    .map((name) =>
-      name.toLowerCase() === 'index' ? '/' : `/${name.toLowerCase()}`
-    );
-}
+const normalizeRoute = (value: string): string => {
+  const replaced = value.replace(/\/+/g, '/');
+  if (replaced === '') {
+    return '/';
+  }
 
-const routes = getRoutes(pagesDir);
+  return replaced.startsWith('/') ? replaced : `/${replaced}`;
+};
+
+const isPageFile = (file: string): boolean =>
+  file.endsWith('.tsx') || file.endsWith('.ts');
+
+const collectRoutes = (directory: string, routePrefix = ''): string[] => {
+  const entries = readdirSync(directory);
+  const routes: string[] = [];
+
+  for (const entry of entries) {
+    if (entry.startsWith('_') || entry === '__tests__') {
+      continue;
+    }
+
+    const fullPath = path.join(directory, entry);
+    const stats = statSync(fullPath);
+
+    if (stats.isDirectory()) {
+      const nextPrefix = routePrefix ? `${routePrefix}/${entry}` : `/${entry}`;
+      routes.push(...collectRoutes(fullPath, nextPrefix));
+      continue;
+    }
+
+    if (!isPageFile(entry)) {
+      continue;
+    }
+
+    const baseName = path.basename(entry, path.extname(entry));
+    if (baseName === 'NotFound') {
+      continue;
+    }
+
+    if (baseName.startsWith('[')) {
+      // Dynamic routes are handled separately via data-driven lists
+      continue;
+    }
+
+    const lowerName = baseName.toLowerCase();
+    if (lowerName === 'index') {
+      const route = routePrefix || '/';
+      routes.push(normalizeRoute(route));
+    } else {
+      const prefix = routePrefix || '';
+      routes.push(normalizeRoute(`${prefix}/${lowerName}`));
+    }
+  }
+
+  return routes;
+};
+
+const staticRoutes = collectRoutes(pagesDir);
+
+const solutionRoutes = fallbackSolutions
+  .map((solution) => solution.slug)
+  .filter((slug): slug is string => Boolean(slug))
+  .map((slug) => normalizeRoute(`/solutions/${slug}`));
+
+const routes = Array.from(new Set([...staticRoutes, ...solutionRoutes])).sort();
 
 const xml =
   '<?xml version="1.0" encoding="UTF-8"?>\n' +
@@ -30,4 +81,4 @@ const xml =
   '\n</urlset>\n';
 
 writeFileSync(path.join(publicDir, 'sitemap.xml'), xml);
-console.log('Sitemap written to public/sitemap.xml');
+console.log(`Sitemap written to public/sitemap.xml with ${routes.length} routes.`);

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,7 +6,7 @@ import { Separator } from '@/components/ui/separator';
 const Footer = () => {
   const { t } = useTranslation();
   return (
-    <footer className="bg-neutral-50 border-t border-neutral-100">
+    <footer className="border-t border-border/60 bg-muted/60 text-foreground transition-colors duration-300 dark:border-border/40 dark:bg-background/80">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8">
           {/* Logo and Description */}
@@ -16,29 +16,29 @@ const Footer = () => {
                 <span className="text-white text-lg font-bold">M</span>
               </div>
               <div className="flex flex-col">
-                <span className="font-brand font-semibold text-xl text-neutral-900">
+                <span className="font-brand font-semibold text-xl text-foreground">
                   Mon<span className="text-brand-blue">y</span>nha.com
                 </span>
-                <span className="text-sm text-neutral-400 font-medium">
+                <span className="text-sm text-muted-foreground font-medium">
                   {t('footer.tagline')}
                 </span>
               </div>
             </Link>
-            <p className="text-neutral-600 max-w-md">
+            <p className="text-muted-foreground max-w-md">
               {t('footer.description')}
             </p>
           </div>
 
           {/* Quick Links */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="font-semibold text-foreground mb-4">
               {t('footer.quickLinks')}
             </h3>
             <ul className="space-y-2">
               <li>
                 <Link
                   to="/solutions"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-muted-foreground transition-colors ease-in-out duration-300 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md px-1"
                 >
                   {t('navigation.solutions')}
                 </Link>
@@ -46,7 +46,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/about"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-muted-foreground transition-colors ease-in-out duration-300 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md px-1"
                 >
                   {t('navigation.about')}
                 </Link>
@@ -54,7 +54,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/blog"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-muted-foreground transition-colors ease-in-out duration-300 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md px-1"
                 >
                   {t('navigation.blog')}
                 </Link>
@@ -62,7 +62,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/contact"
-                  className="text-neutral-600 hover:text-brand-blue transition-colors ease-in-out duration-300"
+                  className="text-muted-foreground transition-colors ease-in-out duration-300 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded-md px-1"
                 >
                   {t('navigation.contact')}
                 </Link>
@@ -72,27 +72,27 @@ const Footer = () => {
 
           {/* Solutions */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="font-semibold text-foreground mb-4">
               {t('footer.solutions')}
             </h3>
             <ul className="space-y-2">
               <li>
-                <span className="text-neutral-600">
+                <span className="text-muted-foreground">
                   {t('footer.solutionList.boteco')}
                 </span>
               </li>
               <li>
-                <span className="text-neutral-600">
+                <span className="text-muted-foreground">
                   {t('footer.solutionList.assistina')}
                 </span>
               </li>
               <li>
-                <span className="text-neutral-600">
+                <span className="text-muted-foreground">
                   {t('footer.solutionList.custom')}
                 </span>
               </li>
               <li>
-                <span className="text-neutral-600">
+                <span className="text-muted-foreground">
                   {t('footer.solutionList.integration')}
                 </span>
               </li>
@@ -101,7 +101,7 @@ const Footer = () => {
 
           {/* Monynha Ecosystem */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="font-semibold text-foreground mb-4">
               {t('footer.ecosystem')}
             </h3>
             <ul className="space-y-2">
@@ -158,7 +158,7 @@ const Footer = () => {
 
           {/* Contact */}
           <div>
-            <h3 className="font-semibold text-neutral-900 mb-4">
+            <h3 className="font-semibold text-foreground mb-4">
               {t('footer.contact')}
             </h3>
             <ul className="space-y-2">
@@ -166,7 +166,7 @@ const Footer = () => {
                 {t('footer.email')}: {
                   <a
                     href="mailto:hello@monynha.com"
-                    className="text-sm text-muted-foreground hover:text-primary transition-colors"
+                    className="text-sm text-muted-foreground hover:text-primary transition-colors focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded"
                     aria-label="Send email to hello@monynha.com"
                     title="hello@monynha.com"
                   >
@@ -184,7 +184,7 @@ const Footer = () => {
         <Separator className="my-8" />
 
         <div className="flex flex-col md:flex-row justify-between items-center">
-          <p className="text-neutral-500 text-sm flex items-center space-x-1">
+          <p className="text-sm text-muted-foreground flex items-center space-x-1">
             <span>
               {t('footer.copyright', { year: new Date().getFullYear() })}
             </span>
@@ -197,13 +197,13 @@ const Footer = () => {
           <div className="flex space-x-6 mt-4 md:mt-0">
             <Link
               to="#"
-              className="text-neutral-500 hover:text-brand-blue transition-colors ease-in-out duration-300 text-sm"
+              className="text-sm text-muted-foreground transition-colors ease-in-out duration-300 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded px-1"
             >
               {t('footer.privacy')}
             </Link>
             <Link
               to="#"
-              className="text-neutral-500 hover:text-brand-blue transition-colors ease-in-out duration-300 text-sm"
+              className="text-sm text-muted-foreground transition-colors ease-in-out duration-300 hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background rounded px-1"
             >
               {t('footer.terms')}
             </Link>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,9 +8,11 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors duration-300">
       <SiteHeader />
-      <main className="flex-1 pt-20">{children}</main>
+      <main id="main-content" className="flex-1 pt-20 focus:outline-none">
+        {children}
+      </main>
       <Footer />
       <BackToTop />
     </div>

--- a/src/components/Meta.tsx
+++ b/src/components/Meta.tsx
@@ -1,4 +1,11 @@
 import { Helmet } from 'react-helmet-async';
+import { useLocation } from 'react-router-dom';
+
+const DEFAULT_SITE_URL =
+  (typeof import.meta !== 'undefined' &&
+    import.meta.env &&
+    (import.meta.env as Record<string, string>).VITE_SITE_URL) ||
+  'https://monynha.com';
 
 interface MetaProps {
   title?: string;
@@ -6,6 +13,8 @@ interface MetaProps {
   ogTitle?: string;
   ogDescription?: string;
   ogImage?: string;
+  canonical?: string;
+  noIndex?: boolean;
 }
 
 const Meta = ({
@@ -14,16 +23,36 @@ const Meta = ({
   ogTitle,
   ogDescription,
   ogImage,
-}: MetaProps) => (
-  <Helmet>
-    {title && <title>{title}</title>}
-    {description && <meta name="description" content={description} />}
-    {ogTitle && <meta property="og:title" content={ogTitle} />}
-    {ogDescription && (
-      <meta property="og:description" content={ogDescription} />
-    )}
-    {ogImage && <meta property="og:image" content={ogImage} />}
-  </Helmet>
-);
+  canonical,
+  noIndex = false,
+}: MetaProps) => {
+  const { pathname } = useLocation();
+  const resolvedUrl = canonical ?? `${DEFAULT_SITE_URL}${pathname}`;
+  const openGraphTitle = ogTitle ?? title;
+  const openGraphDescription = ogDescription ?? description;
+
+  return (
+    <Helmet>
+      {title && <title>{title}</title>}
+      {description && <meta name="description" content={description} />}
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={resolvedUrl} />
+      {openGraphTitle && <meta property="og:title" content={openGraphTitle} />}
+      {openGraphDescription && (
+        <meta property="og:description" content={openGraphDescription} />
+      )}
+      {ogImage && <meta property="og:image" content={ogImage} />}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:url" content={resolvedUrl} />
+      {openGraphTitle && <meta name="twitter:title" content={openGraphTitle} />}
+      {openGraphDescription && (
+        <meta name="twitter:description" content={openGraphDescription} />
+      )}
+      {ogImage && <meta name="twitter:image" content={ogImage} />}
+      <link rel="canonical" href={resolvedUrl} />
+      {noIndex && <meta name="robots" content="noindex, nofollow" />}
+    </Helmet>
+  );
+};
 
 export default Meta;

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -101,7 +101,7 @@ const SiteHeader = () => {
   const isProjectsActive = location.pathname.startsWith('/projects');
 
   const menuCardLinkClasses =
-    'group block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white transition-transform duration-300 hover:-translate-y-0.5 focus-visible:-translate-y-0.5';
+    'group block rounded-2xl transition-transform duration-300 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:-translate-y-0.5 focus-visible:-translate-y-0.5';
 
   const renderGradientCard = (
     gradient: string,
@@ -114,9 +114,9 @@ const SiteHeader = () => {
         'rounded-2xl'
       )}
     >
-      <div className="rounded-[1.05rem] bg-white/95 p-4">
+      <div className="rounded-[1.05rem] bg-white/95 p-4 backdrop-blur-sm dark:bg-neutral-900/90">
         <div className="flex items-center justify-between gap-3">
-          <span className="text-sm font-semibold text-neutral-900">
+          <span className="text-sm font-semibold text-foreground">
             {content.title}
           </span>
           <ArrowRight
@@ -124,7 +124,7 @@ const SiteHeader = () => {
             aria-hidden="true"
           />
         </div>
-        <p className="mt-2 text-xs leading-relaxed text-neutral-600">
+        <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
           {content.description}
         </p>
       </div>
@@ -132,23 +132,28 @@ const SiteHeader = () => {
   );
 
   const desktopNavLinkClasses =
-    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white';
+    'px-4 py-2 text-sm font-medium text-muted-foreground transition-colors rounded-lg hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
   const desktopNavLinkActiveClasses =
-    'text-brand-blue bg-white/80 shadow-soft-lg';
+    'text-primary bg-primary/10 shadow-soft-lg dark:bg-primary/20';
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50 border-b border-white/40 bg-white/70 shadow-[0_10px_35px_rgba(91,44,111,0.08)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/60">
+    <header
+      className={cn(
+        'fixed inset-x-0 top-0 z-50 border-b border-border/60 bg-background/80 shadow-[0_10px_35px_rgba(91,44,111,0.08)] backdrop-blur-xl supports-[backdrop-filter]:bg-background/70',
+        'dark:border-border/40 dark:shadow-[0_18px_40px_rgba(8,7,20,0.45)]'
+      )}
+    >
       <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <NavLink
           to="/"
-          className="flex items-center space-x-3 rounded-xl px-2 py-1 transition-opacity duration-300 ease-in-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white hover:opacity-80"
+          className="flex items-center space-x-3 rounded-xl px-2 py-1 transition-opacity duration-300 ease-in-out focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:opacity-80"
         >
           <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-gradient-brand text-white shadow-soft-lg">
             <span className="text-lg font-bold">M</span>
           </div>
           <div className="flex items-center space-x-1">
-            <span className="font-brand text-xl font-semibold text-neutral-900">
+            <span className="font-brand text-xl font-semibold text-foreground">
               Mon
               <span className="text-brand-blue">y</span>
               nha
@@ -190,14 +195,14 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isSolutionsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue'
+                    'px-4 py-2 text-sm font-medium text-muted-foreground transition-colors rounded-lg hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-card/80 data-[state=open]:text-primary data-[active=true]:bg-card/80 data-[active=true]:text-primary'
                   )}
                 >
                   {t('navigation.solutions')}
                 </NavigationMenuTrigger>
                 <NavigationMenuContent className="rounded-2xl shadow-soft-lg">
                   <div className="rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink p-[1px]">
-                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm">
+                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm dark:bg-neutral-950/80">
                       <div className="grid gap-4 md:grid-cols-2">
                         {solutionItems.map((item) => {
                           const content = solutionsContent[item.key];
@@ -218,7 +223,7 @@ const SiteHeader = () => {
                         <Button
                           asChild
                           variant="ghost"
-                          className="px-4 text-sm font-semibold text-brand-blue transition-colors hover:bg-gradient-to-r hover:from-brand-purple hover:via-brand-blue hover:to-brand-pink hover:text-white focus-visible:ring-brand-blue"
+                          className="px-4 text-sm font-semibold text-brand-blue transition-colors hover:bg-gradient-to-r hover:from-brand-purple hover:via-brand-blue hover:to-brand-pink hover:text-white focus-visible:ring-0"
                         >
                           <Link to="/solutions">
                             {t('navigation.solutionsMenu.viewAll')}
@@ -226,7 +231,7 @@ const SiteHeader = () => {
                         </Button>
                         <Button
                           asChild
-                          className="bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink text-white shadow-soft hover:shadow-soft-lg focus-visible:ring-brand-blue focus-visible:ring-offset-2"
+                          className="bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink text-white shadow-soft hover:shadow-soft-lg focus-visible:ring-0"
                         >
                           <Link to="/contact">
                             {t('navigation.startProject')}
@@ -242,14 +247,14 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isProjectsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue'
+                    'px-4 py-2 text-sm font-medium text-muted-foreground transition-colors rounded-lg hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-card/80 data-[state=open]:text-primary data-[active=true]:bg-card/80 data-[active=true]:text-primary'
                   )}
                 >
                   {t('navigation.projects')}
                 </NavigationMenuTrigger>
                 <NavigationMenuContent className="rounded-2xl shadow-soft-lg">
                   <div className="rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink p-[1px]">
-                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm">
+                    <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm dark:bg-neutral-950/80">
                       <div className="grid gap-4 md:grid-cols-2">
                         {projectItems.map((item) => {
                           const content = projectsContent[item.key];
@@ -285,7 +290,7 @@ const SiteHeader = () => {
                         <Button
                           asChild
                           variant="ghost"
-                          className="px-4 text-sm font-semibold text-brand-blue transition-colors hover:bg-gradient-to-r hover:from-brand-purple hover:via-brand-blue hover:to-brand-pink hover:text-white focus-visible:ring-brand-blue"
+                          className="px-4 text-sm font-semibold text-brand-blue transition-colors hover:bg-gradient-to-r hover:from-brand-purple hover:via-brand-blue hover:to-brand-pink hover:text-white focus-visible:ring-0"
                         >
                           <Link to="/projects">
                             {t('navigation.projectsMenu.viewAll')}
@@ -294,7 +299,7 @@ const SiteHeader = () => {
                         <Button
                           asChild
                           variant="outline"
-                          className="border-brand-blue/20 text-brand-blue hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:ring-brand-blue focus-visible:ring-offset-2"
+                          className="border-brand-blue/20 text-brand-blue hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:ring-0 dark:border-brand-blue/40"
                         >
                           <Link to="/contact">{t('navigation.startProject')}</Link>
                         </Button>
@@ -362,14 +367,14 @@ const SiteHeader = () => {
         <div className="hidden items-center gap-3 lg:flex">
           {user ? (
             <div className="flex items-center gap-3">
-              <span className="text-sm text-neutral-600">
+              <span className="text-sm text-muted-foreground">
                 Olá, {user.email}
               </span>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={signOut}
-                className="flex items-center gap-2 border-brand-blue/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue"
+                className="flex items-center gap-2 border-border/60 text-muted-foreground transition-colors hover:border-primary hover:text-primary focus-visible:ring-0 dark:border-border/40"
               >
                 <LogOut className="h-4 w-4" />
                 <span>Sair</span>
@@ -381,7 +386,7 @@ const SiteHeader = () => {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="flex items-center gap-2 border-brand-purple/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue"
+                  className="flex items-center gap-2 border-border/60 text-muted-foreground transition-colors hover:border-primary hover:text-primary focus-visible:ring-0 dark:border-border/40"
                 >
                   <User className="h-4 w-4" />
                   <span>Login</span>
@@ -401,30 +406,30 @@ const SiteHeader = () => {
             <SheetTrigger asChild>
               <button
                 aria-label={t('navigation.toggleNavigation')}
-                className="flex items-center justify-center rounded-xl border border-white/0 bg-white/70 p-2 text-neutral-700 shadow-soft transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white hover:text-brand-blue"
+                className="flex items-center justify-center rounded-xl border border-transparent bg-background/80 p-2 text-muted-foreground shadow-soft transition-colors hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-background/70"
               >
                 {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </button>
             </SheetTrigger>
             <SheetContent
               side="right"
-              className="w-full border-l border-white/40 bg-white/95 px-6 py-8 backdrop-blur-sm sm:max-w-sm"
+              className="w-full border-l border-border/60 bg-background/95 px-6 py-8 backdrop-blur-sm sm:max-w-sm dark:border-border/40 dark:bg-background/90"
             >
               <div className="flex items-center justify-between">
-                <span className="text-lg font-semibold text-neutral-900">
+                <span className="text-lg font-semibold text-foreground">
                   {t('navigation.toggleNavigation')}
                 </span>
                 <LanguageSwitcher />
               </div>
 
-              <nav className="mt-8 flex flex-col gap-4 text-base font-medium text-neutral-800">
+              <nav className="mt-8 flex flex-col gap-4 text-base font-medium text-foreground">
                 <SheetClose asChild>
                   <NavLink
                     to="/"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
-                        isActive && 'text-brand-blue'
+                        'rounded-lg px-3 py-2 transition-colors hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-primary'
                       )
                     }
                   >
@@ -434,7 +439,7 @@ const SiteHeader = () => {
 
                 <Accordion type="single" collapsible className="w-full border-none">
                   <AccordionItem value="solutions" className="border-none">
-                    <AccordionTrigger className="rounded-lg bg-neutral-50 px-3 py-2 text-left text-base font-semibold text-neutral-900">
+                    <AccordionTrigger className="rounded-lg bg-muted/60 px-3 py-2 text-left text-base font-semibold text-foreground">
                       {t('navigation.solutions')}
                     </AccordionTrigger>
                     <AccordionContent className="px-1">
@@ -476,7 +481,7 @@ const SiteHeader = () => {
                   </AccordionItem>
 
                   <AccordionItem value="projects" className="border-none">
-                    <AccordionTrigger className="mt-2 rounded-lg bg-neutral-50 px-3 py-2 text-left text-base font-semibold text-neutral-900">
+                    <AccordionTrigger className="mt-2 rounded-lg bg-muted/60 px-3 py-2 text-left text-base font-semibold text-foreground">
                       {t('navigation.projects')}
                     </AccordionTrigger>
                     <AccordionContent className="px-1">
@@ -530,8 +535,8 @@ const SiteHeader = () => {
                     to="/about"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
-                        isActive && 'text-brand-blue'
+                        'rounded-lg px-3 py-2 transition-colors hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-primary'
                       )
                     }
                   >
@@ -543,8 +548,8 @@ const SiteHeader = () => {
                     to="/blog"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
-                        isActive && 'text-brand-blue'
+                        'rounded-lg px-3 py-2 transition-colors hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-primary'
                       )
                     }
                   >
@@ -556,8 +561,8 @@ const SiteHeader = () => {
                     to="/contact"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white',
-                        isActive && 'text-brand-blue'
+                        'rounded-lg px-3 py-2 transition-colors hover:text-primary focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-primary'
                       )
                     }
                   >

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Quicksand:wght@500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
@@ -6,34 +6,64 @@
 @layer base {
   :root {
     --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    --foreground: 222 23% 15%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 222 23% 15%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+    --popover-foreground: 222 23% 15%;
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+    --primary: 263 83% 60%;
+    --primary-foreground: 0 0% 100%;
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 199 88% 64%;
+    --secondary-foreground: 222 23% 15%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+    --muted: 215 32% 91%;
+    --muted-foreground: 220 15% 40%;
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+    --accent: 329 86% 67%;
+    --accent-foreground: 0 0% 100%;
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 347 84% 51%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+    --border: 216 33% 91%;
+    --input: 216 33% 91%;
+    --ring: 263 83% 60%;
 
     --radius: 1.5rem;
+  }
+
+  .dark {
+    --background: 222 47% 11%;
+    --foreground: 210 40% 96%;
+
+    --card: 222 47% 14%;
+    --card-foreground: 210 40% 96%;
+
+    --popover: 222 47% 14%;
+    --popover-foreground: 210 40% 96%;
+
+    --primary: 264 83% 72%;
+    --primary-foreground: 222 47% 11%;
+
+    --secondary: 198 84% 53%;
+    --secondary-foreground: 210 40% 96%;
+
+    --muted: 222 36% 22%;
+    --muted-foreground: 213 18% 76%;
+
+    --accent: 329 71% 60%;
+    --accent-foreground: 210 40% 96%;
+
+    --destructive: 355 80% 63%;
+    --destructive-foreground: 210 40% 96%;
+
+    --border: 222 35% 24%;
+    --input: 222 35% 24%;
+    --ring: 264 83% 72%;
   }
 
   * {
@@ -41,7 +71,7 @@
   }
 
   body {
-    @apply bg-background text-neutral-900 font-sans antialiased;
+    @apply bg-background text-foreground font-sans antialiased transition-colors duration-300;
   }
 
   h1,
@@ -50,25 +80,72 @@
   h4,
   h5,
   h6 {
-    @apply font-heading font-semibold text-neutral-900;
+    @apply font-heading font-semibold text-foreground tracking-tight;
   }
 
   code,
   pre {
     @apply font-mono;
   }
+
+  .dark .text-neutral-900,
+  .dark .text-neutral-800 {
+    color: hsl(var(--foreground));
+  }
+
+  .dark .text-neutral-700,
+  .dark .text-neutral-600,
+  .dark .text-neutral-500 {
+    color: hsl(var(--muted-foreground));
+  }
+
+  .dark .bg-white {
+    background-color: hsl(var(--card));
+  }
+
+  .dark .bg-neutral-50 {
+    background-color: hsl(var(--background));
+  }
+
+  .dark .border-neutral-200,
+  .dark .border-white\/60 {
+    border-color: hsl(var(--border));
+  }
+
+  .dark .text-blue-100 {
+    color: #dbeafe;
+  }
+
+  a {
+    @apply transition-colors duration-200 underline-offset-4;
+  }
+
+  a:focus-visible,
+  button:focus-visible,
+  [role='button']:focus-visible,
+  input:focus-visible,
+  textarea:focus-visible,
+  select:focus-visible {
+    @apply outline-none ring-2 ring-ring/80 ring-offset-2 ring-offset-background;
+  }
 }
 
 @layer components {
   .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2;
+    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:ring-0;
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 transition-all ease-in-out duration-300;
+    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:ring-0 transition-all ease-in-out duration-300 dark:bg-neutral-900 dark:text-neutral-100 dark:border-neutral-800 dark:hover:border-primary dark:hover:text-primary;
   }
 
   .card-hover {
     @apply transition-all ease-in-out duration-300 hover:shadow-soft-lg hover:-translate-y-1;
+  }
+}
+
+@layer utilities {
+  .text-balance {
+    text-wrap: balance;
   }
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,11 +4,14 @@ import './index.css';
 import './i18n';
 import { Suspense } from 'react';
 import { HelmetProvider } from 'react-helmet-async';
+import ThemeProvider from './components/ThemeProvider.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <Suspense fallback={null}>
     <HelmetProvider>
-      <App />
+      <ThemeProvider>
+        <App />
+      </ThemeProvider>
     </HelmetProvider>
   </Suspense>
 );

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -147,13 +147,13 @@ const About = () => {
         ogImage="/placeholder.svg"
       />
       {/* Hero Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-background/95 transition-colors duration-300 dark:bg-background/80">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-foreground mb-6 text-balance">
               {t('about.title')}
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               {t('about.description')}
             </p>
           </div>
@@ -161,7 +161,7 @@ const About = () => {
       </section>
 
       {/* Mission & Values Section */}
-      <section className="py-24 bg-neutral-900 text-white">
+      <section className="py-24 bg-neutral-900 text-white transition-colors duration-300 dark:bg-neutral-950">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-start">
             <div className="space-y-8">
@@ -214,7 +214,7 @@ const About = () => {
       </section>
 
       {/* Story Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-background/95 transition-colors duration-300 dark:bg-background/80">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-16 items-center">
             <div className="order-2 lg:order-1 space-y-8">
@@ -223,7 +223,7 @@ const About = () => {
                   {t('about.storyTitle')}
                 </span>
               </div>
-              <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 leading-tight">
+              <h2 className="text-3xl lg:text-4xl font-bold text-foreground leading-tight">
                 {t('about.title')}
               </h2>
               <ul className="space-y-6">
@@ -232,7 +232,7 @@ const About = () => {
                     <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-brand text-white font-semibold">
                       {(index + 1).toString().padStart(2, '0')}
                     </span>
-                    <p className="text-lg text-neutral-600 leading-relaxed">
+                    <p className="text-lg text-muted-foreground leading-relaxed">
                       {story}
                     </p>
                   </li>
@@ -240,12 +240,13 @@ const About = () => {
               </ul>
             </div>
             <div className="order-1 lg:order-2">
-              <Card className="border-0 shadow-soft-lg rounded-3xl overflow-hidden">
+              <Card className="border-0 shadow-soft-lg rounded-3xl overflow-hidden bg-card/95 transition-colors duration-300 dark:bg-card/80">
                 <div className="relative h-80">
                   <img
                     src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?ixlib=rb-4.0.3&auto=format&fit=crop&w=1000&q=80"
                     alt="Team collaboration"
                     loading="lazy"
+                    decoding="async"
                     className="w-full h-full object-cover"
                   />
                   <div className="absolute inset-0 bg-gradient-to-t from-neutral-900/40 via-transparent" aria-hidden="true"></div>
@@ -257,13 +258,13 @@ const About = () => {
       </section>
 
       {/* Stats Section */}
-      <section className="py-24 bg-neutral-50">
+      <section className="py-24 bg-muted/60 transition-colors duration-300 dark:bg-background/70">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-foreground mb-4">
               {t('about.impactTitle')}
             </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               {t('about.impactDescription')}
             </p>
           </div>
@@ -277,41 +278,41 @@ const About = () => {
               {Array.from({ length: 4 }).map((_, index) => (
                 <div
                   key={index}
-                  className="h-32 rounded-2xl bg-white shadow-soft animate-pulse"
+                  className="h-32 rounded-2xl bg-card/80 shadow-soft animate-pulse"
                   aria-hidden="true"
                 ></div>
               ))}
             </div>
           ) : statsError ? (
-            <p className="text-center text-neutral-500">{t('about.statsError')}</p>
+            <p className="text-center text-muted-foreground">{t('about.statsError')}</p>
           ) : aboutStats && aboutStats.length > 0 ? (
             <div className="grid grid-cols-2 lg:grid-cols-4 gap-8">
               {aboutStats.map((stat, index) => (
                 <Card
                   key={`${stat.label}-${index}`}
-                  className="border-0 shadow-soft rounded-2xl bg-white text-center p-8"
+                  className="border-0 shadow-soft rounded-2xl bg-card/95 text-center p-8 transition-colors duration-300 dark:bg-card/80"
                 >
                   <div className="text-4xl lg:text-5xl font-bold text-transparent bg-clip-text bg-gradient-brand mb-2">
                     {stat.number}
                   </div>
-                  <div className="text-neutral-600 font-medium">{stat.label}</div>
+                  <div className="text-muted-foreground font-medium">{stat.label}</div>
                 </Card>
               ))}
             </div>
           ) : (
-            <p className="text-center text-neutral-500">{t('about.statsEmpty')}</p>
+            <p className="text-center text-muted-foreground">{t('about.statsEmpty')}</p>
           )}
         </div>
       </section>
 
       {/* Team Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-background transition-colors duration-300 dark:bg-background/80">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-foreground mb-4">
               {t('team.title')}
             </h2>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               {t('team.description')}
             </p>
           </div>
@@ -325,25 +326,25 @@ const About = () => {
               {Array.from({ length: 4 }).map((_, index) => (
                 <Card
                   key={index}
-                  className="border-0 shadow-soft rounded-2xl p-8 animate-pulse h-full"
+                  className="border-0 shadow-soft rounded-2xl p-8 animate-pulse h-full bg-card/80"
                   aria-hidden="true"
                 >
                   <div className="flex flex-col items-center gap-4">
-                    <div className="w-24 h-24 rounded-full bg-neutral-200" />
-                    <div className="w-32 h-6 rounded bg-neutral-200" />
-                    <div className="w-24 h-4 rounded bg-neutral-200" />
+                    <div className="w-24 h-24 rounded-full bg-muted" />
+                    <div className="w-32 h-6 rounded bg-muted" />
+                    <div className="w-24 h-4 rounded bg-muted" />
                   </div>
                 </Card>
               ))}
             </div>
           ) : teamError ? (
-            <p className="text-center text-neutral-500">{t('team.error')}</p>
+            <p className="text-center text-muted-foreground">{t('team.error')}</p>
           ) : teamMembers && teamMembers.length > 0 ? (
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
               {teamMembers.map((member) => (
                 <Card
                   key={member.id}
-                  className="border-0 shadow-soft hover:shadow-soft-lg transition-all duration-200 rounded-2xl"
+                  className="border-0 shadow-soft hover:shadow-soft-lg transition-all duration-200 rounded-2xl bg-card/95 dark:bg-card/80"
                 >
                   <CardContent className="p-8 text-center space-y-4">
                     <Avatar className="w-24 h-24 mx-auto">
@@ -359,7 +360,7 @@ const About = () => {
                       </AvatarFallback>
                     </Avatar>
                     <div className="space-y-1">
-                      <h3 className="text-xl font-semibold text-neutral-900">
+                      <h3 className="text-xl font-semibold text-foreground">
                         {member.name}
                       </h3>
                       <p className="text-brand-blue font-medium">{member.role}</p>
@@ -369,7 +370,7 @@ const About = () => {
               ))}
             </div>
           ) : (
-            <p className="text-center text-neutral-500">{t('team.empty')}</p>
+            <p className="text-center text-muted-foreground">{t('team.empty')}</p>
           )}
         </div>
       </section>
@@ -377,10 +378,10 @@ const About = () => {
       {/* CTA Section */}
       <section className="py-24 bg-gradient-hero text-white">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center space-y-6">
-          <h2 className="text-3xl lg:text-4xl font-bold">
+          <h2 className="text-3xl lg:text-4xl font-bold text-balance">
             {t('about.ctaTitle')}
           </h2>
-          <p className="text-xl text-blue-100">
+          <p className="text-xl text-blue-100 dark:text-indigo-100">
             {t('about.ctaDescription')}
           </p>
           <Button asChild size="lg" className="rounded-full px-10">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -326,15 +326,15 @@ const Contact = () => {
             </BreadcrumbList>
           </Breadcrumb>
         </div>
-        <section className="py-24 bg-white min-h-screen flex items-center">
+        <section className="py-24 bg-background/95 transition-colors duration-300 dark:bg-background/80 min-h-screen flex items-center">
           <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
             <div className="w-16 h-16 bg-gradient-brand rounded-full flex items-center justify-center mx-auto mb-6">
               <CheckCircle className="h-8 w-8 text-white" />
             </div>
-            <h1 className="text-3xl lg:text-4xl font-bold text-neutral-900 mb-4">
+            <h1 className="text-3xl lg:text-4xl font-bold text-foreground mb-4 text-balance">
               {t('contact.thankYou.title')}
             </h1>
-            <p className="text-xl text-neutral-600 mb-8">
+            <p className="text-xl text-muted-foreground mb-8">
               {t('contact.thankYou.description')}
             </p>
             <Button
@@ -374,13 +374,13 @@ const Contact = () => {
         </Breadcrumb>
       </div>
       {/* Hero Section */}
-      <section className="py-24 bg-white">
+      <section className="py-24 bg-background/95 transition-colors duration-300 dark:bg-background/80">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-foreground mb-6 text-balance">
               {t('contact.title')}
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               {t('contact.description')}
             </p>
           </div>
@@ -388,14 +388,14 @@ const Contact = () => {
       </section>
 
       {/* Contact Form and Info */}
-      <section className="pb-24 bg-white">
+      <section className="pb-24 bg-background transition-colors duration-300 dark:bg-background/80">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-12">
             {/* Contact Form */}
             <div className="lg:col-span-2">
-              <Card className="border-0 shadow-soft-lg rounded-2xl">
+              <Card className="border-0 shadow-soft-lg rounded-2xl bg-card/95 transition-colors duration-300 dark:bg-card/80">
                 <CardContent className="p-8">
-                  <h2 className="text-2xl font-bold text-neutral-900 mb-6">
+                  <h2 className="text-2xl font-bold text-foreground mb-6">
                     {t('contact.form.headline')}
                   </h2>
                   <form onSubmit={handleSubmit} className="space-y-6">
@@ -403,7 +403,7 @@ const Contact = () => {
                       <div>
                         <label
                           htmlFor="name"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-muted-foreground mb-2"
                         >
                           {t('contact.form.fullName')}
                         </label>
@@ -415,7 +415,7 @@ const Contact = () => {
                           value={formData.name}
                           onChange={handleInputChange}
                           onBlur={handleFieldBlur}
-                          className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue"
+                          className="rounded-xl border-border/60 focus:border-primary focus:ring-primary dark:border-border/40 dark:bg-background"
                           placeholder={t('contact.form.placeholderName')}
                         />
                         {errors.name && (
@@ -427,7 +427,7 @@ const Contact = () => {
                       <div>
                         <label
                           htmlFor="email"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-muted-foreground mb-2"
                         >
                           {t('contact.form.email')}
                         </label>
@@ -439,7 +439,7 @@ const Contact = () => {
                           value={formData.email}
                           onChange={handleInputChange}
                           onBlur={handleFieldBlur}
-                          className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue"
+                          className="rounded-xl border-border/60 focus:border-primary focus:ring-primary dark:border-border/40 dark:bg-background"
                           placeholder={t('contact.form.placeholderEmail')}
                         />
                         {errors.email && (
@@ -454,7 +454,7 @@ const Contact = () => {
                       <div>
                         <label
                           htmlFor="company"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-muted-foreground mb-2"
                         >
                           {t('contact.form.company')}
                         </label>
@@ -464,14 +464,14 @@ const Contact = () => {
                           type="text"
                           value={formData.company}
                           onChange={handleInputChange}
-                          className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue"
+                          className="rounded-xl border-border/60 focus:border-primary focus:ring-primary dark:border-border/40 dark:bg-background"
                           placeholder={t('contact.form.placeholderCompany')}
                         />
                       </div>
                       <div>
                         <label
                           htmlFor="project"
-                          className="block text-sm font-medium text-neutral-700 mb-2"
+                          className="block text-sm font-medium text-muted-foreground mb-2"
                         >
                           {t('contact.form.projectType')}
                         </label>
@@ -481,7 +481,7 @@ const Contact = () => {
                           value={formData.project}
                           onChange={handleInputChange}
                           onBlur={handleFieldBlur}
-                          className="w-full px-3 py-2 border border-neutral-200 rounded-xl focus:border-brand-blue focus:ring-1 focus:ring-brand-blue focus:outline-none text-neutral-900"
+                          className="w-full rounded-xl border border-border/60 bg-background px-3 py-2 text-foreground focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary dark:border-border/40 dark:bg-background"
                         >
                           <option value="">{t('contact.form.select')}</option>
                           {projectTypes.map((type, index) => (
@@ -496,7 +496,7 @@ const Contact = () => {
                     <div>
                       <label
                         htmlFor="message"
-                        className="block text-sm font-medium text-neutral-700 mb-2"
+                        className="block text-sm font-medium text-muted-foreground mb-2"
                       >
                         {t('contact.form.details')}
                       </label>
@@ -508,7 +508,7 @@ const Contact = () => {
                         onChange={handleInputChange}
                         onBlur={handleFieldBlur}
                         rows={6}
-                        className="rounded-xl border-neutral-200 focus:border-brand-blue focus:ring-brand-blue resize-none"
+                        className="rounded-xl border-border/60 focus:border-primary focus:ring-primary resize-none dark:border-border/40 dark:bg-background"
                         placeholder={t('contact.form.placeholderDetails')}
                       />
                       {errors.message && (
@@ -536,10 +536,10 @@ const Contact = () => {
             {/* Contact Information */}
             <div className="space-y-8">
               <div>
-                <h2 className="text-2xl font-bold text-neutral-900 mb-6">
+                <h2 className="text-2xl font-bold text-foreground mb-6">
                   {t('contact.info.getInTouch')}
                 </h2>
-                <p className="text-neutral-600 mb-8">
+                <p className="text-muted-foreground mb-8">
                   {t('contact.info.description')}
                 </p>
               </div>
@@ -547,7 +547,7 @@ const Contact = () => {
               {contactInfo.map((info, index) => (
                 <Card
                   key={index}
-                  className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl"
+                  className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl bg-card/95 dark:bg-card/80"
                 >
                   <CardContent className="p-6">
                     <div className="flex items-start space-x-4">
@@ -555,13 +555,13 @@ const Contact = () => {
                         <info.icon className="h-6 w-6 text-white" />
                       </div>
                       <div>
-                        <h3 className="font-semibold text-neutral-900 mb-1">
+                        <h3 className="font-semibold text-foreground mb-1">
                           {info.title}
                         </h3>
                         <p className="text-lg text-brand-blue font-medium mb-1">
                           {info.content}
                         </p>
-                        <p className="text-sm text-neutral-600">
+                        <p className="text-sm text-muted-foreground">
                           {info.description}
                         </p>
                       </div>
@@ -575,7 +575,7 @@ const Contact = () => {
                   <h3 className="font-semibold text-white mb-2">
                     {t('contact.info.quick')}
                   </h3>
-                  <p className="text-blue-100 text-sm">
+                  <p className="text-blue-100 text-sm dark:text-indigo-100">
                     {t('contact.info.quickDesc')}
                   </p>
                 </CardContent>

--- a/src/pages/Projects.tsx
+++ b/src/pages/Projects.tsx
@@ -210,12 +210,17 @@ const Projects = () => {
           ogDescription={t('projects.description')}
           ogImage="/placeholder.svg"
         />
-        <section className={cn(sectionPaddingY, 'bg-white')}>
+        <section
+          className={cn(
+            sectionPaddingY,
+            'bg-background/95 transition-colors duration-300 dark:bg-background/80'
+          )}
+        >
           <div className={sectionContainer}>
             <div className="text-center">
               <div className="mx-auto max-w-md animate-pulse space-y-4">
-                <div className="h-8 rounded-full bg-neutral-100" />
-                <div className="h-4 rounded-full bg-neutral-100" />
+                <div className="h-8 rounded-full bg-muted" />
+                <div className="h-4 rounded-full bg-muted" />
               </div>
             </div>
           </div>
@@ -234,7 +239,12 @@ const Projects = () => {
           ogDescription={t('projects.description')}
           ogImage="/placeholder.svg"
         />
-        <section className={cn(sectionPaddingY, 'bg-white')}>
+        <section
+          className={cn(
+            sectionPaddingY,
+            'bg-background/95 transition-colors duration-300 dark:bg-background/80'
+          )}
+        >
           <div className={sectionContainer}>
             <p className="text-center text-red-500">
               {t('projects.errorProjects')}
@@ -270,10 +280,15 @@ const Projects = () => {
         </Breadcrumb>
       </div>
 
-      <section className={cn(sectionPaddingY, 'bg-white')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-background/95 transition-colors duration-300 dark:bg-background/80'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="text-center">
-            <h1 className="text-4xl md:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl md:text-5xl font-bold text-foreground mb-6 text-balance">
               <Trans
                 i18nKey="projects.title"
                 components={[
@@ -284,26 +299,31 @@ const Projects = () => {
                 ]}
               />
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               {t('projects.description')}
             </p>
           </div>
         </div>
       </section>
 
-      <section className={cn(sectionPaddingY, 'bg-neutral-50')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-muted/60 transition-colors duration-300 dark:bg-background/70'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl font-bold text-foreground mb-4">
               {t('solutionsPage.title')}
             </h2>
-            <p className="text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-muted-foreground max-w-3xl mx-auto">
               {t('solutionsPage.description')}
             </p>
           </div>
 
           {supabaseSolutionsLoading ? (
-            <div className="text-center text-neutral-500">
+            <div className="text-center text-muted-foreground">
               {t('projects.loadingSolutions')}
             </div>
           ) : (
@@ -346,10 +366,15 @@ const Projects = () => {
         </div>
       </section>
 
-      <section className={cn(sectionPaddingY, 'bg-white')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-background transition-colors duration-300 dark:bg-background/70'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl font-bold text-foreground mb-4 text-balance">
               <Trans
                 i18nKey="projects.title"
                 components={[
@@ -360,13 +385,13 @@ const Projects = () => {
                 ]}
               />
             </h2>
-            <p className="text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-muted-foreground max-w-3xl mx-auto">
               {t('projects.description')}
             </p>
           </div>
 
           {isGitHubLoading ? (
-            <div className="text-center text-neutral-500">
+            <div className="text-center text-muted-foreground">
               {t('projects.loadingGithub')}
             </div>
           ) : (
@@ -428,13 +453,18 @@ const Projects = () => {
         </div>
       </section>
 
-      <section className={cn(sectionPaddingY, 'bg-neutral-50')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-muted/60 transition-colors duration-300 dark:bg-background/70'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="text-center mb-12">
-            <h2 className="text-3xl font-bold text-neutral-900 mb-4">
+            <h2 className="text-3xl font-bold text-foreground mb-4">
               {t('navigation.projects')}
             </h2>
-            <p className="text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-muted-foreground max-w-3xl mx-auto">
               {t('projects.description')}
             </p>
           </div>
@@ -448,19 +478,19 @@ const Projects = () => {
               {repositories.map((repo) => (
                 <Card
                   key={repo.id}
-                  className="card-hover rounded-2xl border border-white/60 bg-white/90 shadow-md"
+                  className="card-hover rounded-2xl bg-card/95 shadow-md transition-colors duration-300 dark:bg-card/80"
                 >
                   <CardHeader className="pb-4">
                     <div className="flex items-start justify-between">
-                      <CardTitle className="text-xl font-semibold text-neutral-900">
+                      <CardTitle className="text-xl font-semibold text-foreground">
                         {repo.name}
                       </CardTitle>
-                      <div className="flex items-center gap-1 text-sm text-neutral-500">
+                      <div className="flex items-center gap-1 text-sm text-muted-foreground">
                         <Calendar className="h-4 w-4" />
                         {formatDate(repo.created_at)}
                       </div>
                     </div>
-                    <p className="text-neutral-600 leading-relaxed">
+                    <p className="text-muted-foreground leading-relaxed">
                       {repo.description}
                     </p>
                   </CardHeader>
@@ -471,7 +501,7 @@ const Projects = () => {
                           <Badge
                             key={index}
                             variant="secondary"
-                            className="rounded-full bg-neutral-100 px-3 py-1 text-xs font-medium text-neutral-700"
+                            className="rounded-full bg-muted/80 px-3 py-1 text-xs font-medium text-muted-foreground"
                           >
                             {tag}
                           </Badge>
@@ -520,8 +550,8 @@ const Projects = () => {
 
       <section className={cn(sectionPaddingY, 'bg-gradient-hero text-white')}>
         <div className="max-w-3xl mx-auto px-4 text-center">
-          <h3 className="text-3xl font-bold mb-4">{t('projects.like')}</h3>
-          <p className="text-white/80 mb-8">
+          <h3 className="text-3xl font-bold mb-4 text-balance">{t('projects.like')}</h3>
+          <p className="text-white/80 mb-8 dark:text-white/90">
             {t('projects.likeDescription')}
           </p>
           <Button asChild size="lg" variant="default" className="px-8">

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -125,13 +125,18 @@ const Solutions = () => {
         </Breadcrumb>
       </div>
       {/* Hero Section */}
-      <section className={cn(sectionPaddingY, 'bg-white')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-background/95 transition-colors duration-300 dark:bg-background/80'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 mb-6">
+            <h1 className="text-4xl lg:text-5xl font-bold text-foreground mb-6 text-balance">
               {t('solutionsPage.title')}
             </h1>
-            <p className="text-xl text-neutral-600 max-w-3xl mx-auto">
+            <p className="text-xl text-muted-foreground max-w-3xl mx-auto">
               {t('solutionsPage.description')}
             </p>
           </div>
@@ -139,7 +144,12 @@ const Solutions = () => {
       </section>
 
       {/* Solutions Detail */}
-      <section className={cn(sectionPaddingY, 'bg-white')}>
+      <section
+        className={cn(
+          sectionPaddingY,
+          'bg-background transition-colors duration-300 dark:bg-background/70'
+        )}
+      >
         <div className={sectionContainer}>
           <div className="grid gap-8 md:grid-cols-2 xl:grid-cols-3">
             {displaySolutions.map((solution) => (
@@ -180,16 +190,16 @@ const Solutions = () => {
       {/* Custom Solutions CTA */}
       <section className={cn(sectionPaddingY, 'bg-gradient-hero text-white')}>
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl lg:text-4xl font-bold mb-6">
+          <h2 className="text-3xl lg:text-4xl font-bold mb-6 text-balance">
             {t('solutionsPage.customTitle')}
           </h2>
-          <p className="text-xl text-blue-100 mb-8">
+          <p className="text-xl text-blue-100 mb-8 dark:text-indigo-100">
             {t('solutionsPage.customDescription')}
           </p>
           <Link to="/contact">
             <Button
               size="lg"
-              className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-2xl text-lg transition-all ease-in-out duration-300 shadow-md hover:shadow-soft-lg"
+              className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-2xl text-lg transition-all ease-in-out duration-300 shadow-md hover:shadow-soft-lg dark:bg-transparent dark:text-white dark:ring-1 dark:ring-white/40 dark:hover:bg-white/10"
             >
               {t('solutionsPage.discuss')}
               <ArrowRight className="ml-2 h-5 w-5" />

--- a/src/pages/blog/[slug].tsx
+++ b/src/pages/blog/[slug].tsx
@@ -357,7 +357,7 @@ const BlogPostPage = () => {
           </BreadcrumbList>
         </Breadcrumb>
       </div>
-      <section className="py-16 bg-white">
+      <section className="py-16 bg-background transition-colors duration-300 dark:bg-background/80">
         <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
           <Link
             to="/blog"
@@ -370,14 +370,14 @@ const BlogPostPage = () => {
           <article className="space-y-10">
             <header className="space-y-6">
               <div className="space-y-4">
-                <h1 className="text-4xl font-bold text-neutral-900">
+                <h1 className="text-4xl font-bold text-foreground">
                   {post.title}
                 </h1>
                 {post.excerpt && (
-                  <p className="text-xl text-neutral-600">{post.excerpt}</p>
+                  <p className="text-xl text-muted-foreground">{post.excerpt}</p>
                 )}
               </div>
-              <div className="flex flex-wrap items-center gap-4 text-sm text-neutral-500">
+              <div className="flex flex-wrap items-center gap-4 text-sm text-muted-foreground">
                 <div className="flex items-center gap-2">
                   <User className="h-4 w-4" />
                   <span>{t('blog.post.author', { author: defaultAuthor })}</span>
@@ -387,24 +387,25 @@ const BlogPostPage = () => {
                   <span>{readTimeLabel}</span>
                 </div>
                 <div className="flex items-center gap-2">
-                  <span className="inline-flex h-1.5 w-1.5 rounded-full bg-neutral-300" aria-hidden />
+                  <span className="inline-flex h-1.5 w-1.5 rounded-full bg-muted" aria-hidden />
                   <span>{t('blog.post.published', { date: updatedDate })}</span>
                 </div>
               </div>
             </header>
 
             {post.image_url && (
-              <div className="overflow-hidden rounded-3xl bg-neutral-100 shadow-soft">
+              <div className="overflow-hidden rounded-3xl bg-muted shadow-soft">
                 <img
                   src={post.image_url}
                   alt={post.title}
                   className="h-full w-full object-cover"
                   loading="lazy"
+                  decoding="async"
                 />
               </div>
             )}
 
-            <div className="space-y-6 text-lg leading-relaxed text-neutral-700">
+            <div className="space-y-6 text-lg leading-relaxed text-muted-foreground">
               {renderedContent.length > 0 ? (
                 renderedContent
               ) : (

--- a/src/pages/solutions/[slug].tsx
+++ b/src/pages/solutions/[slug].tsx
@@ -187,17 +187,17 @@ const SolutionDetail = () => {
         </Breadcrumb>
       </div>
 
-      <section className="py-16">
+      <section className="py-16 bg-background transition-colors duration-300 dark:bg-background/80">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid gap-12 lg:grid-cols-[1.1fr_0.9fr] items-start">
             <div>
               <div
                 className={`h-1 w-16 bg-gradient-to-r ${displaySolution.gradient} rounded-full mb-6`}
               />
-              <h1 className="text-4xl font-bold text-neutral-900 mb-6">
+              <h1 className="text-4xl font-bold text-foreground mb-6 text-balance">
                 {displaySolution.title}
               </h1>
-              <p className="text-lg text-neutral-600 leading-relaxed">
+              <p className="text-lg text-muted-foreground leading-relaxed">
                 {displaySolution.description}
               </p>
 
@@ -205,7 +205,7 @@ const SolutionDetail = () => {
                 <Button
                   asChild
                   variant="outline"
-                  className="flex-1 sm:flex-none sm:w-auto border-neutral-200 hover:border-brand-blue hover:text-brand-blue transition-colors"
+                  className="flex-1 sm:flex-none sm:w-auto border-border/60 hover:border-primary hover:text-primary transition-colors dark:border-border/40"
                 >
                   <Link to="/solutions" className="flex items-center justify-center gap-2">
                     <ArrowLeft className="h-4 w-4" />
@@ -225,11 +225,12 @@ const SolutionDetail = () => {
             </div>
 
             {displaySolution.imageUrl && (
-              <Card className="border-0 shadow-soft-lg overflow-hidden rounded-2xl">
+              <Card className="border-0 shadow-soft-lg overflow-hidden rounded-2xl bg-card/95 transition-colors duration-300 dark:bg-card/80">
                 <img
                   src={displaySolution.imageUrl}
                   alt={displaySolution.title}
                   loading="lazy"
+                  decoding="async"
                   className="w-full h-full object-cover"
                 />
                 <div
@@ -242,23 +243,23 @@ const SolutionDetail = () => {
       </section>
 
       {displaySolution.features.length > 0 && (
-        <section className="py-16 bg-neutral-50">
+        <section className="py-16 bg-muted/60 transition-colors duration-300 dark:bg-background/70">
           <div className="max-w-5xl mx-auto px-4 sm:px-6 lg:px-8">
-            <h2 className="text-2xl font-semibold text-neutral-900 mb-8">
+            <h2 className="text-2xl font-semibold text-foreground mb-8">
               {t('solutionsPage.featuresTitle')}
             </h2>
             <div className="space-y-4">
               {displaySolution.features.map((feature, index) => (
                 <div
                   key={`${displaySolution.slug}-detail-feature-${index}`}
-                  className="bg-white rounded-2xl shadow-soft p-6 flex items-start gap-4"
+                  className="bg-card/95 rounded-2xl shadow-soft p-6 flex items-start gap-4 transition-colors duration-300 dark:bg-card/80"
                 >
                   <span
                     className={`inline-flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-r ${displaySolution.gradient}`}
                   >
                     <CheckCircle className="h-5 w-5 text-white" />
                   </span>
-                  <p className="text-neutral-700 leading-relaxed">{feature}</p>
+                  <p className="text-muted-foreground leading-relaxed">{feature}</p>
                 </div>
               ))}
             </div>
@@ -271,13 +272,13 @@ const SolutionDetail = () => {
           <h2 className="text-3xl lg:text-4xl font-bold mb-6">
             {t('solutionsPage.customTitle')}
           </h2>
-          <p className="text-xl text-blue-100 mb-8">
+          <p className="text-xl text-blue-100 mb-8 dark:text-indigo-100">
             {t('solutionsPage.customDescription')}
           </p>
           <Button
             asChild
             size="lg"
-            className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-xl text-lg transition-all ease-in-out duration-300"
+            className="bg-white text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-xl text-lg transition-all ease-in-out duration-300 dark:bg-transparent dark:text-white dark:ring-1 dark:ring-white/40 dark:hover:bg-white/10"
           >
             <Link to="/contact" className="flex items-center justify-center gap-2">
               {t('solutionsPage.discuss')}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,38 +21,38 @@ export default {
     },
     extend: {
       colors: {
-        border: 'hsl(var(--border))',
-        input: 'hsl(var(--input))',
-        ring: 'hsl(var(--ring))',
-        background: 'hsl(var(--background))',
-        foreground: 'hsl(var(--foreground))',
+        border: 'hsl(var(--border) / <alpha-value>)',
+        input: 'hsl(var(--input) / <alpha-value>)',
+        ring: 'hsl(var(--ring) / <alpha-value>)',
+        background: 'hsl(var(--background) / <alpha-value>)',
+        foreground: 'hsl(var(--foreground) / <alpha-value>)',
         primary: {
-          DEFAULT: 'hsl(var(--primary))',
-          foreground: 'hsl(var(--primary-foreground))',
+          DEFAULT: 'hsl(var(--primary) / <alpha-value>)',
+          foreground: 'hsl(var(--primary-foreground) / <alpha-value>)',
         },
         secondary: {
-          DEFAULT: 'hsl(var(--secondary))',
-          foreground: 'hsl(var(--secondary-foreground))',
+          DEFAULT: 'hsl(var(--secondary) / <alpha-value>)',
+          foreground: 'hsl(var(--secondary-foreground) / <alpha-value>)',
         },
         destructive: {
-          DEFAULT: 'hsl(var(--destructive))',
-          foreground: 'hsl(var(--destructive-foreground))',
+          DEFAULT: 'hsl(var(--destructive) / <alpha-value>)',
+          foreground: 'hsl(var(--destructive-foreground) / <alpha-value>)',
         },
         muted: {
-          DEFAULT: 'hsl(var(--muted))',
-          foreground: 'hsl(var(--muted-foreground))',
+          DEFAULT: 'hsl(var(--muted) / <alpha-value>)',
+          foreground: 'hsl(var(--muted-foreground) / <alpha-value>)',
         },
         accent: {
-          DEFAULT: 'hsl(var(--accent))',
-          foreground: 'hsl(var(--accent-foreground))',
+          DEFAULT: 'hsl(var(--accent) / <alpha-value>)',
+          foreground: 'hsl(var(--accent-foreground) / <alpha-value>)',
         },
         popover: {
-          DEFAULT: 'hsl(var(--popover))',
-          foreground: 'hsl(var(--popover-foreground))',
+          DEFAULT: 'hsl(var(--popover) / <alpha-value>)',
+          foreground: 'hsl(var(--popover-foreground) / <alpha-value>)',
         },
         card: {
-          DEFAULT: 'hsl(var(--card))',
-          foreground: 'hsl(var(--card-foreground))',
+          DEFAULT: 'hsl(var(--card) / <alpha-value>)',
+          foreground: 'hsl(var(--card-foreground) / <alpha-value>)',
         },
         // Monynha Softwares Brand Colors
         brand: {
@@ -77,9 +77,9 @@ export default {
         },
       },
       fontFamily: {
-        sans: ['Inter', 'system-ui', 'sans-serif'],
-        heading: ['"Space Grotesk"', 'Inter', 'system-ui', 'sans-serif'],
-        brand: ['"Space Grotesk"', 'Inter', 'system-ui', 'sans-serif'],
+        sans: ['"Inter"', '"Quicksand"', 'system-ui', 'sans-serif'],
+        heading: ['"Quicksand"', '"Inter"', 'system-ui', 'sans-serif'],
+        brand: ['"Quicksand"', '"Inter"', 'system-ui', 'sans-serif'],
         mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
       backgroundImage: {


### PR DESCRIPTION
## Summary
- align Tailwind design tokens with the Quicksand/Inter typography, add <alpha-value> aware brand colors, and expand global base styles for dark mode focus and contrast
- refresh layout, header, footer, shared cards, and key public pages to support dark mode, improve accessibility/alt text, and lazy-load imagery
- enhance Meta metadata handling plus robots/sitemap generation, and regenerate the sitemap with fallback solution routes

## Testing
- npm run sitemap
- npm run lint *(warnings: react-refresh/only-export-components in pre-existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68ca85f604d883228d6fbf47c935e66d