### PR TITLE
Enable strict TypeScript checks and fix type issues

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -61,6 +61,7 @@
         "sonner": "^1.5.0",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.180.0",
         "vaul": "^0.9.3"
       },
       "devDependencies": {
@@ -71,6 +72,7 @@
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/three": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
         "@vitejs/plugin-react-swc": "^3.5.0",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.9.0",
@@ -622,6 +624,13 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.25.8",
@@ -4023,6 +4032,13 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -4250,10 +4266,40 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
     "node_modules/@types/tough-cookie": {
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.23.tgz",
+      "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4567,6 +4613,13 @@
       "peerDependencies": {
         "vite": "^4 || ^5 || ^6 || ^7"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.65",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.65.tgz",
+      "integrity": "sha512-cYrHab4d6wuVvDW5tdsfI6/o6vcLMDe6w2Citd1oS51Xxu2ycLCnVo4fqwujfKWijrZMInTJIKcXxteoy21nVA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/abab": {
       "version": "2.0.6",
@@ -6447,6 +6500,13 @@
       "dependencies": {
         "bser": "2.1.1"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -9009,6 +9069,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -10987,6 +11054,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.180.0",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.180.0.tgz",
+      "integrity": "sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "sonner": "^1.5.0",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.180.0",
     "vaul": "^0.9.3"
   },
   "devDependencies": {
@@ -79,6 +80,7 @@
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/three": "https://registry.npmjs.org/@types/three/-/three-0.180.0.tgz",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.9.0",

--- a/src/components/Loading.tsx
+++ b/src/components/Loading.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 const Loading = () => (
   <div className="flex items-center justify-center py-20 relative flex-1 pt-20 bg-background/70 backdrop-blur-sm supports-[backdrop-filter]:backdrop-blur-md" role="status" >
     <svg

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -41,7 +41,12 @@ const solutionItems = [
   },
 ] as const;
 
-const projectItems = [
+const projectItems: ReadonlyArray<{
+  key: string;
+  href: string;
+  gradient: string;
+  external?: boolean;
+}> = [
   {
     key: 'openSource',
     href: '/projects',
@@ -63,7 +68,7 @@ const projectItems = [
     gradient: 'from-brand-pink to-brand-blue',
     external: true,
   },
-] as const;
+];
 
 type MenuTranslation = Record<
   string,

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -52,8 +52,8 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ..._props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ..._props }) => <ChevronRight className="h-4 w-4" />,
+        IconLeft: () => <ChevronLeft className="h-4 w-4" />,
+        IconRight: () => <ChevronRight className="h-4 w-4" />,
       }}
       {...props}
     />

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -7,7 +7,6 @@ import {
   FieldPath,
   FieldValues,
   FormProvider,
-  useFormContext,
 } from 'react-hook-form';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import * as NavigationMenuPrimitive from '@radix-ui/react-navigation-menu';
-import { cva } from 'class-variance-authority';
 import { ChevronDown } from 'lucide-react';
 
 import { cn } from '@/lib/utils';

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from 'next-themes';
-import { Toaster as Sonner, toast as sonnerToast } from 'sonner';
+import { Toaster as Sonner } from 'sonner';
 
 type ToasterProps = React.ComponentProps<typeof Sonner>;
 

--- a/src/components/ui/use-toast.ts
+++ b/src/components/ui/use-toast.ts
@@ -1,3 +1,2 @@
-import { useToast, ToastProvider } from '@/hooks/use-toast';
-
-export { useToast, ToastProvider };
+export { useToast } from '@/hooks/use-toast';
+export { ToastProvider } from '@/hooks/ToastProvider';

--- a/src/hooks/use-toast.tsx
+++ b/src/hooks/use-toast.tsx
@@ -1,29 +1,4 @@
-import * as React from 'react';
-
-import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
-import reducer, {
-  TOAST_REMOVE_DELAY,
-  genId,
-} from './use-toast-reducer';
-
-type ToasterToast = ToastProps & {
-  id: string;
-  title?: React.ReactNode;
-  description?: React.ReactNode;
-  action?: ToastActionElement;
-};
-
-type Toast = Omit<ToasterToast, 'id'>;
-
-interface ToastContextValue {
-  toasts: ToasterToast[];
-  toast: (toast: Toast) => {
-    id: string;
-    dismiss: () => void;
-    update: (props: ToasterToast) => void;
-  };
-  dismiss: (toastId?: string) => void;
-}
+import { useContext } from 'react';
 
 import { ToastContext } from './ToastProvider';
 
@@ -31,7 +6,7 @@ import { ToastContext } from './ToastProvider';
  * Access the toast context helper for showing notifications.
  */
 function useToast() {
-  const context = React.useContext(ToastContext);
+  const context = useContext(ToastContext);
   if (!context) {
     throw new Error('useToast must be used within a ToastProvider');
   }

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -334,7 +334,16 @@ export type Database = {
       [_ in never]: never;
     };
     Functions: {
-      [_ in never]: never;
+      get_comment_authors: {
+        Args: {
+          user_ids: string[];
+        };
+        Returns: Array<{
+          user_id: string;
+          name: string;
+          avatar_url: string | null;
+        }>;
+      };
     };
     Enums: {
       [_ in never]: never;

--- a/src/lib/a11y.ts
+++ b/src/lib/a11y.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+const REDUCED_MOTION_QUERY = '(prefers-reduced-motion: reduce)';
+
+/**
+ * Hook that returns whether the user prefers reduced motion.
+ */
+export function useReducedMotion(defaultValue = false): boolean {
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(defaultValue);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+
+    const mediaQueryList = window.matchMedia(REDUCED_MOTION_QUERY);
+    const updatePreference = (event: MediaQueryListEvent | MediaQueryList) => {
+      setPrefersReducedMotion(event.matches);
+    };
+
+    updatePreference(mediaQueryList);
+
+    const listener = (event: MediaQueryListEvent) => updatePreference(event);
+
+    if (typeof mediaQueryList.addEventListener === 'function') {
+      mediaQueryList.addEventListener('change', listener);
+      return () => mediaQueryList.removeEventListener('change', listener);
+    }
+
+    // Fallback for older browsers
+    mediaQueryList.addListener(listener);
+    return () => mediaQueryList.removeListener(listener);
+  }, []);
+
+  return prefersReducedMotion;
+}

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import Layout from '@/components/Layout';
@@ -122,7 +122,7 @@ const Blog = () => {
     total: number;
   }>({
     queryKey: ['blog_posts', page],
-    keepPreviousData: true,
+    placeholderData: keepPreviousData,
     queryFn: async () => {
       const from = (page - 1) * POSTS_PER_PAGE;
       const to = from + POSTS_PER_PAGE - 1;

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
-import { Mail, Phone, MapPin, Send, CheckCircle } from 'lucide-react';
+import { Mail, Send, CheckCircle } from 'lucide-react';
 import { supabase } from '@/integrations/supabase';
 import { useToast } from '@/hooks/use-toast';
 import { useTranslation } from 'react-i18next';
@@ -110,7 +110,7 @@ const Contact = () => {
   const {
     data: projectTypeResponse,
     error: projectTypesError,
-  } = useQuery({
+  } = useQuery<string[]>({
     queryKey: ['site-settings', 'project-types'],
     queryFn: async () => {
       const { data, error } = await supabase

--- a/src/pages/solutions/[slug].tsx
+++ b/src/pages/solutions/[slug].tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, keepPreviousData } from '@tanstack/react-query';
 import Layout from '@/components/Layout';
 import Meta from '@/components/Meta';
 import { Button } from '@/components/ui/button';
@@ -89,7 +89,7 @@ const SolutionDetail = () => {
     },
     staleTime: 1000 * 60 * 10,
     retry: 1,
-    keepPreviousData: true,
+    placeholderData: keepPreviousData,
     refetchOnWindowFocus: false,
   });
 

--- a/src/types/three.d.ts
+++ b/src/types/three.d.ts
@@ -1,0 +1,86 @@
+declare module 'three' {
+  export const SRGBColorSpace: unknown;
+  export const ACESFilmicToneMapping: unknown;
+
+  export namespace MathUtils {
+    function clamp(value: number, min: number, max: number): number;
+  }
+
+  export class Vector2 {
+    constructor(x?: number, y?: number);
+    x: number;
+    y: number;
+    clone(): Vector2;
+    set(x: number, y: number): this;
+    setScalar(value: number): this;
+    copy(vector: Vector2): this;
+    lerp(v: Vector2, alpha: number): this;
+  }
+
+  export class Color {
+    constructor(color?: string | number);
+    r: number;
+    g: number;
+    b: number;
+    convertSRGBToLinear(): this;
+  }
+
+  export interface IUniform<T = unknown> {
+    value: T;
+  }
+
+  export interface ShaderMaterialParameters {
+    uniforms?: Record<string, IUniform>;
+    vertexShader?: string;
+    fragmentShader?: string;
+    transparent?: boolean;
+  }
+
+  export class ShaderMaterial {
+    uniforms: Record<string, IUniform>;
+    constructor(parameters?: ShaderMaterialParameters);
+    dispose(): void;
+  }
+
+  export interface WebGLRendererParameters {
+    alpha?: boolean;
+    antialias?: boolean;
+    powerPreference?: 'default' | 'high-performance' | 'low-power';
+  }
+
+  export class WebGLRenderer {
+    domElement: HTMLCanvasElement;
+    outputColorSpace: unknown;
+    toneMapping: unknown;
+    constructor(parameters?: WebGLRendererParameters);
+    setPixelRatio(value: number): void;
+    setSize(width: number, height: number, updateStyle?: boolean): void;
+    render(scene: Scene, camera: Camera): void;
+    dispose(): void;
+  }
+
+  export class Scene {
+    add(...objects: Object3D[]): void;
+    remove(...objects: Object3D[]): void;
+  }
+
+  export class Object3D {}
+
+  export class Camera extends Object3D {}
+
+  export class OrthographicCamera extends Camera {
+    constructor(left: number, right: number, top: number, bottom: number, near?: number, far?: number);
+  }
+
+  export class BufferGeometry {
+    dispose(): void;
+  }
+
+  export class PlaneGeometry extends BufferGeometry {
+    constructor(width: number, height: number);
+  }
+
+  export class Mesh<TGeometry extends BufferGeometry = BufferGeometry, TMaterial = ShaderMaterial> extends Object3D {
+    constructor(geometry?: TGeometry, material?: TMaterial);
+  }
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -15,10 +15,10 @@
     "jsx": "react-jsx",
 
     /* Linting */
-    "strict": false,
-    "noUnusedLocals": false,
-    "noUnusedParameters": false,
-    "noImplicitAny": false,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitAny": true,
     "noFallthroughCasesInSwitch": false,
 
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- enable full TypeScript strictness in the app config and add targeted helper types/hooks required to satisfy the compiler
- harden Supabase-powered features by defining the `get_comment_authors` RPC, tightening query result typing, and guarding responses
- update React Query consumers and UI helpers to work with stricter settings, cleaning up unused imports and parameters along the way

## Testing
- `npx tsc --noEmit -p tsconfig.app.json`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_68cc95b7bfbc8322931cfb4495694fbb