### PR TITLE
Refactor context providers for lint compatibility

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Toaster } from '@/components/ui/toaster';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { ToastProvider } from '@/hooks/ToastProvider';
-import { AuthProvider } from '@/hooks/useAuth';
+import { AuthProvider } from '@/hooks/AuthProvider';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { Suspense, lazy } from 'react';

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -127,7 +127,6 @@ const FormMessage = React.forwardRef<
 FormMessage.displayName = 'FormMessage';
 
 export {
-  useFormField,
   Form,
   FormItem,
   FormLabel,

--- a/src/hooks/ToastProvider.tsx
+++ b/src/hooks/ToastProvider.tsx
@@ -1,27 +1,10 @@
 import * as React from 'react';
 import reducer, { TOAST_REMOVE_DELAY, genId } from './use-toast-reducer';
-import type { ToastActionElement, ToastProps } from '@/components/ui/toast';
-
-type ToasterToast = ToastProps & {
-  id: string;
-  title?: React.ReactNode;
-  description?: React.ReactNode;
-  action?: ToastActionElement;
-};
-
-interface ToastContextValue {
-  toasts: ToasterToast[];
-  toast: (toast: Omit<ToasterToast, 'id'>) => {
-    id: string;
-    dismiss: () => void;
-    update: (props: ToasterToast) => void;
-  };
-  dismiss: (toastId?: string) => void;
-}
-
-export const ToastContext = React.createContext<ToastContextValue | undefined>(
-  undefined
-);
+import {
+  ToastContext,
+  type ToastContextValue,
+  type ToasterToast,
+} from './toast-context';
 
 export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = React.useReducer(reducer, { toasts: [] });

--- a/src/hooks/auth-context.ts
+++ b/src/hooks/auth-context.ts
@@ -1,0 +1,11 @@
+import { createContext } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+
+export interface AuthContextType {
+  user: User | null;
+  session: Session | null;
+  isLoading: boolean;
+  signOut: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextType | undefined>(undefined);

--- a/src/hooks/toast-context.ts
+++ b/src/hooks/toast-context.ts
@@ -1,0 +1,16 @@
+import * as React from 'react';
+import type { ToasterToast } from './use-toast-reducer';
+
+export interface ToastContextValue {
+  toasts: ToasterToast[];
+  toast: (toast: Omit<ToasterToast, 'id'>) => {
+    id: string;
+    dismiss: () => void;
+    update: (props: ToasterToast) => void;
+  };
+  dismiss: (toastId?: string) => void;
+}
+
+export const ToastContext = React.createContext<ToastContextValue | undefined>(
+  undefined
+);

--- a/src/hooks/use-toast.tsx
+++ b/src/hooks/use-toast.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react';
 
-import { ToastContext } from './ToastProvider';
+import { ToastContext } from './toast-context';
 
 /**
  * Access the toast context helper for showing notifications.

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,13 @@
+import { useContext } from 'react';
+import { AuthContext } from './auth-context';
+
+/**
+ * Access the authentication context.
+ */
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
## Summary
- split authentication context into dedicated provider, hook, and context modules to avoid React Refresh lint violations
- extract toast context definitions and update imports to satisfy linting while preserving toast functionality
- stop re-exporting non-component utilities from the shared form component module

## Testing
- npm run lint
- npm test
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d672670a2c83229d16e6845a71ae64