### PR TITLE
feat: refresh marketing layout with new brand palette

### DIFF
--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -9,7 +9,7 @@ export const sectionPaddingY = 'py-24 sm:py-28';
 export const sectionContainer = 'max-w-7xl mx-auto px-4 sm:px-6 lg:px-8';
 
 export const surfaceCardClass =
-  'rounded-2xl border border-white/60 bg-white/90 shadow-md backdrop-blur-sm';
+  'rounded-3xl border border-white/70 bg-white/95 shadow-[0_30px_80px_-45px_rgba(91,44,111,0.45)] backdrop-blur-md transition-colors duration-300 dark:border-neutral-800/70 dark:bg-neutral-900/75';
 
 export const featureIconWrapperClass =
-  'inline-flex h-8 w-8 items-center justify-center rounded-full text-white shadow-sm';
+  'inline-flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-brand text-white shadow-[0_18px_45px_-25px_rgba(91,44,111,0.45)]';

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,8 +6,16 @@ import { Separator } from '@/components/ui/separator';
 const Footer = () => {
   const { t } = useTranslation();
   return (
-    <footer className="border-t border-neutral-100 bg-neutral-50 transition-colors dark:border-neutral-800 dark:bg-neutral-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <footer className="relative overflow-hidden border-t border-brand-purple/10 bg-white/90 transition-colors dark:border-neutral-800/70 dark:bg-neutral-950">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-10 bg-mesh-brand opacity-70"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute right-[-20%] top-[-30%] -z-10 h-96 w-96 rounded-full bg-gradient-to-br from-brand-purple/20 via-brand-blue/15 to-brand-orange/20 blur-3xl"
+      />
+      <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8">
           {/* Logo and Description */}
           <div className="sm:col-span-2">
@@ -38,7 +46,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/solutions"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.solutions')}
                 </Link>
@@ -46,7 +54,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/about"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.about')}
                 </Link>
@@ -54,7 +62,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/blog"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.blog')}
                 </Link>
@@ -62,7 +70,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/contact"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.contact')}
                 </Link>
@@ -110,7 +118,7 @@ const Footer = () => {
                   href="https://monynha.tech"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.tech"
                   title="monynha.tech"
                 >
@@ -122,7 +130,7 @@ const Footer = () => {
                   href="https://monynha.fun"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.fun"
                   title="monynha.fun"
                 >
@@ -134,7 +142,7 @@ const Footer = () => {
                   href="https://monynha.online"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.online"
                   title="monynha.online"
                 >
@@ -146,7 +154,7 @@ const Footer = () => {
                   href="https://monynha.me"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.me"
                   title="monynha.me"
                 >
@@ -166,7 +174,7 @@ const Footer = () => {
                 {t('footer.email')}: {
                   <a
                     href="mailto:hello@monynha.com"
-                    className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                    className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                     aria-label="Send email to hello@monynha.com"
                     title="hello@monynha.com"
                   >
@@ -181,7 +189,7 @@ const Footer = () => {
           </div>
         </div>
 
-        <Separator className="my-8 bg-neutral-200 dark:bg-neutral-800" />
+        <Separator className="my-8 bg-neutral-200/60 dark:bg-neutral-800" />
 
         <div className="flex flex-col md:flex-row justify-between items-center">
           <p className="flex items-center space-x-1 text-sm text-neutral-500 dark:text-neutral-400">
@@ -197,13 +205,13 @@ const Footer = () => {
           <div className="flex space-x-6 mt-4 md:mt-0">
             <Link
               to="#"
-              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-400"
+              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-400"
             >
               {t('footer.privacy')}
             </Link>
             <Link
               to="#"
-              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-400"
+              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-400"
             >
               {t('footer.terms')}
             </Link>

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -1,4 +1,5 @@
 import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
 
 const languages = [
   { code: 'en', label: 'EN' },
@@ -11,18 +12,27 @@ const LanguageSwitcher = () => {
   const { i18n } = useTranslation();
 
   return (
-    <div className="flex space-x-2">
-      {languages.map((lng) => (
-        <button
-          key={lng.code}
-          onClick={() => i18n.changeLanguage(lng.code)}
-          className={`text-sm font-medium hover:text-brand-blue transition-colors ease-in-out duration-300 ${
-            i18n.language === lng.code ? 'text-brand-blue' : 'text-neutral-700'
-          }`}
-        >
-          {lng.label}
-        </button>
-      ))}
+    <div className="inline-flex items-center rounded-full border border-brand-purple/15 bg-white/80 p-1 text-xs shadow-[0_12px_32px_-20px_rgba(91,44,111,0.4)] backdrop-blur-sm transition-colors dark:border-neutral-700/60 dark:bg-neutral-900/70">
+      {languages.map((lng) => {
+        const isActive = i18n.language === lng.code;
+
+        return (
+          <button
+            key={lng.code}
+            type="button"
+            aria-current={isActive ? 'true' : undefined}
+            onClick={() => i18n.changeLanguage(lng.code)}
+            className={cn(
+              'rounded-full px-3 py-1 text-xs font-semibold transition-colors duration-200 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-neutral-900',
+              isActive
+                ? 'bg-gradient-brand text-white shadow-soft'
+                : 'text-neutral-600 hover:text-brand-purple dark:text-neutral-300'
+            )}
+          >
+            {lng.label}
+          </button>
+        );
+      })}
     </div>
   );
 };

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,9 +8,21 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors duration-300">
+    <div className="relative flex min-h-screen flex-col overflow-hidden bg-background text-foreground transition-colors duration-300">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 -z-20 bg-mesh-brand bg-[length:320px_320px] opacity-70"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute -top-48 left-1/2 -z-10 h-[520px] w-[820px] -translate-x-1/2 rounded-[50%] bg-gradient-to-r from-brand-purple/30 via-brand-blue/20 to-brand-pink/25 blur-3xl"
+      />
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute bottom-[-18%] right-[-10%] -z-10 h-[420px] w-[420px] rounded-full bg-gradient-to-br from-brand-blue/20 via-brand-purple/14 to-brand-orange/20 blur-3xl"
+      />
       <SiteHeader />
-      <main className="flex-1 pt-20">{children}</main>
+      <main className="relative z-10 flex-1 pt-24">{children}</main>
       <Footer />
       <BackToTop />
     </div>

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -80,7 +80,7 @@ const NewsletterSection = () => {
           <h2 className="text-3xl lg:text-4xl font-bold mb-4">
             {t('newsletterSection.thankYouTitle')}
           </h2>
-          <p className="text-xl text-blue-100 mb-8">
+          <p className="text-xl text-white/80 mb-8">
             {t('newsletterSection.thankYouDescription')}
           </p>
           <Button
@@ -88,7 +88,7 @@ const NewsletterSection = () => {
               setIsSubscribed(false);
               setEmail('');
             }}
-            className="rounded-xl bg-white px-6 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
+            className="btn-secondary px-6 py-3"
           >
             {t('newsletterSection.subscribeAnother')}
           </Button>
@@ -110,7 +110,7 @@ const NewsletterSection = () => {
               {t('newsletterSection.title')}
             </h2>
 
-            <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+            <p className="text-xl text-white/80 mb-8 max-w-2xl mx-auto">
               {t('newsletterSection.description')}
             </p>
 
@@ -127,7 +127,7 @@ const NewsletterSection = () => {
                 <Button
                   type="submit"
                   disabled={isSubmitting}
-                  className="whitespace-nowrap rounded-xl bg-white px-8 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
+                  className="btn-secondary whitespace-nowrap px-8 py-3"
                 >
                   {isSubmitting
                     ? t('newsletterSection.subscribing')

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -101,7 +101,7 @@ const SiteHeader = () => {
   const isProjectsActive = location.pathname.startsWith('/projects');
 
   const menuCardLinkClasses =
-    'group block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-transform duration-300 hover:-translate-y-0.5 focus-visible:-translate-y-0.5';
+    'group block rounded-2xl transition-transform duration-300 hover:-translate-y-0.5 focus-visible:-translate-y-0.5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/80 focus-visible:ring-offset-2 focus-visible:ring-offset-background';
 
   const renderGradientCard = (
     gradient: string,
@@ -109,12 +109,12 @@ const SiteHeader = () => {
   ) => (
     <div
       className={cn(
-        'bg-gradient-to-r p-[1px] shadow-soft transition-shadow duration-300 group-hover:shadow-soft-lg group-focus-visible:shadow-soft-lg',
+        'bg-gradient-to-br p-[1px] shadow-[0_22px_60px_-32px_rgba(91,44,111,0.5)] transition-shadow duration-300 group-hover:shadow-soft-lg group-focus-visible:shadow-soft-lg',
         gradient,
         'rounded-2xl'
       )}
     >
-      <div className="rounded-[1.05rem] bg-white/95 p-4 transition-colors dark:bg-neutral-950/90">
+      <div className="rounded-[1.1rem] bg-white/95 p-4 shadow-[0_14px_35px_-28px_rgba(91,44,111,0.35)] backdrop-blur-sm transition-colors dark:bg-neutral-950/85">
         <div className="flex items-center justify-between gap-3">
           <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
             {content.title}
@@ -132,13 +132,13 @@ const SiteHeader = () => {
   );
 
   const desktopNavLinkClasses =
-    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-neutral-200';
+    'px-4 py-2 text-sm font-semibold text-neutral-600 transition-colors rounded-xl hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-neutral-200';
 
   const desktopNavLinkActiveClasses =
-    'text-brand-blue bg-white/80 shadow-soft-lg dark:bg-neutral-900/70';
+    'bg-white/90 text-brand-purple shadow-soft-lg dark:bg-neutral-900/70 dark:text-white';
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50 border-b border-white/40 bg-white/70 shadow-[0_10px_35px_rgba(91,44,111,0.08)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/60 transition-colors dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_12px_40px_rgba(3,7,18,0.6)] dark:supports-[backdrop-filter]:bg-neutral-950/70">
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-brand-purple/10 bg-white/80 shadow-[0_24px_60px_-30px_rgba(91,44,111,0.5)] backdrop-blur-2xl supports-[backdrop-filter]:bg-white/70 transition-colors dark:border-neutral-800/70 dark:bg-neutral-950/85 dark:shadow-[0_28px_65px_-22px_rgba(5,10,25,0.7)] dark:supports-[backdrop-filter]:bg-neutral-950/75">
       <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <NavLink
           to="/"
@@ -190,12 +190,12 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isSolutionsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
+                    'rounded-xl px-4 py-2 text-sm font-semibold text-neutral-600 transition-colors hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-purple data-[active=true]:bg-white/80 data-[active=true]:text-brand-purple dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
                   )}
                 >
                   {t('navigation.solutions')}
                 </NavigationMenuTrigger>
-                <NavigationMenuContent className="rounded-2xl shadow-soft-lg">
+                <NavigationMenuContent className="rounded-2xl border border-white/60 bg-white/80 shadow-[0_24px_60px_-28px_rgba(91,44,111,0.45)] backdrop-blur-xl dark:border-neutral-800/70 dark:bg-neutral-950/90">
                   <div className="rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink p-[1px]">
                     <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm transition-colors dark:bg-neutral-950/90">
                       <div className="grid gap-4 md:grid-cols-2">
@@ -218,7 +218,7 @@ const SiteHeader = () => {
                         <Button
                           asChild
                           variant="ghost"
-                          className="px-4 text-sm font-semibold text-brand-blue transition-colors hover:bg-gradient-to-r hover:from-brand-purple hover:via-brand-blue hover:to-brand-pink hover:text-white focus-visible:ring-brand-blue"
+                          className="px-4 text-sm font-semibold text-brand-purple transition-colors hover:bg-gradient-brand hover:text-white focus-visible:ring-brand-blue"
                         >
                           <Link to="/solutions">
                             {t('navigation.solutionsMenu.viewAll')}
@@ -242,12 +242,12 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isProjectsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
+                    'rounded-xl px-4 py-2 text-sm font-semibold text-neutral-600 transition-colors hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-purple data-[active=true]:bg-white/80 data-[active=true]:text-brand-purple dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
                   )}
                 >
                   {t('navigation.projects')}
                 </NavigationMenuTrigger>
-                <NavigationMenuContent className="rounded-2xl shadow-soft-lg">
+                <NavigationMenuContent className="rounded-2xl border border-white/60 bg-white/80 shadow-[0_24px_60px_-28px_rgba(91,44,111,0.45)] backdrop-blur-xl dark:border-neutral-800/70 dark:bg-neutral-950/90">
                   <div className="rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink p-[1px]">
                     <div className="md:w-[560px] rounded-[1.05rem] bg-white/95 p-6 backdrop-blur-sm transition-colors dark:bg-neutral-950/90">
                       <div className="grid gap-4 md:grid-cols-2">
@@ -285,7 +285,7 @@ const SiteHeader = () => {
                         <Button
                           asChild
                           variant="ghost"
-                          className="px-4 text-sm font-semibold text-brand-blue transition-colors hover:bg-gradient-to-r hover:from-brand-purple hover:via-brand-blue hover:to-brand-pink hover:text-white focus-visible:ring-brand-blue"
+                          className="px-4 text-sm font-semibold text-brand-purple transition-colors hover:bg-gradient-brand hover:text-white focus-visible:ring-brand-blue"
                         >
                           <Link to="/projects">
                             {t('navigation.projectsMenu.viewAll')}
@@ -294,7 +294,7 @@ const SiteHeader = () => {
                         <Button
                           asChild
                           variant="outline"
-                          className="border-brand-blue/20 text-brand-blue hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:ring-brand-blue focus-visible:ring-offset-2"
+                          className="border-brand-purple/25 text-brand-purple hover:border-brand-purple hover:bg-brand-purple/10 focus-visible:ring-brand-blue focus-visible:ring-offset-2"
                         >
                           <Link to="/contact">{t('navigation.startProject')}</Link>
                         </Button>
@@ -369,7 +369,7 @@ const SiteHeader = () => {
                 variant="outline"
                 size="sm"
                 onClick={signOut}
-                className="flex items-center gap-2 border-brand-blue/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40 dark:text-neutral-200"
+                className="flex items-center gap-2 border-brand-purple/30 text-neutral-700 transition-colors hover:border-brand-purple hover:text-brand-purple focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
               >
                 <LogOut className="h-4 w-4" />
                 <span>Sair</span>
@@ -381,7 +381,7 @@ const SiteHeader = () => {
                 <Button
                   variant="outline"
                   size="sm"
-                  className="flex items-center gap-2 border-brand-purple/30 text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
+                  className="flex items-center gap-2 border-brand-purple/30 text-neutral-700 transition-colors hover:border-brand-purple hover:text-brand-purple focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
                 >
                   <User className="h-4 w-4" />
                   <span>Login</span>
@@ -401,7 +401,7 @@ const SiteHeader = () => {
             <SheetTrigger asChild>
               <button
                 aria-label={t('navigation.toggleNavigation')}
-                className="flex items-center justify-center rounded-xl border border-white/0 bg-white/70 p-2 text-neutral-700 shadow-soft transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:text-brand-blue dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:text-neutral-100"
+                className="flex items-center justify-center rounded-xl border border-white/0 bg-white/75 p-2 text-neutral-700 shadow-soft transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:text-brand-purple dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:text-neutral-100"
               >
                 {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </button>
@@ -423,8 +423,8 @@ const SiteHeader = () => {
                     to="/"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                        isActive && 'text-brand-blue'
+                        'rounded-xl px-3 py-2 transition-colors hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-brand-purple'
                       )
                     }
                   >
@@ -458,7 +458,7 @@ const SiteHeader = () => {
                         <SheetClose asChild>
                           <Link
                             to="/solutions"
-                            className="inline-flex items-center justify-center rounded-lg border border-brand-blue/20 px-4 py-2 text-sm font-semibold text-brand-blue transition-colors hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40"
+                            className="inline-flex items-center justify-center rounded-xl border border-brand-purple/25 px-4 py-2 text-sm font-semibold text-brand-purple transition-colors hover:border-brand-purple hover:bg-brand-purple/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/35"
                           >
                             {t('navigation.solutionsMenu.viewAll')}
                           </Link>
@@ -515,7 +515,7 @@ const SiteHeader = () => {
                         <SheetClose asChild>
                           <Link
                             to="/projects"
-                            className="inline-flex items-center justify-center rounded-lg border border-brand-blue/20 px-4 py-2 text-sm font-semibold text-brand-blue transition-colors hover:border-brand-blue hover:bg-brand-blue/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40"
+                            className="inline-flex items-center justify-center rounded-xl border border-brand-purple/25 px-4 py-2 text-sm font-semibold text-brand-purple transition-colors hover:border-brand-purple hover:bg-brand-purple/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/35"
                           >
                             {t('navigation.projectsMenu.viewAll')}
                           </Link>
@@ -530,8 +530,8 @@ const SiteHeader = () => {
                     to="/about"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                        isActive && 'text-brand-blue'
+                        'rounded-xl px-3 py-2 transition-colors hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-brand-purple'
                       )
                     }
                   >
@@ -543,8 +543,8 @@ const SiteHeader = () => {
                     to="/blog"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                        isActive && 'text-brand-blue'
+                        'rounded-xl px-3 py-2 transition-colors hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-brand-purple'
                       )
                     }
                   >
@@ -556,8 +556,8 @@ const SiteHeader = () => {
                     to="/contact"
                     className={({ isActive }) =>
                       cn(
-                        'rounded-lg px-3 py-2 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-                        isActive && 'text-brand-blue'
+                        'rounded-xl px-3 py-2 transition-colors hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                        isActive && 'text-brand-purple'
                       )
                     }
                   >
@@ -578,7 +578,7 @@ const SiteHeader = () => {
                         signOut();
                         setMobileOpen(false);
                       }}
-                      className="flex w-full items-center justify-center gap-2 border-brand-blue/30 text-neutral-700 hover:border-brand-blue hover:text-brand-blue focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40 dark:text-neutral-200"
+                      className="flex w-full items-center justify-center gap-2 border-brand-purple/30 text-neutral-700 transition-colors hover:border-brand-purple hover:text-brand-purple focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
                     >
                       <LogOut className="h-4 w-4" />
                       <span>Sair</span>
@@ -589,7 +589,7 @@ const SiteHeader = () => {
                     <SheetClose asChild>
                       <Link
                         to="/auth"
-                        className="inline-flex items-center justify-center gap-2 rounded-lg border border-brand-purple/30 px-4 py-2 text-sm font-semibold text-neutral-700 transition-colors hover:border-brand-blue hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
+                        className="inline-flex items-center justify-center gap-2 rounded-xl border border-brand-purple/30 px-4 py-2 text-sm font-semibold text-neutral-700 transition-colors hover:border-brand-purple hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/40 dark:text-neutral-200"
                       >
                         <User className="h-4 w-4" />
                         <span>Login</span>

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -38,7 +38,7 @@ const TeamSection = () => {
 
   if (isLoading) {
     return (
-      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
+      <section className="py-24">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
@@ -70,7 +70,7 @@ const TeamSection = () => {
 
   if (error) {
     return (
-      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
+      <section className="py-24">
         <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
           <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
             {t('team.title')}
@@ -84,34 +84,38 @@ const TeamSection = () => {
   }
 
   return (
-    <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="mb-16 text-center">
-          <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
-            {t('team.title')}
-          </h2>
-          <p className="mx-auto max-w-3xl text-xl text-neutral-600 dark:text-neutral-300">
-            {t('team.description')}
-          </p>
-        </div>
+      <section className="relative py-24">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 h-full bg-surface-glow opacity-60 blur-[180px]"
+        />
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="mb-16 text-center">
+            <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
+              {t('team.title')}
+            </h2>
+            <p className="mx-auto max-w-3xl text-xl text-neutral-600 dark:text-neutral-300">
+              {t('team.description')}
+            </p>
+          </div>
 
-        <div className="flex flex-wrap justify-center gap-8">
-          {members?.map((member) => (
-            <Card
-              key={member.id}
-              className="card-hover w-full rounded-2xl border-0 shadow-soft transition-all duration-200 hover:shadow-soft-lg md:w-1/2 lg:w-1/4 dark:bg-neutral-900/80"
-            >
-              <CardContent className="p-8 text-center">
-                <Avatar className="mx-auto mb-6 h-24 w-24">
-                  <AvatarImage
-                    src={member.image_url || undefined}
-                    alt={member.name}
-                  />
-                  <AvatarFallback className="bg-gradient-hero text-white text-xl font-semibold">
-                    {member.name
-                      .split(' ')
-                      .map((n) => n[0])
-                      .join('')}
+          <div className="flex flex-wrap justify-center gap-8">
+            {members?.map((member) => (
+              <Card
+                key={member.id}
+              className="card-hover w-full rounded-2xl border border-white/70 bg-white/90 shadow-[0_25px_65px_-35px_rgba(91,44,111,0.35)] transition-all duration-300 hover:-translate-y-2 hover:shadow-soft-lg md:w-1/2 lg:w-1/4 dark:border-neutral-800/70 dark:bg-neutral-900/75"
+              >
+                <CardContent className="p-8 text-center">
+                  <Avatar className="mx-auto mb-6 h-24 w-24">
+                    <AvatarImage
+                      src={member.image_url || undefined}
+                      alt={member.name}
+                    />
+                  <AvatarFallback className="bg-gradient-brand text-white text-xl font-semibold">
+                      {member.name
+                        .split(' ')
+                        .map((n) => n[0])
+                        .join('')}
                   </AvatarFallback>
                 </Avatar>
 
@@ -119,7 +123,7 @@ const TeamSection = () => {
                   {member.name}
                 </h3>
 
-                <p className="mb-4 font-medium text-brand-blue">
+                <p className="mb-4 font-medium text-brand-purple">
                   {member.role}
                 </p>
 
@@ -134,7 +138,7 @@ const TeamSection = () => {
                     variant="outline"
                     size="sm"
                     aria-label={t('team.linkedin')}
-                    className="rounded-full border-brand-blue text-brand-blue transition-colors hover:bg-brand-blue hover:text-white focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                    className="rounded-full border-brand-purple/40 text-brand-purple transition-colors hover:bg-brand-purple hover:text-white focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background"
                     onClick={() => window.open(member.linkedin_url!, '_blank')}
                   >
                     <Linkedin className="h-4 w-4" />

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -10,11 +10,11 @@ export const buttonVariants = cva(
         destructive:
           'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         outline:
-          'border border-brand-blue/30 bg-white text-brand-purple hover:border-brand-blue hover:text-brand-blue hover:bg-brand-blue/5 shadow-sm',
+          'border border-brand-purple/25 bg-white text-brand-purple hover:border-brand-purple hover:bg-brand-purple/5 hover:text-brand-purple shadow-sm dark:border-brand-purple/40 dark:bg-neutral-900 dark:text-white',
         secondary:
-          'bg-brand-blue/10 text-brand-blue hover:bg-brand-blue/20 shadow-sm',
-        ghost: 'shadow-none hover:bg-brand-blue/10 hover:text-brand-blue',
-        link: 'shadow-none text-brand-blue underline-offset-4 hover:underline px-0',
+          'bg-brand-blue/15 text-brand-blue hover:bg-brand-blue/25 shadow-sm dark:bg-brand-blue/20 dark:text-white',
+        ghost: 'shadow-none text-brand-purple hover:bg-brand-purple/10 hover:text-brand-purple',
+        link: 'shadow-none text-brand-purple underline-offset-4 hover:underline px-0',
       },
       size: {
         default: 'h-11 px-5 py-2.5',

--- a/src/index.css
+++ b/src/index.css
@@ -5,65 +5,65 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222 47% 9%;
+    --background: 230 60% 99%;
+    --foreground: 255 32% 18%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222 47% 9%;
+    --card-foreground: 255 32% 18%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 9%;
+    --popover-foreground: 255 32% 18%;
 
-    --primary: 262 83% 58%;
+    --primary: 282 43% 42%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 199 89% 55%;
+    --secondary: 212 72% 58%;
     --secondary-foreground: 210 40% 98%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215 16% 46%;
+    --muted: 230 28% 94%;
+    --muted-foreground: 237 16% 45%;
 
-    --accent: 330 72% 67%;
+    --accent: 0 66% 64%;
     --accent-foreground: 210 40% 98%;
 
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 74% 58%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 262 83% 58%;
+    --border: 230 28% 88%;
+    --input: 230 28% 88%;
+    --ring: 282 58% 45%;
 
-    --radius: 1.5rem;
+    --radius: 1.75rem;
   }
 
   .dark {
-    --background: 240 10% 6%;
+    --background: 240 22% 12%;
     --foreground: 210 40% 96%;
 
-    --card: 240 10% 12%;
+    --card: 240 24% 16%;
     --card-foreground: 210 40% 96%;
 
-    --popover: 240 10% 12%;
+    --popover: 240 24% 16%;
     --popover-foreground: 210 40% 96%;
 
-    --primary: 262 83% 68%;
-    --primary-foreground: 240 33% 12%;
+    --primary: 282 46% 64%;
+    --primary-foreground: 249 35% 14%;
 
-    --secondary: 199 89% 62%;
-    --secondary-foreground: 240 10% 6%;
+    --secondary: 212 70% 66%;
+    --secondary-foreground: 249 35% 14%;
 
-    --muted: 240 8% 18%;
-    --muted-foreground: 215 20% 72%;
+    --muted: 240 20% 22%;
+    --muted-foreground: 240 20% 72%;
 
-    --accent: 330 72% 72%;
-    --accent-foreground: 240 10% 6%;
+    --accent: 0 72% 70%;
+    --accent-foreground: 249 35% 14%;
 
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 70% 58%;
+    --destructive-foreground: 210 40% 96%;
 
-    --border: 240 8% 22%;
-    --input: 240 8% 22%;
-    --ring: 262 83% 68%;
+    --border: 240 20% 28%;
+    --input: 240 20% 28%;
+    --ring: 282 46% 64%;
   }
 
   * {
@@ -78,6 +78,40 @@
 
   body {
     @apply bg-background text-foreground font-sans antialiased;
+    background-image: radial-gradient(
+        circle at 10% 15%,
+        rgba(91, 44, 111, 0.12),
+        transparent 60%
+      ),
+      radial-gradient(
+        circle at 85% 10%,
+        rgba(74, 144, 226, 0.12),
+        transparent 60%
+      ),
+      radial-gradient(
+        circle at 15% 85%,
+        rgba(224, 102, 102, 0.12),
+        transparent 60%
+      );
+    background-attachment: fixed;
+  }
+
+  .dark body {
+    background-image: radial-gradient(
+        circle at 10% 20%,
+        rgba(91, 44, 111, 0.18),
+        transparent 60%
+      ),
+      radial-gradient(
+        circle at 80% 0%,
+        rgba(74, 144, 226, 0.16),
+        transparent 60%
+      ),
+      radial-gradient(
+        circle at 20% 85%,
+        rgba(224, 102, 102, 0.14),
+        transparent 60%
+      );
   }
 
   h1,
@@ -117,14 +151,15 @@
 
 @layer components {
   .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-brand px-7 py-3 text-base font-semibold text-white shadow-soft transition-all duration-300 ease-out hover:shadow-soft-lg hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+    background-size: 200% 200%;
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-all ease-in-out duration-300 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800;
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl border border-brand-purple/15 bg-white/90 px-7 py-3 text-base font-semibold text-brand-purple shadow-[0_18px_40px_-28px_rgba(91,44,111,0.45)] transition-all duration-300 ease-out hover:-translate-y-0.5 hover:border-brand-purple/40 hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-purple/30 dark:bg-neutral-900/80 dark:text-white dark:hover:bg-neutral-800;
   }
 
   .card-hover {
-    @apply transition-all ease-in-out duration-300 hover:shadow-soft-lg hover:-translate-y-1;
+    @apply transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-soft-lg;
   }
 }

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -502,7 +502,7 @@ const Blog = () => {
               placeholder={t('blog.newsletter.placeholder')}
               className="flex-1 px-4 py-3 rounded-xl border-0 text-neutral-900 dark:text-neutral-100 placeholder-neutral-500 focus:ring-2 focus:ring-white focus:outline-none"
             />
-            <Button className="bg-white transition-colors dark:bg-neutral-950 text-brand-purple hover:bg-blue-50 font-semibold px-6 py-3 rounded-xl transition-all ease-in-out duration-300">
+            <Button className="btn-secondary px-6 py-3">
               {t('blog.newsletter.subscribe')}
             </Button>
           </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -149,6 +149,15 @@ const Index = () => {
 
   const displaySolutions = solutions || fallbackSolutions;
 
+  const heroStats = useMemo(
+    () => [
+      { value: '120+', label: t('team.stats.projects') },
+      { value: '98%', label: t('team.stats.satisfaction') },
+      { value: '24/7', label: t('team.stats.support') },
+    ],
+    [t]
+  );
+
   return (
     <Layout>
       <Meta
@@ -159,49 +168,74 @@ const Index = () => {
         ogImage="/placeholder.svg"
       />
       {/* Hero Section */}
-      <section className="relative overflow-hidden bg-gradient-hero text-white">
-        <div className="absolute inset-0 bg-black/20"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
-          <div className="text-center animate-fade-in">
-            <h1 className="text-4xl lg:text-6xl font-bold mb-6 text-white">
+      <section className="relative overflow-hidden rounded-b-[3rem] bg-gradient-hero text-white shadow-[0_60px_140px_-60px_rgba(91,44,111,0.6)]">
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-gradient-to-br from-brand-purple/80 via-brand-blue/60 to-brand-pink/50"
+        />
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 opacity-70 bg-[radial-gradient(circle_at_15%_20%,rgba(247,181,0,0.18),transparent_60%),radial-gradient(circle_at_85%_15%,rgba(74,144,226,0.2),transparent_55%),radial-gradient(circle_at_40%_85%,rgba(224,102,102,0.2),transparent_60%)]"
+        />
+        <div className="relative mx-auto max-w-7xl px-4 py-28 sm:px-6 lg:px-8">
+          <div className="mx-auto flex max-w-4xl flex-col items-center gap-8 text-center animate-fade-in">
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/10 px-5 py-2 text-sm font-medium text-white/80 shadow-[0_15px_45px_-35px_rgba(255,255,255,0.8)] backdrop-blur-sm">
+              {t('footer.tagline')}
+            </span>
+            <h1 className="text-4xl font-bold leading-[1.1] text-white drop-shadow-[0_20px_45px_rgba(15,23,42,0.25)] lg:text-6xl">
               <Trans
                 i18nKey="index.hero.headline"
                 components={[
                   <br key="lb" />,
                   <span
                     key="gradient"
-                    className="text-transparent bg-clip-text bg-gradient-to-r from-white to-blue-200"
+                    className="text-transparent bg-clip-text bg-gradient-to-r from-white via-brand-orange/80 to-brand-blue/80"
                   />,
                 ]}
               />
             </h1>
-            <p className="text-xl lg:text-2xl text-blue-100 mb-8 max-w-3xl mx-auto">
+            <p className="mx-auto max-w-3xl text-xl text-white/80 lg:text-2xl">
               {t('index.hero.description')}
             </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <div className="flex flex-col justify-center gap-4 sm:flex-row">
               <Link to="/contact">
-                <Button className="btn-primary">
+                <Button className="btn-primary px-8 py-4 text-lg">
                   {t('index.hero.cta')}
-
                   <ArrowRight className="ml-2 h-5 w-5" />
                 </Button>
               </Link>
               <Link to="/solutions">
-                <Button
-                  size="lg"
-                  className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
-                >
+                <Button className="btn-secondary px-8 py-4 text-lg">
                   {t('index.hero.viewSolutions')}
                 </Button>
               </Link>
             </div>
+            <div className="mt-8 grid w-full gap-4 sm:grid-cols-3">
+              {heroStats.map((stat) => (
+                <div
+                  key={stat.label}
+                  className="rounded-2xl border border-white/25 bg-white/10 px-6 py-5 text-left shadow-[0_25px_65px_-35px_rgba(15,23,42,0.45)] backdrop-blur-md"
+                >
+                  <p className="text-3xl font-semibold text-white sm:text-4xl">{stat.value}</p>
+                  <p className="mt-1 text-sm font-medium text-white/80">{stat.label}</p>
+                </div>
+              ))}
+            </div>
           </div>
         </div>
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 bottom-[-120px] h-[240px] bg-gradient-to-b from-brand-blue/35 to-transparent blur-3xl"
+        />
       </section>
 
       {/* Features Section */}
-      <section className="py-24 bg-white transition-colors dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="relative py-24">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-0 h-full bg-surface-glow opacity-70 blur-[140px]"
+        />
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('index.why.title')}
@@ -210,19 +244,23 @@ const Index = () => {
               {t('index.why.description')}
             </p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
             {displayFeatures.map((feature, index) => (
               <a
                 key={index}
                 href={feature.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block"
+                className="group block"
               >
-                <Card className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl cursor-pointer">
-                  <CardContent className="p-8 text-center">
-                    <div className="w-16 h-16 bg-gradient-hero rounded-2xl flex items-center justify-center mx-auto mb-6">
-                      <feature.icon className="h-8 w-8 text-white" />
+                <Card className="relative overflow-hidden rounded-2xl border border-white/70 bg-white/90 shadow-[0_25px_65px_-35px_rgba(91,44,111,0.35)] transition-all duration-300 hover:-translate-y-2 hover:shadow-soft-lg dark:border-neutral-800/70 dark:bg-neutral-900/70">
+                  <div
+                    aria-hidden="true"
+                    className="absolute inset-x-0 top-0 h-1.5 bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink"
+                  />
+                  <CardContent className="relative z-10 p-8 text-center">
+                    <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-2xl bg-gradient-brand text-white shadow-[0_20px_45px_-25px_rgba(91,44,111,0.45)] ring-4 ring-white/25 dark:ring-white/10">
+                      <feature.icon className="h-8 w-8" />
                     </div>
                     <h3 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">
                       {feature.title}
@@ -237,8 +275,12 @@ const Index = () => {
       </section>
 
       {/* Solutions Preview */}
-      <section className="py-24 bg-neutral-50 dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="relative py-24">
+        <div
+          aria-hidden="true"
+          className="pointer-events-none absolute inset-x-0 top-10 h-[65%] rounded-[3rem] bg-gradient-to-br from-brand-purple/10 via-white/30 to-brand-blue/10 blur-[180px]"
+        />
+        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
               {t('index.solutions.title')}
@@ -251,12 +293,13 @@ const Index = () => {
             {displaySolutions.map((solution, index) => (
               <Card
                 key={index}
-                className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl overflow-hidden"
+                className="relative overflow-hidden rounded-3xl border border-white/70 bg-white/95 shadow-[0_30px_80px_-45px_rgba(91,44,111,0.45)] transition-all duration-300 hover:-translate-y-2 hover:shadow-soft-lg dark:border-neutral-800/70 dark:bg-neutral-900/75"
               >
                 <div
-                  className={`h-4 bg-gradient-to-r ${solution.gradient}`}
-                ></div>
-                <CardContent className="p-8">
+                  aria-hidden="true"
+                  className={`h-2 bg-gradient-to-r ${solution.gradient}`}
+                />
+                <CardContent className="relative z-10 p-8">
                   <h3 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
                     {solution.name}
                   </h3>
@@ -272,14 +315,14 @@ const Index = () => {
                             key={featureIndex}
                             className="flex items-center text-neutral-700 dark:text-neutral-300"
                           >
-                            <CheckCircle className="h-5 w-5 text-brand-blue mr-3" />
+                            <CheckCircle className="mr-3 h-5 w-5 text-brand-purple" />
                             {feature}
                           </li>
                         ))}
                       </ul>
                     )}
                   <Link to="/solutions">
-                    <Button className="btn-secondary w-full">
+                    <Button className="btn-secondary w-full justify-center">
                       {t('index.learnMore')}
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>
@@ -298,19 +341,20 @@ const Index = () => {
       <NewsletterSection />
 
       {/* CTA Section */}
-      <section className="py-24 bg-gradient-hero text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <section className="relative py-24">
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-4 top-0 z-0 mx-auto h-full max-w-5xl rounded-[3rem] bg-gradient-hero shadow-[0_50px_120px_-60px_rgba(91,44,111,0.55)]"
+        />
+        <div className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-white">
           <h2 className="text-3xl lg:text-4xl font-bold mb-6">
             {t('index.cta.title')}
           </h2>
-          <p className="text-xl text-blue-100 mb-8">
+          <p className="text-xl text-white/80 mb-8">
             {t('index.cta.description')}
           </p>
           <Link to="/contact">
-            <Button
-              size="lg"
-              className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
-            >
+            <Button className="btn-secondary px-8 py-4 text-lg">
               {t('index.cta.getStarted')}
               <ArrowRight className="ml-2 h-5 w-5" />
             </Button>

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -188,19 +188,20 @@ const Solutions = () => {
       </section>
 
       {/* Custom Solutions CTA */}
-      <section className={cn(sectionPaddingY, 'bg-gradient-hero text-white')}>
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <section className={cn(sectionPaddingY, 'relative text-white')}>
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-4 top-0 z-0 mx-auto h-full max-w-5xl rounded-[3rem] bg-gradient-hero shadow-[0_50px_120px_-60px_rgba(91,44,111,0.55)]"
+        />
+        <div className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
           <h2 className="text-3xl lg:text-4xl font-bold mb-6">
             {t('solutionsPage.customTitle')}
           </h2>
-          <p className="text-xl text-blue-100 mb-8">
+          <p className="text-xl text-white/80 mb-8">
             {t('solutionsPage.customDescription')}
           </p>
           <Link to="/contact">
-            <Button
-              size="lg"
-              className="rounded-2xl bg-white px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 shadow-md hover:shadow-soft-lg dark:text-white dark:hover:bg-neutral-800"
-            >
+            <Button className="btn-secondary px-8 py-4 text-lg">
               {t('solutionsPage.discuss')}
               <ArrowRight className="ml-2 h-5 w-5" />
             </Button>

--- a/src/pages/solutions/[slug].tsx
+++ b/src/pages/solutions/[slug].tsx
@@ -266,18 +266,21 @@ const SolutionDetail = () => {
         </section>
       )}
 
-      <section className="py-24 bg-gradient-hero text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+      <section className="relative py-24">
+        <div
+          aria-hidden="true"
+          className="absolute inset-x-4 top-0 z-0 mx-auto h-full max-w-5xl rounded-[3rem] bg-gradient-hero shadow-[0_50px_120px_-60px_rgba(91,44,111,0.55)]"
+        />
+        <div className="relative z-10 max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center text-white">
           <h2 className="text-3xl lg:text-4xl font-bold mb-6">
             {t('solutionsPage.customTitle')}
           </h2>
-          <p className="text-xl text-blue-100 mb-8">
+          <p className="text-xl text-white/80 mb-8">
             {t('solutionsPage.customDescription')}
           </p>
           <Button
             asChild
-            size="lg"
-            className="bg-white transition-colors dark:bg-neutral-950 text-brand-purple hover:bg-blue-50 font-semibold px-8 py-4 rounded-xl text-lg transition-all ease-in-out duration-300"
+            className="btn-secondary px-8 py-4 text-lg"
           >
             <Link to="/contact" className="flex items-center justify-center gap-2">
               {t('solutionsPage.discuss')}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -56,26 +56,26 @@ export default {
         },
         // Monynha Softwares Brand Colors
         brand: {
-          DEFAULT: '#7C3AED',
-          purple: '#7C3AED',
-          blue: '#0EA5E9',
-          pink: '#EC4899',
-          orange: '#F97316',
-          indigo: '#4338CA',
-          teal: '#14B8A6',
+          DEFAULT: '#5B2C6F',
+          purple: '#5B2C6F',
+          blue: '#4A90E2',
+          pink: '#E06666',
+          orange: '#F7B500',
+          lavender: '#C7B4E2',
+          violet: '#7A4D92',
         },
         neutral: {
-          50: '#F9FAFB',
-          100: '#F3F4F6',
-          200: '#E5E7EB',
-          300: '#D1D5DB',
-          400: '#9CA3AF',
-          500: '#6B7280',
-          600: '#4B5563',
-          700: '#374151',
-          800: '#1F2937',
-          900: '#111827',
-          950: '#030712',
+          50: '#F8F7FF',
+          100: '#F1F2FB',
+          200: '#E3E6F5',
+          300: '#CED2EC',
+          400: '#AAB0D9',
+          500: '#858CC3',
+          600: '#6469A5',
+          700: '#4A4E82',
+          800: '#34355B',
+          900: '#22223D',
+          950: '#16162A',
         },
       },
       fontFamily: {
@@ -86,21 +86,25 @@ export default {
       },
       backgroundImage: {
         'gradient-brand':
-          'linear-gradient(135deg, #7C3AED 0%, #0EA5E9 40%, #EC4899 75%, #F97316 100%)',
-        'gradient-hero': 'linear-gradient(135deg, #7C3AED 0%, #0EA5E9 100%)',
+          'linear-gradient(135deg, #5B2C6F 0%, #4A90E2 35%, #E06666 70%, #F7B500 100%)',
+        'gradient-hero': 'linear-gradient(135deg, #5B2C6F 0%, #4A90E2 100%)',
         'gradient-pride':
-          'linear-gradient(135deg, #7C3AED 0%, #0EA5E9 25%, #22C55E 50%, #F97316 75%, #EC4899 100%)',
+          'linear-gradient(135deg, #5B2C6F 0%, #4A90E2 25%, #22C55E 50%, #F7B500 75%, #E06666 100%)',
+        'mesh-brand':
+          'radial-gradient(circle at 10% 20%, rgba(91, 44, 111, 0.14), transparent 55%), radial-gradient(circle at 85% 15%, rgba(74, 144, 226, 0.16), transparent 55%), radial-gradient(circle at 18% 85%, rgba(224, 102, 102, 0.18), transparent 60%)',
+        'surface-glow':
+          'linear-gradient(135deg, rgba(91, 44, 111, 0.12) 0%, rgba(74, 144, 226, 0.12) 45%, rgba(224, 102, 102, 0.12) 100%)',
       },
       borderRadius: {
         lg: 'var(--radius)',
-        md: 'calc(var(--radius) - 4px)',
+        md: 'calc(var(--radius) - 3px)',
         sm: 'calc(var(--radius) - 6px)',
-        xl: '1.25rem',
-        '2xl': '1.75rem',
+        xl: '1.5rem',
+        '2xl': '2rem',
       },
       boxShadow: {
-        soft: '0 10px 30px -15px rgba(124, 58, 237, 0.35)',
-        'soft-lg': '0 25px 60px -20px rgba(14, 165, 233, 0.45)',
+        soft: '0 20px 45px -25px rgba(91, 44, 111, 0.4)',
+        'soft-lg': '0 28px 60px -20px rgba(74, 144, 226, 0.4)',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Summary
- align the Tailwind theme, base CSS and custom gradients with the refreshed Monynha brand palette
- redesign the shared layout, header, footer and marketing sections with mesh backgrounds, soft shadows and updated CTA styling
- refresh homepage hero, feature/solution highlights and supporting sections plus shared button variants for a cohesive look across pages

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68ca9607d89483228fda85220a640bc0