### PR TITLE
Refine auth context typing

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -58,11 +58,9 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
-  return (
-    <AuthContext.Provider value={{ user, session, isLoading, signOut }}>
-      {children}
-    </AuthContext.Provider>
-  );
+  const value: AuthContextType = { user, session, isLoading, signOut };
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
 }
 
 /**
@@ -70,7 +68,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
  */
 export const useAuth = () => {
   const context = useContext(AuthContext);
-  if (!context) {
+  if (context === undefined) {
     throw new Error('useAuth must be used within an AuthProvider');
   }
   return context;


### PR DESCRIPTION
## Summary
- ensure the auth provider supplies a value typed as `AuthContextType`
- throw a clear error when `useAuth` is called without a matching provider

## Testing
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68cd1c44ee0083229c2cae916b07513c