### PR TITLE
Fix dev runtime env and graceful fallbacks

### DIFF
--- a/src/hooks/useRepositorySync.ts
+++ b/src/hooks/useRepositorySync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { supabase } from '@/integrations/supabase';
+import { supabase, isSupabaseConfigured } from '@/integrations/supabase';
 
 interface UseRepositorySyncOptions {
   enabled?: boolean;
@@ -27,7 +27,11 @@ export const useRepositorySync = (options: UseRepositorySyncOptions = {}) => {
   const queryClient = useQueryClient();
 
   useEffect(() => {
-    if (!enabled) {
+    if (
+      !enabled ||
+      !isSupabaseConfigured ||
+      import.meta.env.MODE !== 'production'
+    ) {
       return;
     }
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,22 +1,46 @@
+const FALLBACK_LOCALE = 'en-US';
+
+const LOCALE_FALLBACKS: Record<string, string> = {
+  en: 'en-US',
+  pt: 'pt-BR',
+  es: 'es-ES',
+  fr: 'fr-FR',
+};
+
+const sanitizeLocale = (language: string) =>
+  language
+    .replace('_', '-')
+    .split('@')[0]
+    .split('.')[0]
+    .trim();
+
 export const getNormalizedLocale = (language: string | undefined | null) => {
   if (!language) {
-    return 'en-US';
+    return FALLBACK_LOCALE;
   }
 
-  if (language.includes('-')) {
-    return language;
+  const sanitized = sanitizeLocale(language);
+
+  try {
+    const [canonical] = Intl.getCanonicalLocales(sanitized);
+    if (canonical) {
+      return canonical;
+    }
+  } catch (error) {
+    console.warn('Failed to canonicalize locale, falling back', {
+      language,
+      sanitized,
+      error,
+    });
   }
 
-  switch (language) {
-    case 'pt':
-      return 'pt-BR';
-    case 'en':
-      return 'en-US';
-    case 'es':
-      return 'es-ES';
-    case 'fr':
-      return 'fr-FR';
-    default:
-      return language;
+  const [base] = sanitized.split('-');
+  if (base) {
+    const mapped = LOCALE_FALLBACKS[base];
+    if (mapped) {
+      return mapped;
+    }
   }
+
+  return LOCALE_FALLBACKS.en ?? FALLBACK_LOCALE;
 };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,6 +12,20 @@ export default defineConfig(({ mode }) => ({
   plugins: [react(), mode === 'development' && componentTagger()].filter(
     Boolean
   ),
+  define: {
+    'process.env.NODE_ENV': JSON.stringify(
+      mode === 'development' ? 'development' : 'production'
+    ),
+  },
+  optimizeDeps: {
+    esbuildOptions: {
+      define: {
+        'process.env.NODE_ENV': JSON.stringify(
+          mode === 'development' ? 'development' : 'production'
+        ),
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary
- ensure Vite always exposes development-friendly NODE_ENV values in dev mode
- harden locale normalization and Supabase client so pages render without external services configured
- guard repository sync to production builds to prevent noisy failures during local development

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d681332f0c83228daad23637bbaf7d