### PR TITLE
Refine solutions page gradients and layout

### DIFF
--- a/packages/ui/src/components/SolutionCard.tsx
+++ b/packages/ui/src/components/SolutionCard.tsx
@@ -69,7 +69,12 @@ export const SolutionCard = ({
         />
       )}
 
-      <CardContent className={cn('flex flex-1 flex-col p-8', contentClassName)}>
+      <CardContent
+        className={cn(
+          'flex flex-1 flex-col p-8 text-neutral-900 dark:text-neutral-100',
+          contentClassName
+        )}
+      >
         <div
           className={cn(
             'h-1 w-16 rounded-full bg-gradient-to-r',
@@ -78,15 +83,15 @@ export const SolutionCard = ({
           )}
           aria-hidden="true"
         />
-        <h3 className="text-2xl font-heading font-semibold text-neutral-900">
+        <h3 className="text-2xl font-heading font-semibold text-neutral-900 dark:text-neutral-50">
           {title}
         </h3>
-        <p className="mt-4 flex-1 text-neutral-600 leading-relaxed">
+        <p className="mt-4 text-neutral-600 leading-relaxed dark:text-neutral-300">
           {description}
         </p>
 
         {displayFeatures.length > 0 && (
-          <ul className="mt-8 space-y-3 text-neutral-600">
+          <ul className="mt-8 space-y-3 text-neutral-600 dark:text-neutral-300">
             {displayFeatures.map((feature, index) => (
               <li
                 key={`${slug}-feature-${index}`}
@@ -102,14 +107,18 @@ export const SolutionCard = ({
                 >
                   <CheckCircle className="h-4 w-4" aria-hidden="true" />
                 </span>
-                <span className="text-sm leading-relaxed">{feature}</span>
+                <span className="text-sm leading-relaxed text-neutral-700 dark:text-neutral-200">
+                  {feature}
+                </span>
               </li>
             ))}
           </ul>
         )}
 
         {actions && (
-          <div className="mt-10 flex flex-col gap-3 sm:flex-row">{actions}</div>
+          <div className="mt-auto flex flex-col gap-3 pt-8 sm:flex-row">
+            {actions}
+          </div>
         )}
       </CardContent>
     </Card>

--- a/packages/ui/src/theme.ts
+++ b/packages/ui/src/theme.ts
@@ -9,7 +9,7 @@ export const sectionPaddingY = 'py-24 sm:py-28';
 export const sectionContainer = 'max-w-7xl mx-auto px-4 sm:px-6 lg:px-8';
 
 export const surfaceCardClass =
-  'rounded-2xl border border-white/60 bg-white/90 shadow-md backdrop-blur-sm';
+  'rounded-2xl border border-white/60 bg-white/90 shadow-md backdrop-blur-sm dark:border-neutral-800 dark:bg-neutral-900/80';
 
 export const featureIconWrapperClass =
   'inline-flex h-8 w-8 items-center justify-center rounded-full text-white shadow-sm';

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -7,6 +7,8 @@ export const buttonVariants = cva(
       variant: {
         default:
           'bg-gradient-to-r from-primary via-primary/90 to-secondary text-primary-foreground shadow-soft hover:shadow-soft-lg hover:brightness-105 focus-visible:ring-primary/50',
+        gradient:
+          'bg-gradient-to-r from-brand-purple via-brand-blue to-brand-pink text-white shadow-soft hover:shadow-soft-lg hover:brightness-110 focus-visible:ring-brand-purple/50',
         destructive:
           'bg-destructive text-destructive-foreground shadow-soft hover:bg-destructive/90 focus-visible:ring-destructive/60',
         outline:

--- a/src/pages/Solutions.tsx
+++ b/src/pages/Solutions.tsx
@@ -118,18 +118,14 @@ const Solutions = () => {
         </Breadcrumb>
       </div>
       {/* Hero Section */}
-      <section
-        className={cn(
-          sectionPaddingY,
-          'bg-white transition-colors dark:bg-neutral-950'
-        )}
-      >
-        <div className={sectionContainer}>
-          <div className="text-center mb-16">
-            <h1 className="text-4xl lg:text-5xl font-bold text-neutral-900 dark:text-neutral-100 mb-6">
+      <section className="relative overflow-hidden bg-gradient-hero text-white">
+        <div className="absolute inset-0 bg-gradient-to-br from-neutral-950/20 via-brand-purple/20 to-brand-blue/30 dark:from-neutral-950/40 dark:via-neutral-950/60 dark:to-brand-purple/40" />
+        <div className={cn(sectionPaddingY, 'relative z-10')}>
+          <div className={cn(sectionContainer, 'text-center mb-16')}>
+            <h1 className="mb-6 text-4xl font-bold lg:text-5xl">
               {t('solutionsPage.title')}
             </h1>
-            <p className="text-xl text-neutral-600 dark:text-neutral-300 max-w-3xl mx-auto">
+            <p className="mx-auto max-w-3xl text-xl text-blue-100/90 dark:text-blue-100">
               {t('solutionsPage.description')}
             </p>
           </div>
@@ -149,6 +145,7 @@ const Solutions = () => {
               <SolutionCard
                 key={solution.id ?? solution.slug}
                 solution={solution}
+                className="min-h-[32rem]"
                 actions={
                   <>
                     <Button asChild variant="outline" className="flex-1">
@@ -159,7 +156,7 @@ const Solutions = () => {
                         {t('index.learnMore')}
                       </Link>
                     </Button>
-                    <Button asChild className="flex-1">
+                    <Button asChild variant="gradient" className="flex-1">
                       <Link
                         to="/contact"
                         className="flex items-center justify-center gap-2"


### PR DESCRIPTION
## Summary
- add gradient hero treatment and refreshed CTA styling to the solutions page
- ensure solution cards stretch evenly with improved dark mode contrast and persistent actions
- introduce a reusable gradient button variant and dark mode-friendly surface styling

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68d6819a9e8c8322b66be075ba23b169