### PR TITLE
Add tests for solutions mapping utilities

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,29 @@
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const { jsWithTsESM: defaults } = require('ts-jest/presets');
+
+/** @type {import('jest').Config} */
+const config = {
+  ...defaults,
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json', 'node'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@monynha/ui$': '<rootDir>/packages/ui/src/index.ts',
+    '^@monynha/ui/(.*)$': '<rootDir>/packages/ui/src/$1',
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.app.json',
+      },
+    ],
+  },
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+};
+
+export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -69,6 +69,7 @@
         "@testing-library/jest-dom": "^6.2.2",
         "@testing-library/react": "^14.1.2",
         "@testing-library/user-event": "^14.4.3",
+        "@types/jest": "^30.0.0",
         "@types/node": "^22.5.5",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
@@ -1620,6 +1621,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.0.1.tgz",
+      "integrity": "sha512-n5H8QLDJ47QqbCNn5SuFjCRDrOLEZ0h8vAHCK5RL9Ls7Xa8AQLa/YxAc9UjFqoEDM48muwtBGjtMY5cr0PLDCw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/environment": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
@@ -1681,6 +1692,16 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@jest/globals": {
       "version": "29.7.0",
       "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
@@ -1695,6 +1716,30 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/pattern": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.0.1.tgz",
+      "integrity": "sha512-gWp7NfQW27LaBQz3TITS8L7ZCQ0TLvtmI//4OwlQRx4rnWxcPNIYjxZpDcN4+UlGxgm3jS5QPz8IPTCkb59wZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "jest-regex-util": "30.0.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/pattern/node_modules/jest-regex-util": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
+      "integrity": "sha512-jHEQgBXAgc+Gh4g0p3bCevgRCVRkB4VB70zhoAE48gxeSr1hfUOsM/C2WoJgVL7Eyg//hudYENbm3Ne+/dRVVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
       }
     },
     "node_modules/@jest/reporters": {
@@ -4196,6 +4241,237 @@
       "dependencies": {
         "@types/istanbul-lib-report": "*"
       }
+    },
+    "node_modules/@types/jest": {
+      "version": "30.0.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
+      "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^30.0.0",
+        "pretty-format": "^30.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/expect-utils": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.1.2.tgz",
+      "integrity": "sha512-HXy1qT/bfdjCv7iC336ExbqqYtZvljrV8odNdso7dWK9bSeHtLlvwWWC3YSybSPL03Gg5rug6WLCZAZFH72m0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/schemas": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.0.5.tgz",
+      "integrity": "sha512-DmdYgtezMkh3cpU8/1uyXakv3tJRcmcXxBOcO0tbaozPwpmh4YMsnWrQm9ZmZMfa5ocbxzbFk6O4bDPEc/iAnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@jest/types": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.0.5.tgz",
+      "integrity": "sha512-aREYa3aku9SSnea4aX6bhKn4bgv3AXkgijoQgbYV3yvbiGt6z+MQ85+6mIhx9DsKW2BuB/cLR/A+tcMThx+KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/pattern": "30.0.1",
+        "@jest/schemas": "30.0.5",
+        "@types/istanbul-lib-coverage": "^2.0.6",
+        "@types/istanbul-reports": "^3.0.4",
+        "@types/node": "*",
+        "@types/yargs": "^17.0.33",
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/@sinclair/typebox": {
+      "version": "0.34.41",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
+      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jest/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@types/jest/node_modules/ci-info": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@types/jest/node_modules/expect": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-30.1.2.tgz",
+      "integrity": "sha512-xvHszRavo28ejws8FpemjhwswGj4w/BetHIL8cU49u4sGyXDw2+p3YbeDbj6xzlxi6kWTjIRSTJ+9sNXPnF0Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "30.1.2",
+        "@jest/get-type": "30.1.0",
+        "jest-matcher-utils": "30.1.2",
+        "jest-message-util": "30.1.0",
+        "jest-mock": "30.0.5",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-diff": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.1.2.tgz",
+      "integrity": "sha512-4+prq+9J61mOVXCa4Qp8ZjavdxzrWQXrI80GNxP8f4tkI2syPuPrJgdRPZRrfUTRvIoUwcmNLbqEJy9W800+NQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.0.1",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-matcher-utils": {
+      "version": "30.1.2",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.1.2.tgz",
+      "integrity": "sha512-7ai16hy4rSbDjvPTuUhuV8nyPBd6EX34HkBsBcBX2lENCuAQ0qKCPb/+lt8OSWUa9WWmGYLy41PrEzkwRwoGZQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.1.2",
+        "pretty-format": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-message-util": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.1.0.tgz",
+      "integrity": "sha512-HizKDGG98cYkWmaLUHChq4iN+oCENohQLb7Z5guBPumYs+/etonmNFlg1Ps6yN9LTPyZn+M+b/9BbnHx3WTMDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@jest/types": "30.0.5",
+        "@types/stack-utils": "^2.0.3",
+        "chalk": "^4.1.2",
+        "graceful-fs": "^4.2.11",
+        "micromatch": "^4.0.8",
+        "pretty-format": "30.0.5",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.6"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-mock": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.0.5.tgz",
+      "integrity": "sha512-Od7TyasAAQX/6S+QCbN6vZoWOMwlTtzzGuxJku1GhGanAjz9y+QsQkpScDmETvdc9aSXyJ/Op4rhpMYBWW91wQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "jest-util": "30.0.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/jest-util": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.0.5.tgz",
+      "integrity": "sha512-pvyPWssDZR0FlfMxCBoc0tvM8iUEskaRFALUtGQYzVEAqisAztmy+R8LnU14KT4XA0H/a5HMVTXat1jLne010g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "30.0.5",
+        "@types/node": "*",
+        "chalk": "^4.1.2",
+        "ci-info": "^4.2.0",
+        "graceful-fs": "^4.2.11",
+        "picomatch": "^4.0.2"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/@types/jest/node_modules/pretty-format": {
+      "version": "30.0.5",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.0.5.tgz",
+      "integrity": "sha512-D1tKtYvByrBkFLe2wHJl2bwMJIiT8rW+XA+TiataH79/FszLQMrpGEvzUVkzPau7OCO0Qnrhpe87PqtOAIB8Yw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.0.5",
+        "ansi-styles": "^5.2.0",
+        "react-is": "^18.3.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@types/jest/node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/jsdom": {
       "version": "20.0.1",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@testing-library/jest-dom": "^6.2.2",
     "@testing-library/react": "^14.1.2",
     "@testing-library/user-event": "^14.4.3",
+    "@types/jest": "^30.0.0",
     "@types/node": "^22.5.5",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/src/lib/__tests__/solutions.test.ts
+++ b/src/lib/__tests__/solutions.test.ts
@@ -1,0 +1,205 @@
+import type { GitHubRepository } from '@/lib/solutions';
+import {
+  fetchSupabaseSolutions,
+  getFallbackSolution,
+  getFallbackSolutions,
+  mapGitHubRepoToContent,
+  mapSupabaseSolutionToContent,
+} from '@/lib/solutions';
+import { fallbackSolutions, gradientOptions } from '@/data/solutions';
+import type { Database } from '@/integrations/supabase/types';
+import { supabase } from '@/integrations/supabase';
+
+type SupabaseSolutionRow = Database['public']['Tables']['solutions']['Row'];
+
+const mockOrder = jest.fn();
+const mockEq = jest.fn();
+const mockSelect = jest.fn();
+
+jest.mock('@/integrations/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+const mockedSupabase = supabase as jest.Mocked<typeof supabase>;
+
+describe('solutions library', () => {
+  beforeEach(() => {
+    mockOrder.mockReset();
+    mockEq.mockReset();
+    mockSelect.mockReset();
+    mockedSupabase.from.mockReset();
+  });
+
+  it('maps GitHub repositories using fallback metadata and deduplicated features', () => {
+    const repository: GitHubRepository = {
+      id: 1,
+      name: 'assistina',
+      description: '   ',
+      homepage: 'https://assistina.ai',
+      topics: ['AI', 'AI ', 'automation'],
+      language: 'TypeScript',
+      private: false,
+      archived: false,
+      disabled: false,
+      visibility: 'public',
+      default_branch: 'main',
+      stargazers_count: 25,
+      watchers_count: 25,
+      open_issues_count: 3,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: 'invalid-date',
+      pushed_at: 'invalid-date',
+      html_url: 'https://github.com/monynha/assistina',
+    };
+
+    const content = mapGitHubRepoToContent(repository, 1);
+
+    expect(content).toMatchObject({
+      id: '1',
+      slug: 'assistina',
+      title: 'AssisTina AI',
+      description:
+        'Intelligent AI assistant that learns your business processes and automates routine tasks, increasing efficiency and productivity.',
+      externalUrl: 'https://github.com/monynha/assistina',
+      gradient: fallbackSolutions[1].gradient,
+      imageUrl: fallbackSolutions[1].imageUrl,
+    });
+
+    expect(content.features).toEqual([
+      'AI',
+      'automation',
+      'Built with TypeScript.',
+      'Live project: https://assistina.ai',
+      '25 ⭐ stars on GitHub',
+      '3 open issues',
+      'Default branch: main',
+    ]);
+  });
+
+  it('uses fallback information when Supabase rows do not provide features', () => {
+    const supabaseRow: SupabaseSolutionRow = {
+      id: 'row-1',
+      slug: 'assistina',
+      title: 'Custom title from Supabase',
+      description: 'Supabase description',
+      features: '[]',
+      image_url: null,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+      active: true,
+    };
+
+    const content = mapSupabaseSolutionToContent(supabaseRow, 4);
+
+    expect(content).toEqual({
+      id: 'row-1',
+      slug: 'assistina',
+      title: 'Custom title from Supabase',
+      description: 'Supabase description',
+      imageUrl: fallbackSolutions[1].imageUrl,
+      features: [...fallbackSolutions[1].features],
+      gradient: fallbackSolutions[1].gradient,
+      externalUrl: null,
+    });
+
+    expect(content.features).not.toBe(fallbackSolutions[1].features);
+  });
+
+  it('normalizes Supabase feature payloads and cycles gradients when needed', () => {
+    const supabaseRow: SupabaseSolutionRow = {
+      id: 'row-2',
+      slug: 'custom-solution',
+      title: 'Custom solution',
+      description: 'Provided description',
+      features: JSON.stringify(['Feature from DB', 'Feature from DB', 42, true, '', null]),
+      image_url: 'https://example.com/image.png',
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+      active: true,
+    };
+
+    const content = mapSupabaseSolutionToContent(supabaseRow, { index: 5 });
+
+    expect(content).toEqual({
+      id: 'row-2',
+      slug: 'custom-solution',
+      title: 'Custom solution',
+      description: 'Provided description',
+      imageUrl: 'https://example.com/image.png',
+      features: ['Feature from DB', '42', 'true'],
+      gradient: gradientOptions[1],
+      externalUrl: null,
+    });
+  });
+
+  it('returns isolated fallback entries', () => {
+    const fallback = fallbackSolutions.find((solution) => solution.slug === 'assistina');
+    expect(fallback).toBeDefined();
+
+    const result = getFallbackSolution('assistina');
+
+    expect(result).toEqual(fallback);
+    expect(result).not.toBe(fallback);
+
+    result?.features.push('New feature');
+    expect(fallback?.features).not.toContain('New feature');
+
+    const allFallbacks = getFallbackSolutions();
+    expect(allFallbacks).toHaveLength(fallbackSolutions.length);
+    allFallbacks.forEach((entry, index) => {
+      expect(entry).toEqual(fallbackSolutions[index]);
+      expect(entry).not.toBe(fallbackSolutions[index]);
+      expect(entry.features).not.toBe(fallbackSolutions[index].features);
+    });
+  });
+
+  it('fetches Supabase solutions and maps them correctly', async () => {
+    const supabaseRow: SupabaseSolutionRow = {
+      id: 'row-3',
+      slug: 'custom-solution',
+      title: 'From Supabase',
+      description: 'Description',
+      features: ['Direct feature'],
+      image_url: null,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-02T00:00:00Z',
+      active: true,
+    };
+
+    mockedSupabase.from.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ order: mockOrder });
+    mockOrder.mockResolvedValue({ data: [supabaseRow], error: null });
+
+    const result = await fetchSupabaseSolutions();
+
+    expect(mockedSupabase.from).toHaveBeenCalledWith('solutions');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('active', true);
+    expect(mockOrder).toHaveBeenCalledWith('created_at', { ascending: true });
+
+    expect(result).toEqual([
+      {
+        id: 'row-3',
+        slug: 'custom-solution',
+        title: 'From Supabase',
+        description: 'Description',
+        imageUrl: null,
+        features: ['Direct feature'],
+        gradient: gradientOptions[0],
+        externalUrl: null,
+      },
+    ]);
+  });
+
+  it('throws when Supabase returns an error', async () => {
+    mockedSupabase.from.mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ order: mockOrder });
+    mockOrder.mockResolvedValue({ data: null, error: { message: 'failed to fetch' } });
+
+    await expect(fetchSupabaseSolutions()).rejects.toThrow('failed to fetch');
+  });
+});


### PR DESCRIPTION
## Summary
- add a Jest ESM configuration aligned with the Vite/TypeScript project setup
- cover solution mapping helpers with unit tests, including Supabase error handling and fallback cloning

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cf026547748322baf16a4f7310f643