### PR TITLE
Adjust AuthContext initialization

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -9,12 +9,7 @@ interface AuthContextType {
   signOut: () => Promise<void>;
 }
 
-const AuthContext = createContext<AuthContextType>({
-  user: null,
-  session: null,
-  isLoading: true,
-  signOut: async () => {},
-});
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
 
 /**
  * Provides Supabase authentication state to descendant components.


### PR DESCRIPTION
## Summary
- initialize the AuthContext with an undefined default so consumers must use the provider
- keep the AuthProvider wiring intact and continue to supply the real authentication value

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc65af6840832285480af6dcc0d280