### PR TITLE
feat: refresh homepage layout with brand palette

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,14 +6,19 @@ import { Separator } from '@/components/ui/separator';
 const Footer = () => {
   const { t } = useTranslation();
   return (
-    <footer className="border-t border-neutral-100 bg-neutral-50 transition-colors dark:border-neutral-800 dark:bg-neutral-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <footer className="relative overflow-hidden border-t border-brand-purple/10 bg-white/95 transition-colors dark:border-white/5 dark:bg-neutral-950">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute left-[-6rem] top-[-6rem] h-48 w-48 rounded-full bg-brand-purple/12 blur-3xl dark:bg-brand-purple/25" />
+        <div className="absolute right-[-4rem] top-1/2 h-56 w-56 rounded-full bg-brand-blue/12 blur-3xl dark:bg-brand-blue/25" />
+        <div className="absolute bottom-[-5rem] left-[30%] h-44 w-44 rounded-full bg-brand-pink/10 blur-3xl dark:bg-brand-pink/22" />
+      </div>
+      <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8">
           {/* Logo and Description */}
           <div className="sm:col-span-2">
             <Link to="/" className="mb-4 flex items-center space-x-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-brand">
-                <span className="text-lg font-bold text-white">M</span>
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-gradient-to-br from-brand-purple via-brand-blue to-brand-pink shadow-[0_18px_40px_-22px_rgba(91,44,111,0.65)]">
+                <span className="text-xl font-bold text-white">M</span>
               </div>
               <div className="flex flex-col">
                 <span className="font-brand text-xl font-semibold text-neutral-900 dark:text-neutral-100">
@@ -181,7 +186,7 @@ const Footer = () => {
           </div>
         </div>
 
-        <Separator className="my-8 bg-neutral-200 dark:bg-neutral-800" />
+        <Separator className="my-8 bg-brand-purple/10 dark:bg-white/5" />
 
         <div className="flex flex-col md:flex-row justify-between items-center">
           <p className="flex items-center space-x-1 text-sm text-neutral-500 dark:text-neutral-400">
@@ -194,7 +199,7 @@ const Footer = () => {
               <span>{t('footer.andPride')}</span>
             </span>
           </p>
-          <div className="flex space-x-6 mt-4 md:mt-0">
+          <div className="mt-4 flex space-x-6 md:mt-0">
             <Link
               to="#"
               className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-400"

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,7 +8,12 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors duration-300">
+    <div className="relative flex min-h-screen flex-col overflow-hidden bg-background text-foreground transition-colors duration-300">
+      <div className="pointer-events-none absolute inset-0 -z-10">
+        <div className="absolute left-1/2 top-[-14rem] h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-gradient-to-br from-brand-purple/35 via-brand-blue/25 to-brand-pink/30 blur-3xl dark:from-brand-purple/45 dark:via-brand-blue/35 dark:to-brand-pink/40" />
+        <div className="absolute right-[-12rem] top-1/3 h-[22rem] w-[22rem] rounded-full bg-brand-blue/15 blur-3xl dark:bg-brand-blue/25" />
+        <div className="absolute bottom-[-10rem] left-[-8rem] h-[20rem] w-[20rem] rounded-full bg-brand-pink/10 blur-[140px] dark:bg-brand-pink/20" />
+      </div>
       <SiteHeader />
       <main className="flex-1 pt-20">{children}</main>
       <Footer />

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -72,50 +72,58 @@ const NewsletterSection = () => {
 
   if (isSubscribed) {
     return (
-      <section className="py-24 bg-gradient-hero text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
-            <CheckCircle className="h-8 w-8 text-white" />
+      <section className="relative py-24 text-white">
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-brand-purple via-brand-blue to-brand-pink" />
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.35),_transparent_60%)]" />
+        <div className="relative mx-auto max-w-4xl px-4 sm:px-6 lg:px-8 text-center">
+          <div className="rounded-[2.6rem] border border-white/25 bg-white/10 p-[1px] shadow-[0_25px_65px_-20px_rgba(15,23,42,0.55)] backdrop-blur-2xl">
+            <div className="rounded-[2.5rem] bg-white/10 px-10 py-16 backdrop-blur-xl">
+              <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-white/20">
+                <CheckCircle className="h-8 w-8 text-white" />
+              </div>
+              <h2 className="text-3xl lg:text-4xl font-bold">
+                {t('newsletterSection.thankYouTitle')}
+              </h2>
+              <p className="mt-4 text-xl text-blue-100">
+                {t('newsletterSection.thankYouDescription')}
+              </p>
+              <Button
+                onClick={() => {
+                  setIsSubscribed(false);
+                  setEmail('');
+                }}
+                className="btn-secondary mt-8 inline-flex items-center gap-2 rounded-full border-white/40 bg-white/90 px-8 py-3 text-base font-semibold text-brand-purple hover:border-white/60 hover:text-brand-purple"
+              >
+                {t('newsletterSection.subscribeAnother')}
+              </Button>
+            </div>
           </div>
-          <h2 className="text-3xl lg:text-4xl font-bold mb-4">
-            {t('newsletterSection.thankYouTitle')}
-          </h2>
-          <p className="text-xl text-blue-100 mb-8">
-            {t('newsletterSection.thankYouDescription')}
-          </p>
-          <Button
-            onClick={() => {
-              setIsSubscribed(false);
-              setEmail('');
-            }}
-            className="rounded-xl bg-white px-6 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
-          >
-            {t('newsletterSection.subscribeAnother')}
-          </Button>
         </div>
       </section>
     );
   }
 
   return (
-    <section className="py-24 bg-gradient-hero text-white">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Card className="rounded-2xl border-0 bg-white/10 shadow-soft-lg backdrop-blur-sm">
-          <CardContent className="p-8 lg:p-12 text-center">
-            <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
+    <section className="relative py-24 text-white">
+      <div className="absolute inset-0 -z-10 bg-gradient-to-br from-brand-purple via-brand-blue to-brand-pink" />
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.35),_transparent_60%)]" />
+      <div className="relative mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+        <Card className="rounded-[2.4rem] border-white/25 bg-white/10 p-[1px] shadow-[0_25px_65px_-20px_rgba(15,23,42,0.55)] backdrop-blur-2xl">
+          <CardContent className="rounded-[2.3rem] bg-white/10 p-10 text-center backdrop-blur-xl">
+            <div className="mx-auto mb-6 flex h-16 w-16 items-center justify-center rounded-full bg-white/20">
               <Mail className="h-8 w-8 text-white" />
             </div>
 
-            <h2 className="text-3xl lg:text-4xl font-bold text-white mb-4">
+            <h2 className="text-3xl lg:text-4xl font-bold text-white">
               {t('newsletterSection.title')}
             </h2>
 
-            <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+            <p className="mt-4 text-xl text-blue-100">
               {t('newsletterSection.description')}
             </p>
 
-            <form onSubmit={handleSubmit} className="max-w-md mx-auto">
-              <div className="flex flex-col sm:flex-row gap-4">
+            <form onSubmit={handleSubmit} className="mx-auto mt-10 max-w-md">
+              <div className="flex flex-col gap-4 sm:flex-row">
                 <Input
                   type="email"
                   placeholder={t('newsletterSection.placeholder')}
@@ -127,7 +135,7 @@ const NewsletterSection = () => {
                 <Button
                   type="submit"
                   disabled={isSubmitting}
-                  className="whitespace-nowrap rounded-xl bg-white px-8 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
+                  className="whitespace-nowrap rounded-xl bg-white/90 px-8 py-3 font-semibold text-brand-purple shadow-[0_18px_45px_-24px_rgba(15,23,42,0.8)] transition-colors hover:bg-white focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
                 >
                   {isSubmitting
                     ? t('newsletterSection.subscribing')

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -38,9 +38,11 @@ const TeamSection = () => {
 
   if (isLoading) {
     return (
-      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
+      <section className="relative py-24">
+        <div className="absolute inset-0 -z-20 bg-gradient-to-b from-white via-white to-white transition-colors dark:from-neutral-950 dark:via-neutral-950/95 dark:to-neutral-950" />
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.08),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.25),_transparent_65%)]" />
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mb-16 text-center">
             <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
               {t('team.title')}
             </h2>
@@ -52,7 +54,7 @@ const TeamSection = () => {
             {[...Array(4)].map((_, i) => (
               <Card
                 key={i}
-                className="w-full animate-pulse rounded-2xl border-0 shadow-soft transition-colors md:w-1/2 lg:w-1/4 dark:bg-neutral-900/60"
+                className="w-full animate-pulse rounded-[1.75rem] border border-brand-purple/10 bg-white/85 shadow-[0_24px_60px_-30px_rgba(91,44,111,0.5)] transition-colors md:w-1/2 lg:w-1/4 dark:border-white/10 dark:bg-neutral-900/60"
               >
                 <CardContent className="p-8 text-center">
                   <div className="mx-auto mb-6 h-24 w-24 rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
@@ -70,8 +72,10 @@ const TeamSection = () => {
 
   if (error) {
     return (
-      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
-        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+      <section className="relative py-24">
+        <div className="absolute inset-0 -z-20 bg-gradient-to-b from-white via-white to-white transition-colors dark:from-neutral-950 dark:via-neutral-950/95 dark:to-neutral-950" />
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.08),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.25),_transparent_65%)]" />
+        <div className="relative mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
           <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
             {t('team.title')}
           </h2>
@@ -84,8 +88,10 @@ const TeamSection = () => {
   }
 
   return (
-    <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="relative py-24">
+      <div className="absolute inset-0 -z-20 bg-gradient-to-b from-white via-white to-white transition-colors dark:from-neutral-950 dark:via-neutral-950/95 dark:to-neutral-950" />
+      <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.08),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.25),_transparent_65%)]" />
+      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mb-16 text-center">
           <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
             {t('team.title')}
@@ -99,7 +105,7 @@ const TeamSection = () => {
           {members?.map((member) => (
             <Card
               key={member.id}
-              className="card-hover w-full rounded-2xl border-0 shadow-soft transition-all duration-200 hover:shadow-soft-lg md:w-1/2 lg:w-1/4 dark:bg-neutral-900/80"
+              className="card-hover w-full rounded-[1.75rem] border border-brand-purple/10 bg-white/90 shadow-[0_24px_60px_-30px_rgba(91,44,111,0.5)] transition-all duration-200 hover:-translate-y-1 hover:shadow-[0_32px_70px_-28px_rgba(74,144,226,0.55)] md:w-1/2 lg:w-1/4 dark:border-white/10 dark:bg-neutral-900/80"
             >
               <CardContent className="p-8 text-center">
                 <Avatar className="mx-auto mb-6 h-24 w-24">
@@ -107,7 +113,7 @@ const TeamSection = () => {
                     src={member.image_url || undefined}
                     alt={member.name}
                   />
-                  <AvatarFallback className="bg-gradient-hero text-white text-xl font-semibold">
+                  <AvatarFallback className="bg-gradient-to-br from-brand-purple via-brand-blue to-brand-pink text-xl font-semibold text-white">
                     {member.name
                       .split(' ')
                       .map((n) => n[0])

--- a/src/index.css
+++ b/src/index.css
@@ -5,65 +5,65 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222 47% 9%;
+    --background: 261 100% 99%;
+    --foreground: 265 36% 16%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222 47% 9%;
+    --card-foreground: 265 36% 16%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 9%;
+    --popover-foreground: 265 36% 16%;
 
-    --primary: 262 83% 58%;
+    --primary: 282 43% 30%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 199 89% 55%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 212 72% 59%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215 16% 46%;
+    --muted: 256 56% 95%;
+    --muted-foreground: 263 33% 40%;
 
-    --accent: 330 72% 67%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 0 66% 64%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 262 83% 58%;
+    --border: 257 45% 88%;
+    --input: 257 45% 88%;
+    --ring: 212 72% 59%;
 
     --radius: 1.5rem;
   }
 
   .dark {
-    --background: 240 10% 6%;
+    --background: 261 36% 10%;
     --foreground: 210 40% 96%;
 
-    --card: 240 10% 12%;
+    --card: 261 36% 14%;
     --card-foreground: 210 40% 96%;
 
-    --popover: 240 10% 12%;
+    --popover: 261 36% 14%;
     --popover-foreground: 210 40% 96%;
 
-    --primary: 262 83% 68%;
-    --primary-foreground: 240 33% 12%;
+    --primary: 282 43% 52%;
+    --primary-foreground: 261 100% 97%;
 
-    --secondary: 199 89% 62%;
-    --secondary-foreground: 240 10% 6%;
+    --secondary: 212 72% 70%;
+    --secondary-foreground: 261 36% 10%;
 
-    --muted: 240 8% 18%;
-    --muted-foreground: 215 20% 72%;
+    --muted: 263 28% 22%;
+    --muted-foreground: 260 20% 80%;
 
-    --accent: 330 72% 72%;
-    --accent-foreground: 240 10% 6%;
+    --accent: 0 66% 70%;
+    --accent-foreground: 261 36% 10%;
 
     --destructive: 0 84% 60%;
     --destructive-foreground: 210 40% 98%;
 
-    --border: 240 8% 22%;
-    --input: 240 8% 22%;
-    --ring: 262 83% 68%;
+    --border: 263 32% 28%;
+    --input: 263 32% 28%;
+    --ring: 212 72% 70%;
   }
 
   * {
@@ -78,6 +78,14 @@
 
   body {
     @apply bg-background text-foreground font-sans antialiased;
+    background-image: radial-gradient(
+        circle at 20% -10%,
+        rgba(91, 44, 111, 0.18),
+        transparent 55%
+      ),
+      radial-gradient(circle at 80% -40%, rgba(74, 144, 226, 0.22), transparent 60%),
+      linear-gradient(180deg, #f7f3ff 0%, #ffffff 60%);
+    background-attachment: fixed;
   }
 
   h1,
@@ -117,11 +125,11 @@
 
 @layer components {
   .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink px-7 py-3 text-base font-semibold text-white shadow-[0_20px_45px_-15px_rgba(74,144,226,0.65)] transition-all duration-300 ease-out hover:translate-y-[-2px] hover:shadow-[0_28px_55px_-15px_rgba(74,144,226,0.75)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-all ease-in-out duration-300 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800;
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl border border-brand-purple/15 bg-white/90 px-6 py-3 font-semibold text-brand-purple shadow-[0_10px_30px_-20px_rgba(91,44,111,0.6)] transition-all duration-300 ease-out hover:border-brand-blue/40 hover:text-brand-blue hover:shadow-[0_18px_40px_-18px_rgba(91,44,111,0.65)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800;
   }
 
   .card-hover {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -73,12 +73,31 @@
   },
   "index": {
     "hero": {
+      "tagline": "Technology with pride, diversity, and impact.",
       "headline": "Building the <0/><1>Future with Technology</1>",
       "description": "Democratizing innovation through inclusive, accessible solutions that empower diverse communities and promote social equity.",
       "cta": "Start Your Project",
-      "viewSolutions": "View Solutions"
+      "viewSolutions": "View Solutions",
+      "stats": {
+        "projects": "projects launched with our partners",
+        "efficiency": "average reduction in delivery time",
+        "rating": "average satisfaction rating"
+      },
+      "highlight": {
+        "tag": "Monynha Method",
+        "pill": "Ethical AI + inclusive design",
+        "title": "Solutions guided by real people",
+        "description": "Every product starts with collaborative immersions, continuous prototyping, and transparent delivery cycles.",
+        "items": {
+          "discovery": "Discovery workshops to map challenges and opportunities in your business.",
+          "design": "Human-centered design with inclusive and accessible experiences.",
+          "support": "Strategic support after launch to ensure ongoing evolution."
+        },
+        "cta": "Explore our methodology"
+      }
     },
     "why": {
+      "tagline": "How we build together",
       "title": "Why Choose Monynha Softwares Agency?",
       "description": "We combine technical expertise with business intelligence to deliver solutions that truly make a difference.",
       "features": {
@@ -101,10 +120,13 @@
       }
     },
     "solutions": {
+      "tagline": "From discovery to impact",
       "title": "Our Flagship Solutions",
-      "description": "Proven software solutions that have transformed businesses across industries."
+      "description": "Proven software solutions that have transformed businesses across industries.",
+      "badge": "End-to-end journeys"
     },
     "cta": {
+      "tagline": "Ready for the next step?",
       "title": "Ready to Transform Your Business?",
       "description": "Let's discuss how our AI-powered solutions can streamline your operations and drive growth.",
       "getStarted": "Get Started Today"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -73,12 +73,31 @@
   },
   "index": {
     "hero": {
+      "tagline": "Tecnología con orgullo, diversidad e impacto.",
       "headline": "Construyendo el <0/><1>futuro con tecnología</1>",
       "description": "Democratizando la innovación con soluciones inclusivas y accesibles que empoderan a comunidades diversas y promueven la equidad social.",
       "cta": "Comenzar Proyecto",
-      "viewSolutions": "Ver Soluciones"
+      "viewSolutions": "Ver Soluciones",
+      "stats": {
+        "projects": "proyectos lanzados junto a nuestros aliados",
+        "efficiency": "reducción promedio en el tiempo de implementación",
+        "rating": "calificación promedio de satisfacción"
+      },
+      "highlight": {
+        "tag": "Método Monynha",
+        "pill": "IA ética + diseño inclusivo",
+        "title": "Soluciones guiadas por personas reales",
+        "description": "Cada producto nace de inmersiones colaborativas, prototipado continuo y ciclos de entrega transparentes.",
+        "items": {
+          "discovery": "Workshops de descubrimiento para mapear desafíos y oportunidades de tu negocio.",
+          "design": "Diseño centrado en las personas con experiencias inclusivas y accesibles.",
+          "support": "Acompañamiento estratégico después del lanzamiento para asegurar evolución continua."
+        },
+        "cta": "Conoce nuestra metodología"
+      }
     },
     "why": {
+      "tagline": "Cómo trabajamos en conjunto",
       "title": "¿Por qué elegir Monynha Softwares Agency?",
       "description": "Combinamos experiencia técnica con inteligencia de negocios para entregar soluciones que realmente marcan la diferencia.",
       "features": {
@@ -101,10 +120,13 @@
       }
     },
     "solutions": {
+      "tagline": "Del discovery al impacto",
       "title": "Nuestras Soluciones",
-      "description": "Soluciones comprobadas que han transformado negocios en diversas industrias."
+      "description": "Soluciones comprobadas que han transformado negocios en diversas industrias.",
+      "badge": "Experiencias integrales"
     },
     "cta": {
+      "tagline": "¿Listo para el siguiente paso?",
       "title": "¿Listo para Transformar tu Negocio?",
       "description": "Hablemos de cómo nuestras soluciones con IA pueden optimizar tus operaciones y generar crecimiento.",
       "getStarted": "Empezar Hoy"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -73,12 +73,31 @@
   },
   "index": {
     "hero": {
+      "tagline": "Technologie avec fierté, diversité et impact.",
       "headline": "Construire l'<0/><1>Avenir avec la Technologie</1>",
       "description": "Démocratiser l'innovation grâce à des solutions inclusives et accessibles qui renforcent les communautés diverses et favorisent l'équité sociale.",
       "cta": "Démarrer le projet",
-      "viewSolutions": "Voir les solutions"
+      "viewSolutions": "Voir les solutions",
+      "stats": {
+        "projects": "projets livrés avec nos partenaires",
+        "efficiency": "réduction moyenne des délais de mise en œuvre",
+        "rating": "note moyenne de satisfaction"
+      },
+      "highlight": {
+        "tag": "Méthode Monynha",
+        "pill": "IA éthique + design inclusif",
+        "title": "Des solutions guidées par des personnes réelles",
+        "description": "Chaque produit naît d'immersion collaboratives, de prototypage continu et de cycles de livraison transparents.",
+        "items": {
+          "discovery": "Ateliers de découverte pour cartographier les défis et opportunités de votre organisation.",
+          "design": "Design centré sur l'humain avec des expériences inclusives et accessibles.",
+          "support": "Accompagnement stratégique après le lancement pour assurer une évolution continue."
+        },
+        "cta": "Découvrir notre méthodologie"
+      }
     },
     "why": {
+      "tagline": "Notre manière de co-créer",
       "title": "Pourquoi choisir Monynha Softwares?",
       "description": "Nous combinons expertise technique et intelligence d'affaires pour fournir des solutions qui font vraiment la différence.",
       "features": {
@@ -101,10 +120,13 @@
       }
     },
     "solutions": {
+      "tagline": "Du discovery à l'impact",
       "title": "Nos Solutions",
-      "description": "Des solutions éprouvées qui ont transformé des entreprises dans divers secteurs."
+      "description": "Des solutions éprouvées qui ont transformé des entreprises dans divers secteurs.",
+      "badge": "Parcours complets"
     },
     "cta": {
+      "tagline": "Prêt·e pour la prochaine étape ?",
       "title": "Prêt à transformer votre entreprise ?",
       "description": "Discutons de la manière dont nos solutions IA peuvent rationaliser vos opérations et favoriser la croissance.",
       "getStarted": "Commencer aujourd'hui"

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -73,12 +73,31 @@
   },
   "index": {
     "hero": {
+      "tagline": "Tecnologia com orgulho, diversidade e impacto.",
       "headline": "Construindo o <0/><1>Futuro com Tecnologia</1>",
       "description": "Democratizando a inovação com soluções inclusivas e acessíveis que capacitam comunidades diversas e promovem a equidade social.",
       "cta": "Iniciar Projeto",
-      "viewSolutions": "Ver Soluções"
+      "viewSolutions": "Ver Soluções",
+      "stats": {
+        "projects": "projetos lançados com nossos parceiros",
+        "efficiency": "redução média no tempo de implementação",
+        "rating": "avaliação média de satisfação"
+      },
+      "highlight": {
+        "tag": "Método Monynha",
+        "pill": "IA ética + design inclusivo",
+        "title": "Soluções guiadas por pessoas reais",
+        "description": "Cada produto nasce de imersões colaborativas, prototipagem contínua e ciclos de entrega transparentes.",
+        "items": {
+          "discovery": "Workshops de descoberta para mapear desafios e oportunidades do seu negócio.",
+          "design": "Design centrado em pessoas com experiências inclusivas e acessíveis.",
+          "support": "Suporte estratégico após o lançamento para garantir evolução constante."
+        },
+        "cta": "Conheça nossa metodologia"
+      }
     },
     "why": {
+      "tagline": "Nossa forma de trabalhar",
       "title": "Por que escolher a Monynha Softwares Agency?",
       "description": "Combinamos expertise técnica com inteligência de negócios para entregar soluções que fazem a diferença.",
       "features": {
@@ -101,10 +120,13 @@
       }
     },
     "solutions": {
+      "tagline": "Do discovery ao impacto",
       "title": "Nossas Soluções",
-      "description": "Soluções comprovadas que transformaram empresas em diversos setores."
+      "description": "Soluções comprovadas que transformaram empresas em diversos setores.",
+      "badge": "Experiências completas"
     },
     "cta": {
+      "tagline": "Pronto para o próximo passo?",
       "title": "Pronto para Transformar seu Negócio?",
       "description": "Vamos discutir como nossas soluções com IA podem otimizar suas operações e gerar crescimento.",
       "getStarted": "Começar Hoje"

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -14,6 +14,9 @@ import {
   CheckCircle,
   Laptop,
   Globe,
+  LineChart,
+  ShieldCheck,
+  Sparkles,
   type LucideIcon,
 } from 'lucide-react';
 import { useTranslation, Trans } from 'react-i18next';
@@ -149,6 +152,37 @@ const Index = () => {
 
   const displaySolutions = solutions || fallbackSolutions;
 
+  const heroStats = [
+    {
+      icon: Users,
+      value: '120+',
+      label: t('index.hero.stats.projects'),
+    },
+    {
+      icon: LineChart,
+      value: '30%',
+      label: t('index.hero.stats.efficiency'),
+    },
+    {
+      icon: ShieldCheck,
+      value: '4.9',
+      label: t('index.hero.stats.rating'),
+    },
+  ];
+
+  const heroHighlightItems = [
+    t('index.hero.highlight.items.discovery'),
+    t('index.hero.highlight.items.design'),
+    t('index.hero.highlight.items.support'),
+  ];
+
+  const featureGradients = [
+    'from-brand-purple/90 via-brand-blue/80 to-brand-pink/90',
+    'from-brand-blue/90 via-brand-pink/80 to-brand-orange/90',
+    'from-brand-pink/90 via-brand-orange/80 to-brand-purple/90',
+    'from-brand-orange/90 via-brand-blue/80 to-brand-purple/90',
+  ];
+
   return (
     <Layout>
       <Meta
@@ -159,58 +193,116 @@ const Index = () => {
         ogImage="/placeholder.svg"
       />
       {/* Hero Section */}
-      <section className="relative overflow-hidden bg-gradient-hero text-white">
-        <div className="absolute inset-0 bg-black/20"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
-          <div className="text-center animate-fade-in">
-            <h1 className="text-4xl lg:text-6xl font-bold mb-6 text-white">
-              <Trans
-                i18nKey="index.hero.headline"
-                components={[
-                  <br key="lb" />,
-                  <span
-                    key="gradient"
-                    className="text-transparent bg-clip-text bg-gradient-to-r from-white to-blue-200"
-                  />,
-                ]}
-              />
-            </h1>
-            <p className="text-xl lg:text-2xl text-blue-100 mb-8 max-w-3xl mx-auto">
-              {t('index.hero.description')}
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link to="/contact">
-                <Button className="btn-primary">
-                  {t('index.hero.cta')}
+      <section className="relative isolate overflow-hidden">
+        <div className="absolute inset-0 -z-10 bg-gradient-to-br from-brand-purple via-brand-blue to-brand-pink" />
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.4),_transparent_62%)]" />
+        <div className="relative mx-auto max-w-7xl px-4 pb-24 pt-28 sm:px-6 lg:px-8 lg:pb-32 lg:pt-36">
+          <div className="grid items-center gap-16 lg:grid-cols-[1.05fr_minmax(0,0.95fr)]">
+            <div className="space-y-10 text-left text-white">
+              <span className="inline-flex w-fit items-center gap-2 rounded-full bg-white/15 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-blue-50 ring-1 ring-white/40">
+                <Sparkles className="h-4 w-4" />
+                {t('index.hero.tagline')}
+              </span>
+              <h1 className="text-4xl font-bold leading-tight sm:text-5xl lg:text-6xl">
+                <Trans
+                  i18nKey="index.hero.headline"
+                  components={[
+                    <br key="lb" />,
+                    <span
+                      key="gradient"
+                      className="text-transparent bg-clip-text bg-gradient-to-r from-white via-blue-100 to-blue-200"
+                    />,
+                  ]}
+                />
+              </h1>
+              <p className="max-w-2xl text-lg text-blue-100 lg:text-xl">
+                {t('index.hero.description')}
+              </p>
+              <div className="flex flex-col items-start gap-4 sm:flex-row">
+                <Link to="/contact">
+                  <Button className="btn-primary">
+                    {t('index.hero.cta')}
+                    <ArrowRight className="ml-2 h-5 w-5" />
+                  </Button>
+                </Link>
+                <Link to="/solutions">
+                  <Button
+                    size="lg"
+                    className="btn-secondary border-white/25 bg-white/10 text-white backdrop-blur-sm hover:border-white/40 hover:text-white"
+                  >
+                    {t('index.hero.viewSolutions')}
+                  </Button>
+                </Link>
+              </div>
+              <div className="grid w-full gap-6 sm:grid-cols-3">
+                {heroStats.map((stat) => (
+                  <div
+                    key={stat.label}
+                    className="rounded-2xl border border-white/25 bg-white/10 p-5 backdrop-blur-md"
+                  >
+                    <stat.icon className="mb-3 h-6 w-6 text-blue-100" />
+                    <p className="text-3xl font-bold text-white">{stat.value}</p>
+                    <p className="mt-1 text-sm text-blue-100">{stat.label}</p>
+                  </div>
+                ))}
+              </div>
+            </div>
 
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Button>
-              </Link>
-              <Link to="/solutions">
-                <Button
-                  size="lg"
-                  className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
-                >
-                  {t('index.hero.viewSolutions')}
-                </Button>
-              </Link>
+            <div className="relative">
+              <div className="absolute -right-10 -top-12 h-32 w-32 rounded-full bg-white/25 blur-3xl" />
+              <div className="absolute -bottom-16 left-4 h-40 w-40 rounded-full bg-brand-orange/20 blur-[140px]" />
+              <div className="relative rounded-[2.5rem] border border-white/25 bg-white/10 p-1 shadow-[0_30px_70px_-20px_rgba(15,23,42,0.45)] backdrop-blur-2xl">
+                <div className="rounded-[2.25rem] bg-white/95 p-8 text-brand-purple shadow-[0_25px_55px_-25px_rgba(91,44,111,0.6)] dark:bg-neutral-950/85 dark:text-white">
+                  <div className="flex items-center justify-between gap-4">
+                    <span className="inline-flex items-center gap-2 rounded-full bg-brand-purple/10 px-4 py-1 text-xs font-semibold uppercase tracking-wide text-brand-purple">
+                      {t('index.hero.highlight.tag')}
+                    </span>
+                    <span className="text-sm font-semibold text-brand-blue">
+                      {t('index.hero.highlight.pill')}
+                    </span>
+                  </div>
+                  <h3 className="mt-6 text-2xl font-bold text-brand-purple dark:text-white">
+                    {t('index.hero.highlight.title')}
+                  </h3>
+                  <p className="mt-3 text-sm leading-relaxed text-neutral-600 dark:text-neutral-300">
+                    {t('index.hero.highlight.description')}
+                  </p>
+                  <ul className="mt-6 space-y-3 text-sm text-neutral-600 dark:text-neutral-200">
+                    {heroHighlightItems.map((item, index) => (
+                      <li key={index} className="flex items-start gap-3">
+                        <CheckCircle className="mt-0.5 h-4 w-4 text-brand-blue" />
+                        <span>{item}</span>
+                      </li>
+                    ))}
+                  </ul>
+                  <div className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-brand-blue">
+                    {t('index.hero.highlight.cta')}
+                    <ArrowRight className="h-4 w-4" />
+                  </div>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </section>
 
       {/* Features Section */}
-      <section className="py-24 bg-white transition-colors dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
+      <section className="relative py-24">
+        <div className="absolute inset-0 -z-20 bg-white/95 transition-colors dark:bg-neutral-950" />
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.08),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.22),_transparent_60%)]" />
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <span className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-purple/10 px-4 py-1 text-sm font-semibold text-brand-purple">
+              {t('index.why.tagline')}
+            </span>
+            <h2 className="mt-6 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-white">
               {t('index.why.title')}
             </h2>
-            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
+            <p className="mt-4 text-lg text-neutral-600 dark:text-neutral-300">
               {t('index.why.description')}
             </p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+          <div className="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
             {displayFeatures.map((feature, index) => (
               <a
                 key={index}
@@ -219,15 +311,26 @@ const Index = () => {
                 rel="noopener noreferrer"
                 className="block"
               >
-                <Card className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl cursor-pointer">
-                  <CardContent className="p-8 text-center">
-                    <div className="w-16 h-16 bg-gradient-hero rounded-2xl flex items-center justify-center mx-auto mb-6">
-                      <feature.icon className="h-8 w-8 text-white" />
+                <Card className="group relative overflow-hidden rounded-[1.75rem] border border-brand-purple/10 bg-white/90 shadow-[0_24px_60px_-30px_rgba(91,44,111,0.6)] transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_30px_70px_-28px_rgba(74,144,226,0.6)] dark:border-white/10 dark:bg-neutral-900/70">
+                  <CardContent className="relative h-full p-8">
+                    <div
+                      className={`absolute right-6 top-6 h-14 w-14 rounded-full bg-gradient-to-br ${featureGradients[index % featureGradients.length]} opacity-20 blur-xl transition-all duration-300 group-hover:opacity-40`}
+                    />
+                    <div
+                      className={`relative mb-6 flex h-14 w-14 items-center justify-center rounded-2xl bg-gradient-to-br ${featureGradients[index % featureGradients.length]} text-white shadow-[0_16px_35px_-18px_rgba(91,44,111,0.8)]`}
+                    >
+                      <feature.icon className="h-7 w-7" />
                     </div>
-                    <h3 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">
+                    <h3 className="text-left text-xl font-semibold text-neutral-900 dark:text-white">
                       {feature.title}
                     </h3>
-                    <p className="text-neutral-600 dark:text-neutral-300">{feature.description}</p>
+                    <p className="mt-3 text-left text-sm leading-relaxed text-neutral-600 dark:text-neutral-300">
+                      {feature.description}
+                    </p>
+                    <span className="mt-8 inline-flex items-center gap-2 text-sm font-semibold text-brand-blue transition-all duration-300 group-hover:gap-3">
+                      {t('index.learnMore')}
+                      <ArrowRight className="h-4 w-4" />
+                    </span>
                   </CardContent>
                 </Card>
               </a>
@@ -237,49 +340,55 @@ const Index = () => {
       </section>
 
       {/* Solutions Preview */}
-      <section className="py-24 bg-neutral-50 dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
+      <section className="relative py-24">
+        <div className="absolute inset-0 -z-20 bg-gradient-to-b from-white via-white to-white transition-colors dark:from-neutral-950 dark:via-neutral-950/95 dark:to-neutral-950" />
+        <div className="absolute inset-x-0 top-0 -z-10 h-2/3 bg-[radial-gradient(circle_at_top,_rgba(74,144,226,0.12),_transparent_60%)] dark:bg-[radial-gradient(circle_at_top,_rgba(74,144,226,0.25),_transparent_60%)]" />
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <span className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-blue/10 px-4 py-1 text-sm font-semibold text-brand-blue">
+              {t('index.solutions.tagline')}
+            </span>
+            <h2 className="mt-6 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-white">
               {t('index.solutions.title')}
             </h2>
-            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
+            <p className="mt-4 text-lg text-neutral-600 dark:text-neutral-300">
               {t('index.solutions.description')}
             </p>
           </div>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+          <div className="mt-16 grid grid-cols-1 gap-12 lg:grid-cols-2">
             {displaySolutions.map((solution, index) => (
               <Card
                 key={index}
-                className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl overflow-hidden"
+                className="relative overflow-hidden rounded-[2rem] border border-brand-purple/10 bg-white/95 shadow-[0_30px_70px_-35px_rgba(74,144,226,0.6)] transition-all duration-300 ease-out hover:-translate-y-1 hover:shadow-[0_35px_85px_-30px_rgba(91,44,111,0.55)] dark:border-white/10 dark:bg-neutral-900/70"
               >
-                <div
-                  className={`h-4 bg-gradient-to-r ${solution.gradient}`}
-                ></div>
-                <CardContent className="p-8">
-                  <h3 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
+                <div className={`absolute inset-x-0 top-0 h-32 bg-gradient-to-r ${solution.gradient} opacity-90`} />
+                <CardContent className="relative p-10 pt-24">
+                  <div className="absolute left-10 top-8 inline-flex items-center gap-2 rounded-full bg-white/90 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-brand-purple shadow-[0_12px_40px_-25px_rgba(15,23,42,0.55)] dark:bg-neutral-950/70 dark:text-white">
+                    {t('index.solutions.badge')}
+                  </div>
+                  <h3 className="text-2xl font-bold text-neutral-900 dark:text-white">
                     {solution.name}
                   </h3>
-                  <p className="text-neutral-600 dark:text-neutral-300 mb-6">
+                  <p className="mt-3 text-neutral-600 dark:text-neutral-300">
                     {solution.description}
                   </p>
                   {solution.features &&
                     Array.isArray(solution.features) &&
                     solution.features.length > 0 && (
-                      <ul className="space-y-3 mb-8">
+                      <ul className="mt-6 space-y-3">
                         {solution.features.map((feature, featureIndex) => (
                           <li
                             key={featureIndex}
-                            className="flex items-center text-neutral-700 dark:text-neutral-300"
+                            className="flex items-center gap-3 text-neutral-700 dark:text-neutral-300"
                           >
-                            <CheckCircle className="h-5 w-5 text-brand-blue mr-3" />
+                            <CheckCircle className="h-5 w-5 text-brand-blue" />
                             {feature}
                           </li>
                         ))}
                       </ul>
                     )}
-                  <Link to="/solutions">
-                    <Button className="btn-secondary w-full">
+                  <Link to="/solutions" className="mt-10 block">
+                    <Button className="btn-primary w-full justify-center text-base">
                       {t('index.learnMore')}
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>
@@ -298,23 +407,28 @@ const Index = () => {
       <NewsletterSection />
 
       {/* CTA Section */}
-      <section className="py-24 bg-gradient-hero text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl lg:text-4xl font-bold mb-6">
-            {t('index.cta.title')}
-          </h2>
-          <p className="text-xl text-blue-100 mb-8">
-            {t('index.cta.description')}
-          </p>
-          <Link to="/contact">
-            <Button
-              size="lg"
-              className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
-            >
-              {t('index.cta.getStarted')}
-              <ArrowRight className="ml-2 h-5 w-5" />
-            </Button>
-          </Link>
+      <section className="relative py-24">
+        <div className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,_rgba(91,44,111,0.18),_transparent_65%)]" />
+        <div className="relative mx-auto max-w-4xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-[2.6rem] border border-brand-purple/30 bg-gradient-to-br from-brand-purple via-brand-blue to-brand-pink p-[1px] shadow-[0_32px_85px_-30px_rgba(15,23,42,0.55)]">
+            <div className="rounded-[2.5rem] bg-white/92 px-8 py-16 text-center shadow-[inset_0_1px_0_rgba(255,255,255,0.6)] backdrop-blur-sm dark:bg-neutral-950/85">
+              <span className="inline-flex items-center justify-center gap-2 rounded-full bg-brand-purple/15 px-4 py-1 text-sm font-semibold text-brand-purple">
+                {t('index.cta.tagline')}
+              </span>
+              <h2 className="mt-6 text-3xl lg:text-4xl font-bold text-brand-purple dark:text-white">
+                {t('index.cta.title')}
+              </h2>
+              <p className="mt-4 text-lg text-neutral-600 dark:text-neutral-300">
+                {t('index.cta.description')}
+              </p>
+              <Link to="/contact" className="mt-10 inline-block">
+                <Button className="btn-primary px-10 py-3 text-base">
+                  {t('index.cta.getStarted')}
+                  <ArrowRight className="ml-2 h-5 w-5" />
+                </Button>
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
     </Layout>


### PR DESCRIPTION
## Summary
- refresh the homepage hero, features, solutions, and CTA sections with brand gradients, stat highlights, and updated call-to-action styling
- update sitewide background accents, button styling, team and newsletter sections, and footer layout to match the new Monynha palette
- extend i18n resources with the new hero copy, badges, and taglines in all supported languages

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ca9607d89483228fda85220a640bc0