### PR TITLE
Add branded button variants and migrate usages

### DIFF
--- a/src/components/blog/CommentsSection.tsx
+++ b/src/components/blog/CommentsSection.tsx
@@ -316,7 +316,8 @@ const CommentsSection = ({ postId }: CommentsSectionProps) => {
                   </span>
                   <Button
                     type="submit"
-                    className="btn-primary"
+                    variant="brandPrimary"
+                    size="md"
                     disabled={addComment.isPending}
                   >
                     {addComment.isPending && (
@@ -332,7 +333,7 @@ const CommentsSection = ({ postId }: CommentsSectionProps) => {
           <Card className="border border-dashed border-brand-blue/30 bg-white">
             <CardContent className="flex flex-col items-center gap-4 p-6 text-center text-neutral-600">
               <p>{t('blog.comments.signInPrompt')}</p>
-              <Button asChild className="btn-primary">
+              <Button asChild variant="brandPrimary" size="md">
                 <Link to="/auth">{t('blog.comments.signInCta')}</Link>
               </Button>
             </CardContent>

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -1,7 +1,7 @@
 import { cva } from 'class-variance-authority';
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-2xl text-sm font-semibold shadow-md transition-all ease-in-out duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-2xl font-semibold shadow-md transition-all ease-in-out duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-60 [&_svg]:pointer-events-none [&_svg]:h-4 [&_svg]:w-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
@@ -15,17 +15,21 @@ export const buttonVariants = cva(
           'bg-brand-blue/10 text-brand-blue hover:bg-brand-blue/20 shadow-sm',
         ghost: 'shadow-none hover:bg-brand-blue/10 hover:text-brand-blue',
         link: 'shadow-none text-brand-blue underline-offset-4 hover:underline px-0',
+        brandPrimary:
+          'bg-gradient-brand text-white shadow-md hover:shadow-soft-lg focus-visible:ring-offset-background',
+        brandSecondary:
+          'border border-neutral-200 bg-white text-neutral-700 shadow-sm hover:border-brand-blue hover:shadow-soft focus-visible:ring-offset-background dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800',
       },
       size: {
-        default: 'h-11 px-5 py-2.5',
-        sm: 'h-10 px-4 py-2 text-sm',
-        lg: 'h-12 px-8 text-base',
+        sm: 'h-9 px-4 text-sm',
+        md: 'h-11 px-5 text-base',
+        lg: 'h-12 px-6 text-lg',
         icon: 'h-11 w-11',
       },
     },
     defaultVariants: {
       variant: 'default',
-      size: 'default',
+      size: 'md',
     },
   }
 );

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -66,7 +66,7 @@ const PaginationPrevious = ({
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
     aria-label="Go to previous page"
-    size="default"
+    size="md"
     className={cn('gap-1 pl-2.5', className)}
     {...props}
   >
@@ -82,7 +82,7 @@ const PaginationNext = ({
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
     aria-label="Go to next page"
-    size="default"
+    size="md"
     className={cn('gap-1 pr-2.5', className)}
     {...props}
   >

--- a/src/index.css
+++ b/src/index.css
@@ -116,14 +116,6 @@
 }
 
 @layer components {
-  .btn-primary {
-    @apply inline-flex items-center justify-center gap-2 bg-gradient-brand text-white font-semibold px-6 py-3 rounded-2xl shadow-md transition-all ease-in-out duration-300 hover:shadow-soft-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background;
-  }
-
-  .btn-secondary {
-    @apply inline-flex items-center justify-center gap-2 bg-white text-neutral-700 font-semibold px-6 py-3 rounded-2xl border border-neutral-200 shadow-sm hover:shadow-soft hover:border-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue focus-visible:ring-offset-2 focus-visible:ring-offset-background transition-all ease-in-out duration-300 dark:border-neutral-700 dark:bg-neutral-900 dark:text-neutral-100 dark:hover:bg-neutral-800;
-  }
-
   .card-hover {
     @apply transition-all ease-in-out duration-300 hover:shadow-soft-lg hover:-translate-y-1;
   }

--- a/src/pages/Blog.tsx
+++ b/src/pages/Blog.tsx
@@ -332,7 +332,12 @@ const Blog = () => {
                   <p className="text-lg text-neutral-600 dark:text-neutral-300 mb-6">
                     {featuredPost.excerpt}
                   </p>
-                  <Button asChild className="btn-primary w-fit">
+                  <Button
+                    asChild
+                    variant="brandPrimary"
+                    size="md"
+                    className="w-fit"
+                  >
                     <Link
                       to={`/blog/${featuredPost.slug}`}
                       className="inline-flex items-center"
@@ -431,7 +436,7 @@ const Blog = () => {
                   <PaginationItem>
                     <PaginationLink
                       href="#"
-                      size="default"
+                      size="md"
                       className={cn(
                         'gap-1 pl-2.5',
                         page === 1 && 'pointer-events-none opacity-50'
@@ -467,7 +472,7 @@ const Blog = () => {
                   <PaginationItem>
                     <PaginationLink
                       href="#"
-                      size="default"
+                      size="md"
                       className={cn(
                         'gap-1 pr-2.5',
                         page === totalPages && 'pointer-events-none opacity-50'

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -332,7 +332,8 @@ const Contact = () => {
             </p>
             <Button
               onClick={() => setIsSubmitted(false)}
-              className="btn-secondary"
+              variant="brandSecondary"
+              size="md"
             >
               {t('contact.thankYou.another')}
             </Button>
@@ -513,7 +514,9 @@ const Contact = () => {
 
                     <Button
                       type="submit"
-                      className="btn-primary w-full"
+                      variant="brandPrimary"
+                      size="md"
+                      className="w-full"
                       disabled={isSubmitting}
                     >
                       {isSubmitting

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -178,7 +178,7 @@ const Index = () => {
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">
               <Link to="/contact">
-                <Button className="btn-primary">
+                <Button variant="brandPrimary" size="lg">
                   {t('index.hero.cta')}
 
                   <ArrowRight className="ml-2 h-5 w-5" />
@@ -279,7 +279,11 @@ const Index = () => {
                       </ul>
                     )}
                   <Link to="/solutions">
-                    <Button className="btn-secondary w-full">
+                    <Button
+                      variant="brandSecondary"
+                      size="md"
+                      className="w-full"
+                    >
                       {t('index.learnMore')}
                       <ArrowRight className="ml-2 h-4 w-4" />
                     </Button>


### PR DESCRIPTION
## Summary
- add brandPrimary/brandSecondary variants and refreshed size scale to the shared button styles
- remove legacy btn utility classes and update feature pages to use the new button API
- align pagination helpers with the new size naming to avoid references to removed tokens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d66bec3c188322a0b4ab9a2e914b56