### PR TITLE
Refresh homepage styling with updated brand palette

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -6,13 +6,17 @@ import { Separator } from '@/components/ui/separator';
 const Footer = () => {
   const { t } = useTranslation();
   return (
-    <footer className="border-t border-neutral-100 bg-neutral-50 transition-colors dark:border-neutral-800 dark:bg-neutral-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+    <footer className="relative border-t border-brand-purple/10 bg-white/85 backdrop-blur-sm transition-colors dark:border-brand-purple/30 dark:bg-neutral-950/90">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-brand-purple/30 to-transparent"
+        aria-hidden="true"
+      />
+      <div className="relative mx-auto max-w-7xl px-4 py-16 sm:px-6 lg:px-8">
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-5 gap-8">
           {/* Logo and Description */}
           <div className="sm:col-span-2">
             <Link to="/" className="mb-4 flex items-center space-x-3">
-              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-brand">
+              <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-gradient-brand shadow-soft">
                 <span className="text-lg font-bold text-white">M</span>
               </div>
               <div className="flex flex-col">
@@ -38,7 +42,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/solutions"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.solutions')}
                 </Link>
@@ -46,7 +50,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/about"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.about')}
                 </Link>
@@ -54,7 +58,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/blog"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.blog')}
                 </Link>
@@ -62,7 +66,7 @@ const Footer = () => {
               <li>
                 <Link
                   to="/contact"
-                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-300"
+                  className="text-neutral-600 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-300"
                 >
                   {t('navigation.contact')}
                 </Link>
@@ -110,7 +114,7 @@ const Footer = () => {
                   href="https://monynha.tech"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.tech"
                   title="monynha.tech"
                 >
@@ -122,7 +126,7 @@ const Footer = () => {
                   href="https://monynha.fun"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.fun"
                   title="monynha.fun"
                 >
@@ -134,7 +138,7 @@ const Footer = () => {
                   href="https://monynha.online"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.online"
                   title="monynha.online"
                 >
@@ -146,7 +150,7 @@ const Footer = () => {
                   href="https://monynha.me"
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                  className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                   aria-label="Visit monynha.me"
                   title="monynha.me"
                 >
@@ -166,7 +170,7 @@ const Footer = () => {
                 {t('footer.email')}: {
                   <a
                     href="mailto:hello@monynha.com"
-                    className="text-sm text-muted-foreground transition-colors hover:text-primary dark:text-neutral-300"
+                    className="text-sm text-muted-foreground transition-colors hover:text-brand-purple dark:text-neutral-300"
                     aria-label="Send email to hello@monynha.com"
                     title="hello@monynha.com"
                   >
@@ -194,16 +198,16 @@ const Footer = () => {
               <span>{t('footer.andPride')}</span>
             </span>
           </p>
-          <div className="flex space-x-6 mt-4 md:mt-0">
+          <div className="mt-4 flex space-x-6 md:mt-0">
             <Link
               to="#"
-              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-400"
+              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-400"
             >
               {t('footer.privacy')}
             </Link>
             <Link
               to="#"
-              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-blue dark:text-neutral-400"
+              className="text-sm text-neutral-500 transition-colors duration-300 ease-in-out hover:text-brand-purple dark:text-neutral-400"
             >
               {t('footer.terms')}
             </Link>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -8,11 +8,18 @@ interface LayoutProps {
 
 const Layout = ({ children }: LayoutProps) => {
   return (
-    <div className="min-h-screen flex flex-col bg-background text-foreground transition-colors duration-300">
-      <SiteHeader />
-      <main className="flex-1 pt-20">{children}</main>
-      <Footer />
-      <BackToTop />
+    <div className="relative min-h-screen overflow-hidden bg-gradient-surface text-foreground transition-colors duration-300">
+      <div className="pointer-events-none absolute inset-0 opacity-80">
+        <div className="absolute -top-40 right-[-12%] h-[420px] w-[420px] rounded-full bg-brand-blue/20 blur-3xl" />
+        <div className="absolute bottom-[-30%] left-[-15%] h-[360px] w-[360px] rounded-full bg-brand-pink/20 blur-[140px]" />
+        <div className="absolute left-1/2 top-1/3 h-72 w-72 -translate-x-1/2 rounded-full bg-brand-purple/15 blur-[130px]" />
+      </div>
+      <div className="relative z-10 flex min-h-screen flex-col">
+        <SiteHeader />
+        <main className="flex-1 pt-20">{children}</main>
+        <Footer />
+        <BackToTop />
+      </div>
     </div>
   );
 };

--- a/src/components/NewsletterSection.tsx
+++ b/src/components/NewsletterSection.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { supabase } from '@/integrations/supabase';
@@ -18,7 +17,6 @@ const NewsletterSection = () => {
     e.preventDefault();
     setIsSubmitting(true);
 
-    // Basic email validation
     if (!email.trim() || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
       toast({
         title: t('newsletterSection.invalidEmailTitle'),
@@ -36,7 +34,6 @@ const NewsletterSection = () => {
 
       if (error) {
         if (error.code === '23505') {
-          // Unique constraint violation
           toast({
             title: t('newsletterSection.alreadySubscribedTitle'),
             description: t('newsletterSection.alreadySubscribedDescription'),
@@ -72,75 +69,81 @@ const NewsletterSection = () => {
 
   if (isSubscribed) {
     return (
-      <section className="py-24 bg-gradient-hero text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
-            <CheckCircle className="h-8 w-8 text-white" />
+      <section className="relative py-24">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-brand-blue/15 via-transparent to-transparent"
+          aria-hidden="true"
+        />
+        <div className="relative mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+          <div className="overflow-hidden rounded-[3rem] bg-gradient-hero p-[1px] shadow-soft-lg">
+            <div className="rounded-[2.9rem] bg-white/10 px-6 py-16 text-center text-white backdrop-blur-sm sm:px-12 lg:px-16">
+              <div className="mx-auto mb-8 flex h-20 w-20 items-center justify-center rounded-full bg-white/20">
+                <CheckCircle className="h-10 w-10 text-white" />
+              </div>
+              <h2 className="text-3xl font-bold lg:text-4xl">
+                {t('newsletterSection.thankYouTitle')}
+              </h2>
+              <p className="mt-4 text-lg text-white/80">
+                {t('newsletterSection.thankYouDescription')}
+              </p>
+              <Button
+                onClick={() => {
+                  setIsSubscribed(false);
+                  setEmail('');
+                }}
+                className="btn-secondary mt-10 inline-flex px-10 py-4 text-base"
+              >
+                {t('newsletterSection.subscribeAnother')}
+              </Button>
+            </div>
           </div>
-          <h2 className="text-3xl lg:text-4xl font-bold mb-4">
-            {t('newsletterSection.thankYouTitle')}
-          </h2>
-          <p className="text-xl text-blue-100 mb-8">
-            {t('newsletterSection.thankYouDescription')}
-          </p>
-          <Button
-            onClick={() => {
-              setIsSubscribed(false);
-              setEmail('');
-            }}
-            className="rounded-xl bg-white px-6 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
-          >
-            {t('newsletterSection.subscribeAnother')}
-          </Button>
         </div>
       </section>
     );
   }
 
   return (
-    <section className="py-24 bg-gradient-hero text-white">
-      <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8">
-        <Card className="rounded-2xl border-0 bg-white/10 shadow-soft-lg backdrop-blur-sm">
-          <CardContent className="p-8 lg:p-12 text-center">
-            <div className="w-16 h-16 bg-white/20 rounded-full flex items-center justify-center mx-auto mb-6">
-              <Mail className="h-8 w-8 text-white" />
+    <section className="relative py-24">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-brand-blue/15 via-transparent to-transparent"
+        aria-hidden="true"
+      />
+      <div className="relative mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+        <div className="overflow-hidden rounded-[3rem] bg-gradient-hero p-[1px] shadow-soft-lg">
+          <div className="rounded-[2.9rem] bg-white/10 px-6 py-16 text-center text-white backdrop-blur-sm sm:px-12 lg:px-16">
+            <div className="mx-auto mb-8 flex h-20 w-20 items-center justify-center rounded-full bg-white/20">
+              <Mail className="h-10 w-10 text-white" />
             </div>
-
-            <h2 className="text-3xl lg:text-4xl font-bold text-white mb-4">
+            <h2 className="text-3xl font-bold lg:text-4xl">
               {t('newsletterSection.title')}
             </h2>
-
-            <p className="text-xl text-blue-100 mb-8 max-w-2xl mx-auto">
+            <p className="mt-4 text-lg text-white/80">
               {t('newsletterSection.description')}
             </p>
-
-            <form onSubmit={handleSubmit} className="max-w-md mx-auto">
-              <div className="flex flex-col sm:flex-row gap-4">
-                <Input
-                  type="email"
-                  placeholder={t('newsletterSection.placeholder')}
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="flex-1 rounded-xl border-white/30 bg-white/20 text-white placeholder:text-white/70 focus:border-white focus:ring-white"
-                  required
-                />
-                <Button
-                  type="submit"
-                  disabled={isSubmitting}
-                  className="whitespace-nowrap rounded-xl bg-white px-8 py-3 font-semibold text-brand-purple transition-colors hover:bg-blue-50 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:bg-neutral-900 dark:text-white dark:hover:bg-neutral-800"
-                >
-                  {isSubmitting
-                    ? t('newsletterSection.subscribing')
-                    : t('newsletterSection.subscribe')}
-                </Button>
-              </div>
+            <form onSubmit={handleSubmit} className="mx-auto mt-10 flex w-full max-w-xl flex-col gap-4 sm:flex-row">
+              <Input
+                type="email"
+                placeholder={t('newsletterSection.placeholder')}
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="flex-1 rounded-2xl border-white/30 bg-white/15 text-white placeholder:text-white/70 focus:border-white focus:ring-white"
+                required
+              />
+              <Button
+                type="submit"
+                disabled={isSubmitting}
+                className="rounded-2xl bg-white/90 px-10 py-3 text-base font-semibold text-brand-purple shadow-soft transition-all duration-300 ease-in-out hover:-translate-y-0.5 hover:bg-white"
+              >
+                {isSubmitting
+                  ? t('newsletterSection.subscribing')
+                  : t('newsletterSection.subscribe')}
+              </Button>
             </form>
-
-            <p className="mt-4 text-sm text-blue-200">
+            <p className="mt-6 text-sm text-white/70">
               {t('newsletterSection.privacy')}
             </p>
-          </CardContent>
-        </Card>
+          </div>
+        </div>
       </div>
     </section>
   );

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -101,7 +101,7 @@ const SiteHeader = () => {
   const isProjectsActive = location.pathname.startsWith('/projects');
 
   const menuCardLinkClasses =
-    'group block rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-transform duration-300 hover:-translate-y-0.5 focus-visible:-translate-y-0.5';
+    'group block rounded-3xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-transform duration-300 hover:-translate-y-1 focus-visible:-translate-y-1';
 
   const renderGradientCard = (
     gradient: string,
@@ -114,13 +114,13 @@ const SiteHeader = () => {
         'rounded-2xl'
       )}
     >
-      <div className="rounded-[1.05rem] bg-white/95 p-4 transition-colors dark:bg-neutral-950/90">
+      <div className="rounded-[1.25rem] bg-white/95 p-4 shadow-[0_12px_30px_-18px_rgba(91,44,111,0.25)] transition-colors dark:bg-neutral-950/90 dark:shadow-none">
         <div className="flex items-center justify-between gap-3">
-          <span className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+          <span className="text-sm font-semibold text-brand-purple dark:text-neutral-100">
             {content.title}
           </span>
           <ArrowRight
-            className="h-4 w-4 text-brand-blue opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100"
+            className="h-4 w-4 text-brand-purple opacity-0 transition-opacity duration-300 group-hover:opacity-100 group-focus-visible:opacity-100"
             aria-hidden="true"
           />
         </div>
@@ -132,13 +132,13 @@ const SiteHeader = () => {
   );
 
   const desktopNavLinkClasses =
-    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-neutral-200';
+    'px-4 py-2 text-sm font-medium text-neutral-600 transition-colors rounded-xl hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:text-neutral-200';
 
   const desktopNavLinkActiveClasses =
-    'text-brand-blue bg-white/80 shadow-soft-lg dark:bg-neutral-900/70';
+    'bg-white/90 text-brand-purple shadow-soft-lg dark:bg-neutral-900/70';
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50 border-b border-white/40 bg-white/70 shadow-[0_10px_35px_rgba(91,44,111,0.08)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/60 transition-colors dark:border-neutral-800 dark:bg-neutral-950/85 dark:shadow-[0_12px_40px_rgba(3,7,18,0.6)] dark:supports-[backdrop-filter]:bg-neutral-950/70">
+    <header className="fixed inset-x-0 top-0 z-50 border-b border-brand-purple/10 bg-white/80 shadow-[0_18px_40px_rgba(91,44,111,0.1)] backdrop-blur-xl supports-[backdrop-filter]:bg-white/70 transition-colors dark:border-brand-purple/30 dark:bg-neutral-950/85 dark:shadow-[0_18px_40px_rgba(3,7,18,0.65)] dark:supports-[backdrop-filter]:bg-neutral-950/70">
       <div className="mx-auto flex h-20 max-w-7xl items-center justify-between px-4 sm:px-6 lg:px-8">
         <NavLink
           to="/"
@@ -190,7 +190,7 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isSolutionsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
+                    'px-4 py-2 text-sm font-medium text-neutral-600 transition-colors rounded-xl hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-purple data-[active=true]:bg-white/85 data-[active=true]:text-brand-purple dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
                   )}
                 >
                   {t('navigation.solutions')}
@@ -242,7 +242,7 @@ const SiteHeader = () => {
                 <NavigationMenuTrigger
                   data-active={isProjectsActive}
                   className={cn(
-                    'px-4 py-2 text-sm font-medium text-neutral-700 transition-colors rounded-lg hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-blue data-[active=true]:bg-white/80 data-[active=true]:text-brand-blue dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
+                    'px-4 py-2 text-sm font-medium text-neutral-600 transition-colors rounded-xl hover:text-brand-purple focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple focus-visible:ring-offset-2 focus-visible:ring-offset-background data-[state=open]:bg-white/90 data-[state=open]:text-brand-purple data-[active=true]:bg-white/85 data-[active=true]:text-brand-purple dark:text-neutral-200 dark:data-[state=open]:bg-neutral-900/80 dark:data-[active=true]:bg-neutral-900/70'
                   )}
                 >
                   {t('navigation.projects')}
@@ -401,14 +401,14 @@ const SiteHeader = () => {
             <SheetTrigger asChild>
               <button
                 aria-label={t('navigation.toggleNavigation')}
-                className="flex items-center justify-center rounded-xl border border-white/0 bg-white/70 p-2 text-neutral-700 shadow-soft transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:text-brand-blue dark:border-neutral-700/60 dark:bg-neutral-900/70 dark:text-neutral-100"
+                className="flex items-center justify-center rounded-xl border border-brand-purple/15 bg-white/75 p-2 text-neutral-600 shadow-soft transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-purple focus-visible:ring-offset-2 focus-visible:ring-offset-background hover:text-brand-purple dark:border-brand-purple/40 dark:bg-neutral-900/70 dark:text-neutral-100"
               >
                 {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
               </button>
             </SheetTrigger>
             <SheetContent
               side="right"
-              className="w-full border-l border-white/40 bg-white/95 px-6 py-8 backdrop-blur-sm transition-colors sm:max-w-sm dark:border-neutral-800 dark:bg-neutral-950/90"
+              className="w-full border-l border-brand-purple/15 bg-white/95 px-6 py-8 backdrop-blur-sm transition-colors sm:max-w-sm dark:border-brand-purple/40 dark:bg-neutral-950/90"
             >
               <div className="flex items-center justify-between">
                 <span className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">

--- a/src/components/TeamSection.tsx
+++ b/src/components/TeamSection.tsx
@@ -38,8 +38,12 @@ const TeamSection = () => {
 
   if (isLoading) {
     return (
-      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+      <section className="relative py-24">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-brand-purple/12 via-transparent to-transparent"
+          aria-hidden="true"
+        />
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
           <div className="text-center mb-16">
             <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
               {t('team.title')}
@@ -50,10 +54,10 @@ const TeamSection = () => {
           </div>
           <div className="flex flex-wrap justify-center gap-8">
             {[...Array(4)].map((_, i) => (
-              <Card
-                key={i}
-                className="w-full animate-pulse rounded-2xl border-0 shadow-soft transition-colors md:w-1/2 lg:w-1/4 dark:bg-neutral-900/60"
-              >
+            <Card
+              key={i}
+              className="w-full animate-pulse rounded-2xl border border-brand-purple/15 bg-white/80 shadow-soft transition-colors md:w-1/2 lg:w-1/4 dark:border-neutral-800 dark:bg-neutral-900/60"
+            >
                 <CardContent className="p-8 text-center">
                   <div className="mx-auto mb-6 h-24 w-24 rounded-full bg-neutral-200 dark:bg-neutral-700"></div>
                   <div className="mb-2 h-6 rounded bg-neutral-200 dark:bg-neutral-700"></div>
@@ -70,8 +74,12 @@ const TeamSection = () => {
 
   if (error) {
     return (
-      <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
-        <div className="mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
+      <section className="relative py-24">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-brand-purple/12 via-transparent to-transparent"
+          aria-hidden="true"
+        />
+        <div className="relative mx-auto max-w-7xl px-4 text-center sm:px-6 lg:px-8">
           <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
             {t('team.title')}
           </h2>
@@ -84,8 +92,12 @@ const TeamSection = () => {
   }
 
   return (
-    <section className="bg-neutral-50 py-24 transition-colors dark:bg-neutral-950">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <section className="relative py-24">
+      <div
+        className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-brand-purple/12 via-transparent to-transparent"
+        aria-hidden="true"
+      />
+      <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
         <div className="mb-16 text-center">
           <h2 className="mb-4 text-3xl font-bold text-neutral-900 lg:text-4xl dark:text-neutral-100">
             {t('team.title')}
@@ -99,7 +111,7 @@ const TeamSection = () => {
           {members?.map((member) => (
             <Card
               key={member.id}
-              className="card-hover w-full rounded-2xl border-0 shadow-soft transition-all duration-200 hover:shadow-soft-lg md:w-1/2 lg:w-1/4 dark:bg-neutral-900/80"
+              className="card-hover w-full rounded-2xl border border-brand-purple/15 bg-white/90 shadow-soft transition-all duration-300 hover:border-brand-purple/30 md:w-1/2 lg:w-1/4 dark:border-neutral-800 dark:bg-neutral-900/80"
             >
               <CardContent className="p-8 text-center">
                 <Avatar className="mx-auto mb-6 h-24 w-24">
@@ -119,7 +131,7 @@ const TeamSection = () => {
                   {member.name}
                 </h3>
 
-                <p className="mb-4 font-medium text-brand-blue">
+                <p className="mb-4 font-medium text-brand-purple">
                   {member.role}
                 </p>
 

--- a/src/index.css
+++ b/src/index.css
@@ -5,65 +5,65 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222 47% 9%;
+    --background: 276 40% 98%;
+    --foreground: 258 50% 16%;
 
     --card: 0 0% 100%;
-    --card-foreground: 222 47% 9%;
+    --card-foreground: 258 50% 16%;
 
     --popover: 0 0% 100%;
-    --popover-foreground: 222 47% 9%;
+    --popover-foreground: 258 50% 16%;
 
-    --primary: 262 83% 58%;
+    --primary: 282 43% 40%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 199 89% 55%;
-    --secondary-foreground: 210 40% 98%;
+    --secondary: 212 72% 58%;
+    --secondary-foreground: 0 0% 100%;
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215 16% 46%;
+    --muted: 280 44% 94%;
+    --muted-foreground: 257 24% 36%;
 
-    --accent: 330 72% 67%;
-    --accent-foreground: 210 40% 98%;
+    --accent: 0 66% 64%;
+    --accent-foreground: 0 0% 100%;
 
     --destructive: 0 84% 60%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive-foreground: 0 0% 100%;
 
-    --border: 214 32% 91%;
-    --input: 214 32% 91%;
-    --ring: 262 83% 58%;
+    --border: 276 32% 86%;
+    --input: 276 32% 86%;
+    --ring: 212 72% 58%;
 
-    --radius: 1.5rem;
+    --radius: 1.75rem;
   }
 
   .dark {
-    --background: 240 10% 6%;
+    --background: 258 44% 8%;
     --foreground: 210 40% 96%;
 
-    --card: 240 10% 12%;
+    --card: 258 46% 12%;
     --card-foreground: 210 40% 96%;
 
-    --popover: 240 10% 12%;
+    --popover: 258 46% 12%;
     --popover-foreground: 210 40% 96%;
 
-    --primary: 262 83% 68%;
-    --primary-foreground: 240 33% 12%;
+    --primary: 282 53% 68%;
+    --primary-foreground: 250 35% 12%;
 
-    --secondary: 199 89% 62%;
-    --secondary-foreground: 240 10% 6%;
+    --secondary: 212 72% 62%;
+    --secondary-foreground: 258 44% 8%;
 
-    --muted: 240 8% 18%;
-    --muted-foreground: 215 20% 72%;
+    --muted: 258 32% 18%;
+    --muted-foreground: 260 20% 72%;
 
-    --accent: 330 72% 72%;
-    --accent-foreground: 240 10% 6%;
+    --accent: 0 66% 70%;
+    --accent-foreground: 258 44% 8%;
 
-    --destructive: 0 84% 60%;
-    --destructive-foreground: 210 40% 98%;
+    --destructive: 0 72% 56%;
+    --destructive-foreground: 210 40% 96%;
 
-    --border: 240 8% 22%;
-    --input: 240 8% 22%;
-    --ring: 262 83% 68%;
+    --border: 258 32% 24%;
+    --input: 258 32% 24%;
+    --ring: 212 72% 62%;
   }
 
   * {
@@ -78,6 +78,16 @@
 
   body {
     @apply bg-background text-foreground font-sans antialiased;
+    background-image:
+      radial-gradient(circle at 12% 20%, rgba(91, 44, 111, 0.12), transparent 55%),
+      radial-gradient(circle at 88% 16%, rgba(74, 144, 226, 0.12), transparent 50%),
+      radial-gradient(circle at 10% 82%, rgba(224, 102, 102, 0.1), transparent 45%),
+      linear-gradient(180deg, #f8f4ff 0%, #ffffff 55%, #fff6f0 100%);
+    background-attachment: fixed;
+  }
+
+  .dark body {
+    background-image: none;
   }
 
   h1,
@@ -117,14 +127,14 @@
 
 @layer components {
   .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink px-6 py-3 font-semibold text-white shadow-soft transition-all duration-300 ease-in-out hover:-translate-y-0.5 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-all ease-in-out duration-300 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800;
+    @apply inline-flex items-center justify-center gap-2 rounded-2xl border border-brand-purple/20 bg-white/90 px-6 py-3 font-semibold text-brand-purple shadow-sm backdrop-blur transition-all duration-300 ease-in-out hover:-translate-y-0.5 hover:border-brand-blue/60 hover:bg-brand-blue/10 hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background dark:border-brand-blue/40 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800 dark:hover:text-white;
   }
 
   .card-hover {
-    @apply transition-all ease-in-out duration-300 hover:shadow-soft-lg hover:-translate-y-1;
+    @apply transition-all duration-300 ease-in-out hover:-translate-y-2 hover:shadow-soft-lg;
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,6 +75,7 @@
     "hero": {
       "headline": "Building the <0/><1>Future with Technology</1>",
       "description": "Democratizing innovation through inclusive, accessible solutions that empower diverse communities and promote social equity.",
+      "tagline": "Technology that celebrates diversity and social impact",
       "cta": "Start Your Project",
       "viewSolutions": "View Solutions"
     },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -75,6 +75,7 @@
     "hero": {
       "headline": "Construyendo el <0/><1>futuro con tecnología</1>",
       "description": "Democratizando la innovación con soluciones inclusivas y accesibles que empoderan a comunidades diversas y promueven la equidad social.",
+      "tagline": "Tecnología que celebra la diversidad y el impacto social",
       "cta": "Comenzar Proyecto",
       "viewSolutions": "Ver Soluciones"
     },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -75,6 +75,7 @@
     "hero": {
       "headline": "Construire l'<0/><1>Avenir avec la Technologie</1>",
       "description": "Démocratiser l'innovation grâce à des solutions inclusives et accessibles qui renforcent les communautés diverses et favorisent l'équité sociale.",
+      "tagline": "Une technologie qui célèbre la diversité et l'impact social",
       "cta": "Démarrer le projet",
       "viewSolutions": "Voir les solutions"
     },

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -75,6 +75,7 @@
     "hero": {
       "headline": "Construindo o <0/><1>Futuro com Tecnologia</1>",
       "description": "Democratizando a inovação com soluções inclusivas e acessíveis que capacitam comunidades diversas e promovem a equidade social.",
+      "tagline": "Tecnologia que celebra diversidade e impacto social",
       "cta": "Iniciar Projeto",
       "viewSolutions": "Ver Soluções"
     },

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -16,7 +16,7 @@ import {
   Globe,
   type LucideIcon,
 } from 'lucide-react';
-import { useTranslation, Trans } from 'react-i18next';
+import { Trans, useTranslation } from 'react-i18next';
 import { useQuery } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase';
 import { useMemo } from 'react';
@@ -42,8 +42,7 @@ const fallbackSolutionsConfig = [
 const Index = () => {
   const { t } = useTranslation();
 
-  // Fetch dynamic homepage features from database
-  const { data: features, isLoading: featuresLoading } = useQuery({
+  const { data: features } = useQuery({
     queryKey: ['homepage-features'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -54,7 +53,6 @@ const Index = () => {
 
       if (error) throw error;
 
-      // Map to the expected format with icon components
       const iconMap: Record<string, LucideIcon> = {
         Brain,
         Zap,
@@ -73,8 +71,7 @@ const Index = () => {
     },
   });
 
-  // Fetch dynamic solutions from database
-  const { data: solutions, isLoading: solutionsLoading } = useQuery({
+  const { data: solutions } = useQuery({
     queryKey: ['solutions-preview'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -100,7 +97,6 @@ const Index = () => {
     },
   });
 
-  // Fallback features for loading/error states
   const fallbackFeatures = useMemo(
     () => [
       {
@@ -132,6 +128,8 @@ const Index = () => {
   );
 
   const displayFeatures = features || fallbackFeatures;
+  const heroHighlights = displayFeatures.slice(0, 3);
+
   const fallbackSolutions = useMemo(
     () =>
       fallbackSolutionsConfig.map((solution) => ({
@@ -158,76 +156,112 @@ const Index = () => {
         ogDescription={t('index.hero.description')}
         ogImage="/placeholder.svg"
       />
-      {/* Hero Section */}
-      <section className="relative overflow-hidden bg-gradient-hero text-white">
-        <div className="absolute inset-0 bg-black/20"></div>
-        <div className="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 lg:py-32">
-          <div className="text-center animate-fade-in">
-            <h1 className="text-4xl lg:text-6xl font-bold mb-6 text-white">
-              <Trans
-                i18nKey="index.hero.headline"
-                components={[
-                  <br key="lb" />,
-                  <span
-                    key="gradient"
-                    className="text-transparent bg-clip-text bg-gradient-to-r from-white to-blue-200"
-                  />,
-                ]}
-              />
-            </h1>
-            <p className="text-xl lg:text-2xl text-blue-100 mb-8 max-w-3xl mx-auto">
-              {t('index.hero.description')}
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link to="/contact">
-                <Button className="btn-primary">
-                  {t('index.hero.cta')}
 
-                  <ArrowRight className="ml-2 h-5 w-5" />
-                </Button>
-              </Link>
-              <Link to="/solutions">
-                <Button
-                  size="lg"
-                  className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
-                >
-                  {t('index.hero.viewSolutions')}
-                </Button>
-              </Link>
-            </div>
+      <section className="relative overflow-hidden bg-gradient-hero text-white">
+        <div className="absolute inset-0">
+          <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.18),_rgba(91,44,111,0.35))]" />
+          <div className="absolute left-1/2 top-16 h-64 w-64 -translate-x-1/2 rounded-full bg-white/20 blur-3xl" />
+          <div className="absolute -left-24 bottom-[-80px] h-72 w-72 rounded-full bg-brand-orange/30 blur-3xl" />
+          <div className="absolute -right-24 -top-24 h-80 w-80 rounded-full bg-brand-blue/30 blur-[120px]" />
+        </div>
+        <div className="relative mx-auto flex max-w-7xl flex-col items-center px-4 py-28 text-center sm:px-6 lg:px-8 lg:py-36">
+          <span className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/10 px-6 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-white/80">
+            {t('index.hero.tagline')}
+          </span>
+          <h1 className="text-balance text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl">
+            <Trans
+              i18nKey="index.hero.headline"
+              components={[
+                <br key="lb" />,
+                <span
+                  key="gradient"
+                  className="text-transparent bg-clip-text bg-gradient-to-r from-white via-brand-blue/80 to-brand-orange/70"
+                />,
+              ]}
+            />
+          </h1>
+          <p className="mt-6 max-w-3xl text-lg text-white/80 sm:text-xl">
+            {t('index.hero.description')}
+          </p>
+          <div className="mt-10 flex flex-col gap-4 sm:flex-row">
+            <Link to="/contact">
+              <Button size="lg" className="btn-primary px-10 py-4 text-base">
+                {t('index.hero.cta')}
+                <ArrowRight className="ml-2 h-5 w-5" />
+              </Button>
+            </Link>
+            <Link to="/solutions">
+              <Button
+                size="lg"
+                className="btn-secondary px-10 py-4 text-base"
+              >
+                {t('index.hero.viewSolutions')}
+              </Button>
+            </Link>
           </div>
+
+          {heroHighlights.length > 0 && (
+            <div className="mt-16 grid w-full gap-6 sm:grid-cols-2 lg:grid-cols-3">
+              {heroHighlights.map((feature, index) => (
+                <div
+                  key={`${feature.title}-${index}`}
+                  className="group relative overflow-hidden rounded-3xl border border-white/20 bg-white/10 p-6 text-left backdrop-blur-sm transition-all duration-300 hover:-translate-y-2 hover:bg-white/15"
+                >
+                  <div className="mb-4 inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-white/20 text-white">
+                    <feature.icon className="h-6 w-6" />
+                  </div>
+                  <h3 className="text-lg font-semibold text-white">
+                    {feature.title}
+                  </h3>
+                  <p className="mt-2 text-sm text-white/75">
+                    {feature.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          )}
         </div>
       </section>
 
-      {/* Features Section */}
-      <section className="py-24 bg-white transition-colors dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
+      <section className="relative py-24">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-brand-purple/15 via-transparent to-transparent"
+          aria-hidden="true"
+        />
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <h2 className="text-3xl font-bold text-brand-purple lg:text-4xl">
               {t('index.why.title')}
             </h2>
-            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
+            <p className="mt-4 text-lg text-neutral-600">
               {t('index.why.description')}
             </p>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-8">
+          <div className="mt-16 grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
             {displayFeatures.map((feature, index) => (
               <a
-                key={index}
+                key={`${feature.title}-${index}`}
                 href={feature.url}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="block"
               >
-                <Card className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl cursor-pointer">
-                  <CardContent className="p-8 text-center">
-                    <div className="w-16 h-16 bg-gradient-hero rounded-2xl flex items-center justify-center mx-auto mb-6">
-                      <feature.icon className="h-8 w-8 text-white" />
+                <Card className="card-hover relative overflow-hidden border border-brand-purple/15 bg-white/90 shadow-soft backdrop-blur-md transition-shadow duration-300 hover:border-brand-purple/30 dark:border-neutral-800 dark:bg-neutral-900/80">
+                  <div className="absolute inset-x-0 top-0 h-1 bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink" />
+                  <CardContent className="relative p-8">
+                    <div className="inline-flex h-12 w-12 items-center justify-center rounded-2xl bg-brand-purple/10 text-brand-purple">
+                      <feature.icon className="h-6 w-6" />
                     </div>
-                    <h3 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100 mb-4">
+                    <h3 className="mt-6 text-xl font-semibold text-neutral-900 dark:text-neutral-100">
                       {feature.title}
                     </h3>
-                    <p className="text-neutral-600 dark:text-neutral-300">{feature.description}</p>
+                    <p className="mt-3 text-sm text-neutral-600 dark:text-neutral-300">
+                      {feature.description}
+                    </p>
+                    <span className="mt-6 inline-flex items-center gap-2 text-sm font-semibold text-brand-blue">
+                      {t('index.learnMore')}
+                      <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                    </span>
                   </CardContent>
                 </Card>
               </a>
@@ -236,50 +270,61 @@ const Index = () => {
         </div>
       </section>
 
-      {/* Solutions Preview */}
-      <section className="py-24 bg-neutral-50 dark:bg-neutral-950 transition-colors dark:bg-neutral-950">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl lg:text-4xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
+      <section className="relative py-24">
+        <div
+          className="pointer-events-none absolute inset-x-0 top-0 h-40 bg-gradient-to-b from-brand-blue/15 via-transparent to-transparent"
+          aria-hidden="true"
+        />
+        <div className="relative mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div className="mx-auto max-w-3xl text-center">
+            <h2 className="text-3xl font-bold text-brand-purple lg:text-4xl">
               {t('index.solutions.title')}
             </h2>
-            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
+            <p className="mt-4 text-lg text-neutral-600">
               {t('index.solutions.description')}
             </p>
           </div>
-          <div className="grid grid-cols-1 lg:grid-cols-2 gap-12">
+          <div className="mt-16 grid grid-cols-1 gap-12 lg:grid-cols-2">
             {displaySolutions.map((solution, index) => (
               <Card
-                key={index}
-                className="border-0 shadow-soft hover:shadow-soft-lg transition-all ease-in-out duration-300 card-hover rounded-2xl overflow-hidden"
+                key={`${solution.name}-${index}`}
+                className="card-hover relative overflow-hidden border border-brand-purple/15 bg-white/95 shadow-soft backdrop-blur-md transition-shadow duration-300 hover:border-brand-purple/30 dark:border-neutral-800 dark:bg-neutral-900/85"
               >
                 <div
-                  className={`h-4 bg-gradient-to-r ${solution.gradient}`}
-                ></div>
-                <CardContent className="p-8">
-                  <h3 className="text-2xl font-bold text-neutral-900 dark:text-neutral-100 mb-4">
+                  className={`absolute inset-0 -z-10 bg-gradient-to-br ${solution.gradient} opacity-10`}
+                  aria-hidden="true"
+                />
+                <div
+                  className={`absolute inset-x-0 top-0 h-1 bg-gradient-to-r ${solution.gradient}`}
+                  aria-hidden="true"
+                />
+                <CardContent className="relative p-10">
+                  <div className="inline-flex items-center gap-2 rounded-full bg-brand-purple/10 px-4 py-1 text-xs font-semibold uppercase tracking-[0.35em] text-brand-purple/80">
+                    {t('navigation.solutions')}
+                  </div>
+                  <h3 className="mt-6 text-2xl font-bold text-neutral-900 dark:text-neutral-100">
                     {solution.name}
                   </h3>
-                  <p className="text-neutral-600 dark:text-neutral-300 mb-6">
+                  <p className="mt-4 text-neutral-600 dark:text-neutral-300">
                     {solution.description}
                   </p>
                   {solution.features &&
                     Array.isArray(solution.features) &&
                     solution.features.length > 0 && (
-                      <ul className="space-y-3 mb-8">
+                      <ul className="mt-8 space-y-3">
                         {solution.features.map((feature, featureIndex) => (
                           <li
-                            key={featureIndex}
+                            key={`${feature}-${featureIndex}`}
                             className="flex items-center text-neutral-700 dark:text-neutral-300"
                           >
-                            <CheckCircle className="h-5 w-5 text-brand-blue mr-3" />
+                            <CheckCircle className="mr-3 h-5 w-5 text-brand-purple" />
                             {feature}
                           </li>
                         ))}
                       </ul>
                     )}
                   <Link to="/solutions">
-                    <Button className="btn-secondary w-full">
+                    <Button className="btn-primary mt-8 w-full">
                       {t('index.learnMore')}
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>
@@ -291,30 +336,32 @@ const Index = () => {
         </div>
       </section>
 
-      {/* Team Section */}
       <TeamSection />
-
-      {/* Newsletter Section */}
       <NewsletterSection />
 
-      {/* CTA Section */}
-      <section className="py-24 bg-gradient-hero text-white">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
-          <h2 className="text-3xl lg:text-4xl font-bold mb-6">
-            {t('index.cta.title')}
-          </h2>
-          <p className="text-xl text-blue-100 mb-8">
-            {t('index.cta.description')}
-          </p>
-          <Link to="/contact">
-            <Button
-              size="lg"
-              className="rounded-xl bg-white transition-colors dark:bg-neutral-950 px-8 py-4 text-lg font-semibold text-brand-purple transition-all duration-300 ease-in-out hover:bg-blue-50 dark:text-white dark:hover:bg-neutral-800"
-            >
-              {t('index.cta.getStarted')}
-              <ArrowRight className="ml-2 h-5 w-5" />
-            </Button>
-          </Link>
+      <section className="px-4 pb-24 pt-12 sm:px-6 lg:px-8">
+        <div className="relative mx-auto max-w-5xl overflow-hidden rounded-[3rem] bg-gradient-hero px-6 py-16 text-center text-white shadow-soft-lg sm:px-10 lg:px-16">
+          <div className="pointer-events-none absolute inset-0">
+            <div className="absolute -left-16 top-16 h-48 w-48 rounded-full bg-white/15 blur-3xl" />
+            <div className="absolute -right-20 bottom-16 h-56 w-56 rounded-full bg-white/15 blur-3xl" />
+          </div>
+          <div className="relative z-10">
+            <h2 className="text-3xl font-bold lg:text-4xl">
+              {t('index.cta.title')}
+            </h2>
+            <p className="mt-4 text-xl text-white/80">
+              {t('index.cta.description')}
+            </p>
+            <Link to="/contact">
+              <Button
+                size="lg"
+                className="mt-8 rounded-2xl bg-white/90 px-10 py-4 text-lg font-semibold text-brand-purple shadow-soft transition-all duration-300 ease-in-out hover:-translate-y-0.5 hover:bg-white"
+              >
+                {t('index.cta.getStarted')}
+                <ArrowRight className="ml-2 h-5 w-5" />
+              </Button>
+            </Link>
+          </div>
         </div>
       </section>
     </Layout>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -86,10 +86,13 @@ export default {
       },
       backgroundImage: {
         'gradient-brand':
-          'linear-gradient(135deg, #7C3AED 0%, #0EA5E9 40%, #EC4899 75%, #F97316 100%)',
-        'gradient-hero': 'linear-gradient(135deg, #7C3AED 0%, #0EA5E9 100%)',
+          'linear-gradient(130deg, #5B2C6F 0%, #4A90E2 40%, #E06666 75%, #F7B500 100%)',
+        'gradient-hero':
+          'linear-gradient(130deg, #5B2C6F 0%, #4A90E2 55%, #E06666 100%)',
         'gradient-pride':
-          'linear-gradient(135deg, #7C3AED 0%, #0EA5E9 25%, #22C55E 50%, #F97316 75%, #EC4899 100%)',
+          'linear-gradient(135deg, #5B2C6F 0%, #4A90E2 25%, #22C55E 50%, #E06666 75%, #F7B500 100%)',
+        'gradient-surface':
+          'radial-gradient(circle at 20% 20%, rgba(91, 44, 111, 0.18), transparent 55%), radial-gradient(circle at 85% 10%, rgba(74, 144, 226, 0.18), transparent 50%), radial-gradient(circle at 10% 85%, rgba(224, 102, 102, 0.16), transparent 45%), linear-gradient(180deg, #f8f4ff 0%, #ffffff 55%, #fff6f0 100%)',
       },
       borderRadius: {
         lg: 'var(--radius)',
@@ -99,8 +102,8 @@ export default {
         '2xl': '1.75rem',
       },
       boxShadow: {
-        soft: '0 10px 30px -15px rgba(124, 58, 237, 0.35)',
-        'soft-lg': '0 25px 60px -20px rgba(14, 165, 233, 0.45)',
+        soft: '0 18px 45px -22px rgba(91, 44, 111, 0.35)',
+        'soft-lg': '0 26px 65px -24px rgba(74, 144, 226, 0.35)',
       },
       keyframes: {
         'accordion-down': {


### PR DESCRIPTION
## Summary
- align the Tailwind theme, buttons, and surface backgrounds with the Monynha brand gradient palette
- redesign the homepage hero, features, solutions, and CTA sections with layered gradients and highlight cards that echo the provided reference
- refresh shared layout, header, newsletter, team, footer, and translation files so the new look and tagline stay consistent across the site

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ca9607d89483228fda85220a640bc0