### PR TITLE
Allow GitHub API requests in CSP

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -9,7 +9,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; img-src 'self' data: https://images.unsplash.com; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://bbbyhjhiucptqgqidfki.supabase.co"
+          "value": "default-src 'self'; img-src 'self' data: https://images.unsplash.com; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://bbbyhjhiucptqgqidfki.supabase.co https://api.github.com https://avatars.githubusercontent.com https://raw.githubusercontent.com https://objects.githubusercontent.com"
         },
         {
           "key": "Strict-Transport-Security",


### PR DESCRIPTION
## Summary
- extend the Content-Security-Policy connect-src directive to include the GitHub API and related GitHubusercontent domains while keeping the Supabase project and self allowed

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cc9580201483228d617ed169ca051e