### PR TITLE
Run Prettier formatting

### DIFF
--- a/docs/VISUAL.md
+++ b/docs/VISUAL.md
@@ -4,13 +4,14 @@ This document captures the design direction introduced in the latest UI refresh.
 
 ## Typography
 
-| Usage | Font family | Weights |
-|-------|-------------|---------|
-| Headings & brand accents | [Poppins](https://fonts.google.com/specimen/Poppins) | 500–800 |
-| Body text & UI copy | [Open Sans](https://fonts.google.com/specimen/Open+Sans) | 400–700 |
-| Code snippets | JetBrains Mono | 400–600 |
+| Usage                    | Font family                                              | Weights |
+| ------------------------ | -------------------------------------------------------- | ------- |
+| Headings & brand accents | [Poppins](https://fonts.google.com/specimen/Poppins)     | 500–800 |
+| Body text & UI copy      | [Open Sans](https://fonts.google.com/specimen/Open+Sans) | 400–700 |
+| Code snippets            | JetBrains Mono                                           | 400–600 |
 
 **Implementation notes**
+
 - Fonts are loaded globally via `index.html` and configured in `tailwind.config.ts` as `font-heading`, `font-brand`, and `font-sans` utilities.
 - Headings use tight tracking for a confident voice; paragraphs cap at `max-w-3xl` to protect readability.
 
@@ -18,13 +19,13 @@ This document captures the design direction introduced in the latest UI refresh.
 
 Brand hues focus on a purple→blue core with warm amber accents.
 
-| Token | Light mode | Dark mode | Usage |
-|-------|------------|-----------|-------|
-| `--primary` | `hsl(262 70% 53%)` | `hsl(262 72% 60%)` | Primary actions, gradients |
-| `--secondary` | `hsl(221 85% 56%)` | `hsl(220 70% 65%)` | Secondary buttons, supporting CTAs |
-| `--accent` | `hsl(44 95% 52%)` | `hsl(44 95% 56%)` | Highlights and badges |
-| `--foreground` | `hsl(232 35% 16%)` | `hsl(210 40% 96%)` | Base text colors |
-| `--background` | `hsl(0 0% 100%)` | `hsl(235 32% 8%)` | Page background |
+| Token          | Light mode         | Dark mode          | Usage                              |
+| -------------- | ------------------ | ------------------ | ---------------------------------- |
+| `--primary`    | `hsl(262 70% 53%)` | `hsl(262 72% 60%)` | Primary actions, gradients         |
+| `--secondary`  | `hsl(221 85% 56%)` | `hsl(220 70% 65%)` | Secondary buttons, supporting CTAs |
+| `--accent`     | `hsl(44 95% 52%)`  | `hsl(44 95% 56%)`  | Highlights and badges              |
+| `--foreground` | `hsl(232 35% 16%)` | `hsl(210 40% 96%)` | Base text colors                   |
+| `--background` | `hsl(0 0% 100%)`   | `hsl(235 32% 8%)`  | Page background                    |
 
 Gradients (`bg-gradient-hero`, `bg-gradient-brand`) blend the new brand purple `#5F2EEA` into vivid blues and cyan, while cards can opt-in to a gradient header via the new `variant="gradient"` on `CardHeader`.
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -64,14 +64,18 @@ const ThemeToggle = ({ className, variant = 'header' }: ThemeToggleProps) => {
         aria-hidden="true"
         className={cn(
           'h-5 w-5 transition-all duration-200',
-          mounted && isDark ? 'rotate-90 scale-0 opacity-0' : 'rotate-0 scale-100 opacity-100'
+          mounted && isDark
+            ? 'rotate-90 scale-0 opacity-0'
+            : 'rotate-0 scale-100 opacity-100'
         )}
       />
       <Moon
         aria-hidden="true"
         className={cn(
           'absolute h-5 w-5 transition-all duration-200',
-          mounted && isDark ? 'rotate-0 scale-100 opacity-100' : '-rotate-90 scale-0 opacity-0'
+          mounted && isDark
+            ? 'rotate-0 scale-100 opacity-100'
+            : '-rotate-90 scale-0 opacity-0'
         )}
       />
       <span className="sr-only">{label}</span>

--- a/src/components/ui/button-variants.ts
+++ b/src/components/ui/button-variants.ts
@@ -17,8 +17,7 @@ export const buttonVariants = cva(
           'bg-secondary/20 text-secondary hover:bg-secondary/30 hover:text-secondary-foreground shadow-soft',
         ghost:
           'shadow-none text-foreground hover:bg-muted/70 hover:text-foreground/90 focus-visible:ring-primary/30',
-        link:
-          'shadow-none text-primary underline-offset-8 hover:underline focus-visible:ring-offset-0 px-0 py-0 h-auto',
+        link: 'shadow-none text-primary underline-offset-8 hover:underline focus-visible:ring-offset-0 px-0 py-0 h-auto',
       },
       size: {
         default: 'px-6 py-3 text-base',

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,8 +9,10 @@ const cardVariants = cva(
     variants: {
       variant: {
         default: '',
-        bordered: 'border-2 border-primary/20 hover:-translate-y-1 hover:shadow-soft-lg',
-        elevated: 'border-transparent shadow-soft-lg hover:-translate-y-1 hover:shadow-soft-lg',
+        bordered:
+          'border-2 border-primary/20 hover:-translate-y-1 hover:shadow-soft-lg',
+        elevated:
+          'border-transparent shadow-soft-lg hover:-translate-y-1 hover:shadow-soft-lg',
         subtle: 'border-transparent bg-muted/60',
       },
     },
@@ -35,22 +37,19 @@ const Card = React.forwardRef<HTMLDivElement, CardProps>(
 );
 Card.displayName = 'Card';
 
-const cardHeaderVariants = cva(
-  'flex flex-col gap-2 px-8 py-6 text-left',
-  {
-    variants: {
-      variant: {
-        default: '',
-        gradient:
-          'relative -mx-8 -mt-6 rounded-t-[1.4rem] bg-gradient-to-r from-primary/15 via-primary/10 to-secondary/20 px-8 py-6 text-foreground dark:text-white',
-        muted: 'bg-muted/60 rounded-[1.25rem] px-8 py-6',
-      },
+const cardHeaderVariants = cva('flex flex-col gap-2 px-8 py-6 text-left', {
+  variants: {
+    variant: {
+      default: '',
+      gradient:
+        'relative -mx-8 -mt-6 rounded-t-[1.4rem] bg-gradient-to-r from-primary/15 via-primary/10 to-secondary/20 px-8 py-6 text-foreground dark:text-white',
+      muted: 'bg-muted/60 rounded-[1.25rem] px-8 py-6',
     },
-    defaultVariants: {
-      variant: 'default',
-    },
-  }
-);
+  },
+  defaultVariants: {
+    variant: 'default',
+  },
+});
 
 interface CardHeaderProps
   extends React.HTMLAttributes<HTMLDivElement>,
@@ -73,7 +72,10 @@ const CardTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <h3
     ref={ref}
-    className={cn('text-2xl font-semibold leading-tight tracking-tight', className)}
+    className={cn(
+      'text-2xl font-semibold leading-tight tracking-tight',
+      className
+    )}
     {...props}
   />
 ));
@@ -97,7 +99,10 @@ const CardContent = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('px-8 pb-8 pt-0 text-base leading-relaxed space-y-4', className)}
+    className={cn(
+      'px-8 pb-8 pt-0 text-base leading-relaxed space-y-4',
+      className
+    )}
     {...props}
   />
 ));
@@ -109,7 +114,10 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('flex flex-wrap items-center gap-4 px-8 pb-8 pt-0', className)}
+    className={cn(
+      'flex flex-wrap items-center gap-4 px-8 pb-8 pt-0',
+      className
+    )}
     {...props}
   />
 ));

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -126,4 +126,12 @@ const FormMessage = React.forwardRef<
 });
 FormMessage.displayName = 'FormMessage';
 
-export { Form, FormItem, FormLabel, FormControl, FormDescription, FormMessage, FormField };
+export {
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+};

--- a/src/hooks/auth-context.ts
+++ b/src/hooks/auth-context.ts
@@ -8,4 +8,6 @@ export interface AuthContextValue {
   signOut: () => Promise<void>;
 }
 
-export const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+export const AuthContext = createContext<AuthContextValue | undefined>(
+  undefined
+);

--- a/src/integrations/supabase.ts
+++ b/src/integrations/supabase.ts
@@ -2,15 +2,10 @@ import { createClient } from '@supabase/supabase-js';
 import type { Database } from '@/integrations/supabase/types';
 
 const SUPABASE_URL = import.meta.env.VITE_SUPABASE_URL as string | undefined;
-const SUPABASE_ANON_KEY =
-  (import.meta.env.VITE_SUPABASE_ANON_KEY ||
-    import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY) as
-    | string
-    | undefined;
+const SUPABASE_ANON_KEY = (import.meta.env.VITE_SUPABASE_ANON_KEY ||
+  import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY) as string | undefined;
 
-export const isSupabaseConfigured = Boolean(
-  SUPABASE_URL && SUPABASE_ANON_KEY
-);
+export const isSupabaseConfigured = Boolean(SUPABASE_URL && SUPABASE_ANON_KEY);
 
 if (!isSupabaseConfigured) {
   console.warn(

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -8,11 +8,7 @@ const LOCALE_FALLBACKS: Record<string, string> = {
 };
 
 const sanitizeLocale = (language: string) =>
-  language
-    .replace('_', '-')
-    .split('@')[0]
-    .split('.')[0]
-    .trim();
+  language.replace('_', '-').split('@')[0].split('.')[0].trim();
 
 export const getNormalizedLocale = (language: string | undefined | null) => {
   if (!language) {


### PR DESCRIPTION
## Summary
- format docs/VISUAL.md typography and color tables to align with Prettier output
- apply Prettier formatting to UI components and hooks to maintain consistent style
- tidy Supabase integration and i18n utility formatting for readability

## Testing
- npm run format:check
- npm run lint
- npm run test


------
https://chatgpt.com/codex/tasks/task_e_68d6aeddc36883228c6222b79504c6c2